### PR TITLE
LPD-81719 Fix ephemeral JWT signing key to persist across restarts and cluster nodes

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.4"
+	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/configuration/AIHubCellConfiguration.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/configuration/AIHubCellConfiguration.java
@@ -7,6 +7,7 @@ package com.liferay.ai.hub.cell.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedAttributeDefinition;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
 /**
@@ -28,6 +29,14 @@ public interface AIHubCellConfiguration {
 
 	@Meta.AD(name = "client-secret", type = Meta.Type.Password)
 	public String clientSecret();
+
+	@ExtendedAttributeDefinition(
+		visibilityControllerKey = "com.liferay.ai.hub.cell.internal.configuration.admin.display.AIHubCellSecretVisibilityController"
+	)
+	@Meta.AD(
+		deflt = "", name = "secret", required = false, type = Meta.Type.Password
+	)
+	public String secret();
 
 	@Meta.AD(name = "service-url")
 	public String serviceURL();

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
@@ -5,9 +5,12 @@
 
 package com.liferay.ai.hub.cell.security;
 
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -44,7 +47,7 @@ public class JWTTokenUtil {
 			).build());
 
 		try {
-			signedJWT.sign(new MACSigner(_SECRET));
+			signedJWT.sign(new MACSigner(_getSecret()));
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -63,7 +66,7 @@ public class JWTTokenUtil {
 		try {
 			SignedJWT signedJWT = SignedJWT.parse(token);
 
-			if (!signedJWT.verify(new MACVerifier(_SECRET))) {
+			if (!signedJWT.verify(new MACVerifier(_getSecret()))) {
 				if (_log.isDebugEnabled()) {
 					_log.debug("Invalid JWT signature");
 				}
@@ -105,20 +108,15 @@ public class JWTTokenUtil {
 		return GetterUtil.getLong(jwtClaimsSet.getSubject());
 	}
 
-	private static final byte[] _SECRET;
+	private static byte[] _getSecret() throws Exception {
+		AIHubCellConfiguration aiHubCellConfiguration =
+			ConfigurationProviderUtil.getCompanyConfiguration(
+				AIHubCellConfiguration.class,
+				CompanyThreadLocal.getCompanyId());
+
+		return Base64.decode(aiHubCellConfiguration.secret());
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(JWTTokenUtil.class);
-
-	static {
-		int sha256BlockSize = 64;
-
-		byte[] secret = new byte[sha256BlockSize];
-
-		for (int i = 0; i < secret.length; i++) {
-			secret[i] = SecureRandomUtil.nextByte();
-		}
-
-		_SECRET = secret;
-	}
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -48,9 +48,9 @@ public class JWTTokenUtilTest {
 
 			Assert.assertFalse(token.isEmpty());
 
-			JWTClaimsSet jwtClaimsSet = SignedJWT.parse(
-				token
-			).getJWTClaimsSet();
+			SignedJWT signedJWT = SignedJWT.parse(token);
+
+			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
 
 			Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
 			Assert.assertEquals(
@@ -97,6 +97,9 @@ public class JWTTokenUtilTest {
 	}
 
 	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
+
 		int sha256BlockSize = 64;
 
 		byte[] secretBytes = new byte[sha256BlockSize];
@@ -104,9 +107,6 @@ public class JWTTokenUtilTest {
 		for (int i = 0; i < secretBytes.length; i++) {
 			secretBytes[i] = SecureRandomUtil.nextByte();
 		}
-
-		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
-			AIHubCellConfiguration.class);
 
 		Mockito.when(
 			aiHubCellConfiguration.secret()

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -46,12 +46,11 @@ public class JWTTokenUtilTest {
 			String token = JWTTokenUtil.generateToken(
 				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-			Assert.assertNotNull(token);
 			Assert.assertFalse(token.isEmpty());
 
-			SignedJWT signedJWT = SignedJWT.parse(token);
-
-			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+			JWTClaimsSet jwtClaimsSet = SignedJWT.parse(
+				token
+			).getJWTClaimsSet();
 
 			Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
 			Assert.assertEquals(
@@ -98,9 +97,6 @@ public class JWTTokenUtilTest {
 	}
 
 	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
-		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
-			AIHubCellConfiguration.class);
-
 		int sha256BlockSize = 64;
 
 		byte[] secretBytes = new byte[sha256BlockSize];
@@ -108,6 +104,9 @@ public class JWTTokenUtilTest {
 		for (int i = 0; i < secretBytes.length; i++) {
 			secretBytes[i] = SecureRandomUtil.nextByte();
 		}
+
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
 
 		Mockito.when(
 			aiHubCellConfiguration.secret()
@@ -125,11 +124,14 @@ public class JWTTokenUtilTest {
 			configurationProviderUtilMockedStatic = Mockito.mockStatic(
 				ConfigurationProviderUtil.class);
 
+		AIHubCellConfiguration aiHubCellConfiguration =
+			_mockAIHubCellConfiguration();
+
 		configurationProviderUtilMockedStatic.when(
 			() -> ConfigurationProviderUtil.getCompanyConfiguration(
 				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
-		).thenAnswer(
-			invocation -> _mockAIHubCellConfiguration()
+		).thenReturn(
+			aiHubCellConfiguration
 		);
 
 		return configurationProviderUtilMockedStatic;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -5,9 +5,11 @@
 
 package com.liferay.ai.hub.cell.security;
 
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -19,9 +21,14 @@ import com.nimbusds.jwt.SignedJWT;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Rafael Praxedes
@@ -31,6 +38,17 @@ public class JWTTokenUtilTest {
 	@ClassRule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+		_setUpConfigurationProviderUtil();
+	}
+
+	@After
+	public void tearDown() {
+		_configurationProviderUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testGenerateToken() throws Exception {
@@ -56,19 +74,6 @@ public class JWTTokenUtilTest {
 
 		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(_ISSUER, token));
 
-		byte[] secret = new byte[64];
-
-		for (int i = 0; i < secret.length; i++) {
-			secret[i] = SecureRandomUtil.nextByte();
-		}
-
-		try (AutoCloseable autoCloseable =
-				ReflectionTestUtil.setFieldValueWithAutoCloseable(
-					JWTTokenUtil.class, "_SECRET", secret)) {
-
-			_testGetUserId("Invalid JWT signature", _ISSUER, token);
-		}
-
 		_testGetUserId(
 			"Invalid JWT issuer", RandomTestUtil.randomString(),
 			JWTTokenUtil.generateToken(
@@ -76,12 +81,47 @@ public class JWTTokenUtilTest {
 		_testGetUserId(
 			"Invalid JWT signature", _ISSUER,
 			token.substring(0, token.length() - 5) + "abcde");
+
 		_testGetUserId(
 			"The JWT token is expired", _ISSUER,
 			JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
 		_testGetUserId(
 			"Unable to parse and verify the JWT token", _ISSUER,
 			RandomTestUtil.randomString());
+
+		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+
+		_testGetUserId("Invalid JWT signature", _ISSUER, token);
+	}
+
+	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
+
+		int sha256BlockSize = 64;
+
+		byte[] secretBytes = new byte[sha256BlockSize];
+
+		for (int i = 0; i < secretBytes.length; i++) {
+			secretBytes[i] = SecureRandomUtil.nextByte();
+		}
+
+		Mockito.when(
+			aiHubCellConfiguration.secret()
+		).thenReturn(
+			Base64.encode(secretBytes)
+		);
+
+		return aiHubCellConfiguration;
+	}
+
+	private void _setUpConfigurationProviderUtil() {
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getCompanyConfiguration(
+				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
+		).thenAnswer(
+			invocation -> _aiHubCellConfiguration
+		);
 	}
 
 	private void _testGetUserId(
@@ -108,5 +148,10 @@ public class JWTTokenUtilTest {
 	private static final String _ISSUER = RandomTestUtil.randomString();
 
 	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private AIHubCellConfiguration _aiHubCellConfiguration;
+	private final MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -96,13 +96,17 @@ public class JWTTokenUtilTest {
 		}
 	}
 
-	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
+	private MockedStatic<ConfigurationProviderUtil>
+		_mockConfigurationProviderUtil() {
+
+		MockedStatic<ConfigurationProviderUtil>
+			configurationProviderUtilMockedStatic = Mockito.mockStatic(
+				ConfigurationProviderUtil.class);
+
 		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
 			AIHubCellConfiguration.class);
 
-		int sha256BlockSize = 64;
-
-		byte[] secretBytes = new byte[sha256BlockSize];
+		byte[] secretBytes = new byte[64];
 
 		for (int i = 0; i < secretBytes.length; i++) {
 			secretBytes[i] = SecureRandomUtil.nextByte();
@@ -113,19 +117,6 @@ public class JWTTokenUtilTest {
 		).thenReturn(
 			Base64.encode(secretBytes)
 		);
-
-		return aiHubCellConfiguration;
-	}
-
-	private MockedStatic<ConfigurationProviderUtil>
-		_mockConfigurationProviderUtil() {
-
-		MockedStatic<ConfigurationProviderUtil>
-			configurationProviderUtilMockedStatic = Mockito.mockStatic(
-				ConfigurationProviderUtil.class);
-
-		AIHubCellConfiguration aiHubCellConfiguration =
-			_mockAIHubCellConfiguration();
 
 		configurationProviderUtilMockedStatic.when(
 			() -> ConfigurationProviderUtil.getCompanyConfiguration(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -21,9 +21,7 @@ import com.nimbusds.jwt.SignedJWT;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -39,59 +37,64 @@ public class JWTTokenUtilTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@Before
-	public void setUp() {
-		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
-		_setUpConfigurationProviderUtil();
-	}
-
-	@After
-	public void tearDown() {
-		_configurationProviderUtilMockedStatic.close();
-	}
-
 	@Test
 	public void testGenerateToken() throws Exception {
-		String token = JWTTokenUtil.generateToken(
-			TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
 
-		Assert.assertNotNull(token);
-		Assert.assertFalse(token.isEmpty());
+			String token = JWTTokenUtil.generateToken(
+				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-		SignedJWT signedJWT = SignedJWT.parse(token);
+			Assert.assertNotNull(token);
+			Assert.assertFalse(token.isEmpty());
 
-		JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+			SignedJWT signedJWT = SignedJWT.parse(token);
 
-		Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
-		Assert.assertEquals(
-			String.valueOf(_USER_ID), jwtClaimsSet.getSubject());
+			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+
+			Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
+			Assert.assertEquals(
+				String.valueOf(_USER_ID), jwtClaimsSet.getSubject());
+		}
 	}
 
 	@Test
 	public void testGetUserId() throws Exception {
-		String token = JWTTokenUtil.generateToken(
-			TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
+		String token = null;
 
-		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(_ISSUER, token));
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
 
-		_testGetUserId(
-			"Invalid JWT issuer", RandomTestUtil.randomString(),
-			JWTTokenUtil.generateToken(
-				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID));
-		_testGetUserId(
-			"Invalid JWT signature", _ISSUER,
-			token.substring(0, token.length() - 5) + "abcde");
+			token = JWTTokenUtil.generateToken(
+				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-		_testGetUserId(
-			"The JWT token is expired", _ISSUER,
-			JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
-		_testGetUserId(
-			"Unable to parse and verify the JWT token", _ISSUER,
-			RandomTestUtil.randomString());
+			Assert.assertEquals(
+				_USER_ID, JWTTokenUtil.getUserId(_ISSUER, token));
 
-		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+			_testGetUserId(
+				"Invalid JWT issuer", RandomTestUtil.randomString(),
+				JWTTokenUtil.generateToken(
+					TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID));
+			_testGetUserId(
+				"Invalid JWT signature", _ISSUER,
+				token.substring(0, token.length() - 5) + "abcde");
 
-		_testGetUserId("Invalid JWT signature", _ISSUER, token);
+			_testGetUserId(
+				"The JWT token is expired", _ISSUER,
+				JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
+			_testGetUserId(
+				"Unable to parse and verify the JWT token", _ISSUER,
+				RandomTestUtil.randomString());
+		}
+
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
+
+			_testGetUserId("Invalid JWT signature", _ISSUER, token);
+		}
 	}
 
 	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
@@ -115,13 +118,21 @@ public class JWTTokenUtilTest {
 		return aiHubCellConfiguration;
 	}
 
-	private void _setUpConfigurationProviderUtil() {
-		_configurationProviderUtilMockedStatic.when(
+	private MockedStatic<ConfigurationProviderUtil>
+		_mockConfigurationProviderUtil() {
+
+		MockedStatic<ConfigurationProviderUtil>
+			configurationProviderUtilMockedStatic = Mockito.mockStatic(
+				ConfigurationProviderUtil.class);
+
+		configurationProviderUtilMockedStatic.when(
 			() -> ConfigurationProviderUtil.getCompanyConfiguration(
 				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
 		).thenAnswer(
-			invocation -> _aiHubCellConfiguration
+			invocation -> _mockAIHubCellConfiguration()
 		);
+
+		return configurationProviderUtilMockedStatic;
 	}
 
 	private void _testGetUserId(
@@ -148,10 +159,5 @@ public class JWTTokenUtilTest {
 	private static final String _ISSUER = RandomTestUtil.randomString();
 
 	private static final long _USER_ID = RandomTestUtil.randomLong();
-
-	private AIHubCellConfiguration _aiHubCellConfiguration;
-	private final MockedStatic<ConfigurationProviderUtil>
-		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
-			ConfigurationProviderUtil.class);
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
@@ -7,5 +7,7 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/admin/display/AIHubCellSecretVisibilityController.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/admin/display/AIHubCellSecretVisibilityController.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class AIHubCellSecretVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return false;
+	}
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.Base64;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@Component(
+	property = "model.class.name=com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class AIHubCellConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeSave(
+		String pid, Dictionary<String, Object> properties) {
+
+		int sha256BlockSize = 64;
+
+		byte[] secretBytes = new byte[sha256BlockSize];
+
+		for (int i = 0; i < secretBytes.length; i++) {
+			secretBytes[i] = SecureRandomUtil.nextByte();
+		}
+
+		properties.put("secret", Base64.encode(secretBytes));
+	}
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -27,9 +27,7 @@ public class AIHubCellConfigurationModelListener
 	public void onBeforeSave(
 		String pid, Dictionary<String, Object> properties) {
 
-		int sha256BlockSize = 64;
-
-		byte[] secretBytes = new byte[sha256BlockSize];
+		byte[] secretBytes = new byte[64];
 
 		for (int i = 0; i < secretBytes.length; i++) {
 			secretBytes[i] = SecureRandomUtil.nextByte();

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
@@ -30,16 +30,16 @@ public class AIHubCellConfigurationModelListenerTest {
 	public void test() {
 		Dictionary<String, Object> properties = new Hashtable<>();
 
-		_aiHubCellConfigurationModelListener.onBeforeSave("pid", properties);
+		AIHubCellConfigurationModelListener
+			aiHubCellConfigurationModelListener =
+				new AIHubCellConfigurationModelListener();
+
+		aiHubCellConfigurationModelListener.onBeforeSave("pid", properties);
 
 		String secret = GetterUtil.getString(properties.get("secret"));
 
 		Assert.assertFalse(Validator.isBlank(secret));
 		Assert.assertEquals(64, Base64.decode(secret).length);
 	}
-
-	private final AIHubCellConfigurationModelListener
-		_aiHubCellConfigurationModelListener =
-			new AIHubCellConfigurationModelListener();
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.persistence.listener;
+
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class AIHubCellConfigurationModelListenerTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void test() {
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		_aiHubCellConfigurationModelListener.onBeforeSave("pid", properties);
+
+		String secret = GetterUtil.getString(properties.get("secret"));
+
+		Assert.assertFalse(Validator.isBlank(secret));
+		Assert.assertEquals(64, Base64.decode(secret).length);
+	}
+
+	private final AIHubCellConfigurationModelListener
+		_aiHubCellConfigurationModelListener =
+			new AIHubCellConfigurationModelListener();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81719

**What is being fixed:** The JWT signing secret in JWTTokenUtil was generated
at class load time via SecureRandomUtil and stored in a static field. This
caused two critical issues: the secret was regenerated on every JVM restart,
invalidating all outstanding tokens, and in a clustered deployment each node
held a different secret, so tokens signed on one node were rejected by another.

**How it is being fixed:** The secret is now persisted in AIHubCellConfiguration
(stored per company via Liferay's configuration service) so it survives restarts
and is shared across cluster nodes. JWTTokenUtil reads the key through
ConfigurationProviderUtil.getCompanyConfiguration() instead of the static field.
The tests are updated to mock ConfigurationProviderUtil using try-with-resources
to scope each static mock per test.