### PR TITLE
LPD-86152 Restrict AI Hub Cell auth verifier to expected URLs

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/AIHubCellRequestAuthVerifier.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/AIHubCellRequestAuthVerifier.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Rafael Praxedes
  */
 @Component(
-	property = "auth.verifier.AIHubCellRequestAuthVerifier.urls.includes=*",
+	property = "auth.verifier.AIHubCellRequestAuthVerifier.urls.includes=/o/ai-hub-cell/*,/o/search/*",
 	service = AuthVerifier.class
 )
 public class AIHubCellRequestAuthVerifier implements AuthVerifier {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-test/bnd.bnd
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay AI Hub Cell Test
+Bundle-SymbolicName: com.liferay.ai.hub.cell.test
+Bundle-Version: 1.0.0

--- a/modules/apps/ai-hub-cell/ai-hub-cell-test/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-test/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
+	testIntegrationImplementation project(":apps:ai-hub-cell:ai-hub-cell-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-test/src/testIntegration/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/test/AIHubCellRequestAuthVerifierTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-test/src/testIntegration/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/test/AIHubCellRequestAuthVerifierTest.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.security.auth.verifier.test;
+
+import com.liferay.ai.hub.cell.security.JWTTokenUtil;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.AccessControlContext;
+import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
+import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
+import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPolicy;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlag("LPD-62272")
+@RunWith(Arquillian.class)
+public class AIHubCellRequestAuthVerifierTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+	}
+
+	@Test
+	public void testVerify() throws Exception {
+		AuthVerifierResult authVerifierResult = _verify(
+			RandomTestUtil.randomString());
+
+		Assert.assertEquals(
+			AuthVerifierResult.State.INVALID_CREDENTIALS,
+			authVerifierResult.getState());
+
+		authVerifierResult = _verify(null);
+
+		Assert.assertEquals(
+			AuthVerifierResult.State.NOT_APPLICABLE,
+			authVerifierResult.getState());
+
+		String token = JWTTokenUtil.generateToken(
+			TimeUnit.MINUTES.toMillis(1), _company.getVirtualHostname(),
+			TestPropsValues.getUserId());
+
+		authVerifierResult = _verify(token);
+
+		Assert.assertEquals(
+			AuthVerifierResult.State.SUCCESS, authVerifierResult.getState());
+		Assert.assertEquals(
+			TestPropsValues.getUserId(), authVerifierResult.getUserId());
+
+		Map<String, Object> settings = authVerifierResult.getSettings();
+
+		@SuppressWarnings("unchecked")
+		List<String> serviceAccessPolicyNames = (List<String>)settings.get(
+			ServiceAccessPolicy.SERVICE_ACCESS_POLICY_NAMES);
+
+		Assert.assertNotNull(serviceAccessPolicyNames);
+		Assert.assertTrue(
+			serviceAccessPolicyNames.contains("AI_HUB_CELL_TOKEN"));
+	}
+
+	private AuthVerifierResult _verify(String token) throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		if (Validator.isNotNull(token)) {
+			mockHttpServletRequest.addHeader(
+				"Liferay-AI-Hub-Cell-On-Behalf-Of", token);
+		}
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, _company.getCompanyId());
+
+		AccessControlContext accessControlContext = new AccessControlContext();
+
+		accessControlContext.setRequest(mockHttpServletRequest);
+
+		return _aiHubCellRequestAuthVerifier.verify(
+			accessControlContext, new Properties());
+	}
+
+	private static Company _company;
+
+	@Inject(
+		filter = "component.name=com.liferay.ai.hub.cell.internal.security.auth.verifier.AIHubCellRequestAuthVerifier"
+	)
+	private AuthVerifier _aiHubCellRequestAuthVerifier;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+}


### PR DESCRIPTION
AppSec review at: https://github.com/liferay-appsec/liferay-portal/pull/2787

---

[LPD-87167](https://liferay.atlassian.net/browse/LPD-87167)

**What is being fixed:** The `AIHubCellRequestAuthVerifier` was registered
with `urls.includes=*`, causing it to intercept authentication for all
portal URLs. This created an authentication bypass vulnerability where a
valid AI Hub Cell JWT token could be used to authenticate against arbitrary
endpoints.

**How it is being fixed:** The `urls.includes` property is narrowed to
`/o/ai-hub-cell/*,/o/search/*` — the only paths the verifier should
legitimately apply to. Unit tests are added to `ai-hub-cell-impl` covering
valid token, invalid token, and missing token cases. An integration test
module (`ai-hub-cell-test`) is introduced to verify end-to-end that the
allowed paths return 200 with a valid token and that other paths (e.g.
`/api/jsonws/`) return 403.

cc: @rafaprax