### PR TITLE
LPD-78738 Update Workflow Designer visual styles for AI Hub

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_app.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_app.scss
@@ -9,7 +9,7 @@
 		height: 100%;
 
 		.diagram-area {
-			background-color: $light-l1;
+			background-color: #ededed;
 			height: 100%;
 			position: relative;
 			width: 100%;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_nodes.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_nodes.scss
@@ -5,12 +5,13 @@
 .node {
 	align-items: center;
 	background: #fff;
-	border: 1px $light-l1 solid;
-	border-radius: 8px;
+	border: none;
+	border-radius: 16px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 	display: flex;
-	height: 74px;
+	height: 64px;
 	left: 18px;
-	padding: 18px 16px;
+	padding: 16px;
 	top: 18px;
 	width: 254px;
 
@@ -20,8 +21,7 @@
 
 	.node-icon {
 		align-items: center;
-		background: #f7f8f9;
-		border-radius: 4px;
+		border-radius: 8px;
 		display: flex;
 		height: 32px;
 		justify-content: center;
@@ -43,40 +43,101 @@
 		size: 14px;
 	}
 
-	&.ai-decision,
-	&.end-node,
-	&.llm-node,
 	&.start-node {
-		.node-icon svg {
-			fill: #4b9bff;
+		.node-icon {
+			background: #eafbf8;
+
+			svg {
+				fill: #24a892;
+			}
 		}
 	}
 
-	&.condition-node,
-	&.fork-node,
-	&.state-node {
-		.node-icon svg {
-			fill: #ffb46e;
+	&.end-node {
+		.node-icon {
+			background: #feefef;
+
+			svg {
+				fill: #f66;
+			}
+		}
+	}
+
+	&.fork-node {
+		.node-icon {
+			background: #fff4ec;
+
+			svg {
+				fill: #ff8f39;
+			}
+		}
+	}
+
+	&.condition-node {
+		.node-icon {
+			background: #fff4ec;
+
+			svg {
+				fill: #ff8f39;
+			}
 		}
 	}
 
 	&.join-node,
 	&.join-xor-node {
-		.node-icon svg {
-			fill: #7785ff;
+		.node-icon {
+			background: #e5e8ff;
+
+			svg {
+				fill: #4d5fff;
+			}
+		}
+	}
+
+	&.ai-decision {
+		.node-icon {
+			background: #f0f5ff;
+
+			svg {
+				fill: #0b5fff;
+			}
+		}
+	}
+
+	&.llm-node {
+		.node-icon {
+			background: #f0f5ff;
+
+			svg {
+				fill: #0b5fff;
+			}
+		}
+	}
+
+	&.state-node {
+		.node-icon {
+			background: #edf9f0;
+
+			svg {
+				fill: #5aca75;
+			}
 		}
 	}
 
 	&.task-node {
-		.node-icon svg {
-			fill: #50d2a0;
+		.node-icon {
+			background: #edf9f0;
+
+			svg {
+				fill: #5aca75;
+			}
 		}
 	}
 }
 
 .node-border-area {
-	border-radius: 4px;
-	height: 110px;
+	border-radius: 16px;
+	height: 100px;
 	opacity: 0.5;
 	width: 290px;
 
@@ -92,11 +153,12 @@
 }
 
 .node.selected {
-	border: 2px solid #80acff;
+	background: #f0f5ff;
+	border: 4px solid #5791ff;
 }
 
 .node-handle-area {
-	height: 110px;
+	height: 100px;
 	left: -18px;
 	position: absolute;
 	top: -18px;
@@ -104,7 +166,7 @@
 	z-index: -1;
 
 	.handles {
-		height: 110px;
+		height: 100px;
 		opacity: 0;
 		position: absolute;
 		width: 290px;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_sidebar.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/css/definition-builder/_sidebar.scss
@@ -1,7 +1,15 @@
 .sidebar {
 	background: #fff;
-	border-left: 1px solid #e7e7ed;
-	width: 368px;
+	border: 1px solid #cdced9;
+	border-radius: 8px;
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100% - 24px);
+	position: absolute;
+	right: 12px;
+	top: 12px;
+	width: 320px;
+	z-index: 5;
 
 	.tab-pane {
 		padding: 10px;
@@ -54,8 +62,9 @@
 	}
 
 	.sidebar-body {
-		overflow: hidden;
-		padding: 12px;
+		flex: 1;
+		overflow-y: auto;
+		padding: 16px;
 
 		.delete-button {
 			& svg {
@@ -71,6 +80,14 @@
 			display: flex;
 			justify-content: space-between;
 			width: 100%;
+		}
+
+		.panel-group {
+			margin-bottom: 0;
+
+			& + .panel-group {
+				margin-top: 24px;
+			}
 		}
 
 		.recipient-type-form-group {
@@ -159,23 +176,59 @@
 			display: flex;
 			margin-bottom: 1.5rem;
 		}
+
+		.form-group {
+			label {
+				color: #272833;
+				font-size: 12px;
+				font-weight: 600;
+				line-height: 1.5;
+			}
+
+			.form-control {
+				background-color: #f7f8f9;
+				border: 1px solid #e7e7ed;
+				border-radius: 8px;
+				font-size: 14px;
+
+				&:focus {
+					background-color: #fff;
+					border-color: #80acff;
+					box-shadow: 0 0 0 0.125rem rgba(11, 95, 255, 0.25);
+				}
+			}
+
+			textarea.form-control {
+				background-color: #f1f2f5;
+				border-radius: 4px;
+			}
+		}
 	}
 
 	.sidebar-header {
 		align-items: center;
-		border-bottom: 1px solid #e7e7ed;
 		display: flex;
-		height: 75px;
+		flex-shrink: 0;
+		padding: 16px;
 
 		.title {
 			color: #272833;
-			font-size: 20px;
-			font-weight: 700;
+			font-size: 18px;
+			font-weight: 600;
+			line-height: 1.5;
 
 			&:first-letter {
 				text-transform: capitalize;
 			}
 		}
+	}
+
+	.sidebar-description {
+		color: #6b6c7e;
+		font-size: 14px;
+		line-height: 1.5;
+		margin-top: -8px;
+		padding: 0 16px 16px;
 	}
 
 	.spaced-items {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/DiagramBuilder.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/DiagramBuilder.js
@@ -562,10 +562,8 @@ export default function DiagramBuilder() {
 
 					<Controls showInteractive={false} />
 
-					<Background size={1} />
+					<Sidebar />
 				</div>
-
-				<Sidebar />
 			</div>
 		</DiagramBuilderContextProvider>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
@@ -8,6 +8,7 @@ import {isEdge, isNode} from 'react-flow-renderer';
 
 import {DefinitionBuilderContext} from '../../../DefinitionBuilderContext';
 import {DiagramBuilderContext} from '../../DiagramBuilderContext';
+import {nodeDescription} from '../nodes/utils';
 import {DefinitionInfo} from './DefinitionInfo/DefinitionInfo';
 import SidebarBody from './SidebarBody';
 import SidebarHeader from './SidebarHeader';
@@ -239,6 +240,10 @@ export default function Sidebar() {
 
 	const content = contents[contentName];
 	const title = content?.title ?? Liferay.Language.get('nodes');
+	const description =
+		!showDefinitionInfo && contentName
+			? nodeDescription[contentName]
+			: null;
 
 	return (
 		<div className="sidebar">
@@ -257,6 +262,10 @@ export default function Sidebar() {
 				}
 				title={!showDefinitionInfo ? title : definitionTitle}
 			/>
+
+			{description && (
+				<div className="sidebar-description">{description}</div>
+			)}
 
 			<SidebarBody
 				displayDefaultContent={!content && !showDefinitionInfo}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/SidebarHeader.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/SidebarHeader.js
@@ -94,7 +94,7 @@ export default function SidebarHeader({
 				{showDeleteButton && (
 					<ClayButtonWithIcon
 						aria-label={Liferay.Language.get('delete')}
-						className="text-secondary trash-button"
+						className="text-dark trash-button"
 						disabled={contentName === 'assignments'}
 						displayType="unstyled"
 						onClick={() => setShowDeleteConfirmationModal(true)}


### PR DESCRIPTION
## What

In order to differentiate experiences between Kaleo Workflow Designer and AI Hub Agent Designer and as part of the AI Hub UI redesign (LPD-78738), we started to redesign some styles of the Agent Designer, and including some new features as prompt expanding. 

https://github.com/user-attachments/assets/b9618cc4-6ef7-4e98-bbae-5ac4926526c7

This PR covers two things:

1. **Visual style updates** for the Workflow Designer — updated node cards, sidebar layout, and diagram background.
2. **Prompt expansion improvement** in the LLM node — the sidebar now renders a description below the header using `nodeDescription[contentName]`, giving the LLM node more context/guidance when editing its prompt.

## Test Plan

- [ ] Open Workflow Designer and verify nodes render with updated styles
- [ ] Click the LLM node and confirm the description appears below the sidebar header
- [ ] Verify sidebar appears as a floating card and scrolls correctly when content overflows

Jira: https://liferay.atlassian.net/browse/LPD-78738