### PR TITLE
LPD-86154

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -82,15 +80,9 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 				@P("Transition name") String transitionName)
 			throws PortalException {
 
-			PermissionChecker permissionChecker =
-				PermissionThreadLocal.getPermissionChecker();
-
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						invocationParameters.get("companyId"))) {
-
-				PermissionThreadLocal.setPermissionChecker(
-					invocationParameters.get("permissionChecker"));
 
 				ExecutionContext executionContext = invocationParameters.get(
 					"executionContext");
@@ -108,9 +100,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 					kaleoInstanceToken.getUserId(),
 					kaleoInstanceToken.getKaleoInstanceTokenId(),
 					transitionName, workflowContext, false);
-			}
-			finally {
-				PermissionThreadLocal.setPermissionChecker(permissionChecker);
 			}
 		}
 
@@ -167,9 +156,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 				InvocationParameters.from(
 					Map.of(
 						"companyId", CompanyThreadLocal.getCompanyId(),
-						"executionContext", executionContext,
-						"permissionChecker",
-						PermissionThreadLocal.getPermissionChecker()))
+						"executionContext", executionContext))
 			).memoryId(
 				GetterUtil.getString(workflowContext.get("memoryId"))
 			).onCompleteResponseConsumer(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -134,10 +133,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 			AssistantHandlerContext.builder(
 			).invocationParameters(
 				InvocationParameters.from(
-					Map.of(
-						"executionContext", executionContext,
-						"permissionChecker",
-						PermissionThreadLocal.getPermissionChecker()))
+					Map.of("executionContext", executionContext))
 			).memoryId(
 				GetterUtil.getString(workflowContext.get("memoryId"))
 			).onCompleteResponseConsumer(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86154

What is being fixed: AIDecisionNodeExecutor and LLMNodeExecutor
captured a live PermissionChecker from PermissionThreadLocal and
transported it through InvocationParameters. In
AIDecisionNodeExecutor.Tools.completeWorkflowNode(), the captured
object was later extracted and re-applied to the thread local when the
LLM invoked the tool, creating a CWE-269 risk: a stale security
credential was carried through a data structure with the LLM controlling
when it was restored to the thread.

How it is being fixed: Investigation showed the manipulation was
entirely redundant. GraphWalkerPortalExecutor.execute() submits
_walk() to a thread pool via CompanyInheritableThreadLocalCallable,
so it runs on a different thread whose PermissionThreadLocal is never
the calling thread's. If none is set, _walk() creates a fresh
PermissionChecker from serviceContext.getUserId(). Removing the
capture, transport, and restoration eliminates the leak with no
functional impact.