### PR TITLE
LPD-90368 [BE] Create object definitions that represent the entities related to the model armor template

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -157,6 +157,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"AIHubMCPServer", "/ai-hub/mcp-servers"
 		).put(
+			"AIHubModelArmorTemplate", "/ai-hub/model-armor-templates"
+		).put(
 			"AIHubQuota", "/ai-hub/quotas"
 		).put(
 			"APIApplication", "/headless-builder/applications"

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -16,6 +16,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -85,8 +86,8 @@ public class AIHubSiteInitializerTest {
 		_assertListTypeDefinitionExists(
 			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_GUARDRAIL_TYPES", "input", "output");
 		_assertListTypeDefinitionExists(
-			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_RAI_LEVELS", "high", "lowAndAbove",
-			"mediumAndAbove", "none");
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS", "high",
+			"lowAndAbove", "mediumAndAbove", "none");
 
 		_assertObjectDefinitionExists("L_AI_HUB_AGENT_DEFINITION");
 		_assertObjectDefinitionExists("L_AI_HUB_CHATBOT");
@@ -95,6 +96,43 @@ public class AIHubSiteInitializerTest {
 		_assertObjectDefinitionExists("L_AI_HUB_INSTRUCTION_DEFINITION");
 		_assertObjectDefinitionExists("L_AI_HUB_MCP_SERVER");
 		_assertObjectDefinitionExists("L_AI_HUB_MODEL_ARMOR_TEMPLATE");
+
+		_assertObjectFieldsExist(
+			"L_AI_HUB_AGENT_DEFINITION", "active", "description",
+			"inputVariables", "outputVariable",
+			"r_accountToAIHubAgentDefinitions_accountEntryId", "title",
+			"workflowDefinitionName");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_CHATBOT", "active", "companyLogo", "description",
+			"introMessage", "notificationMessage", "placeholderMessage",
+			"r_accountToAIHubChatbots_accountEntryId", "showCompanyLogo",
+			"title");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_CONTENT_RETRIEVER", "crawlDate", "description",
+			"indexName", "r_accountToAIHubContentRetrievers_accountEntryId",
+			"title", "type", "url");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_CRAWLER_JOB", "crawlerJobStatus", "endDate",
+			"errorMessage", "executionId", "indexedDocumentCount",
+			"r_accountToAIHubCrawlerJobs_accountEntryId",
+			"r_contentRetrieverToCrawlerJobs_aiHubContentRetrieverId",
+			"startDate");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_INSTRUCTION_DEFINITION", "active", "description",
+			"instruction", "occasion",
+			"r_accountToAIHubInstructionDefinitions_accountEntryId", "scope",
+			"title");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_MCP_SERVER", "r_accountToAIHubMCPServers_accountEntryId",
+			"title", "url");
+		_assertObjectFieldsExist(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE", "active", "description",
+			"guardrailType", "location", "maliciousUriFilterEnabled",
+			"multiLanguageDetectionEnabled", "piAndJailbreakConfidenceLevel",
+			"piAndJailbreakFilterEnabled",
+			"r_accountToAIHubModelArmorTemplates_accountEntryId",
+			"raiDangerousLevel", "raiHarassmentLevel", "raiHateSpeechLevel",
+			"raiSexuallyExplicitLevel", "sdpFilterEnabled", "title");
 
 		_assertObjectRelationshipExists(
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
@@ -122,7 +160,7 @@ public class AIHubSiteInitializerTest {
 			"L_AI_HUB_AGENT_DEFINITION",
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 		_assertObjectRelationshipExists(
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			"L_AI_HUB_AGENT_DEFINITIONS_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES",
 			"L_AI_HUB_AGENT_DEFINITION",
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
@@ -184,6 +222,24 @@ public class AIHubSiteInitializerTest {
 		Assert.assertTrue(objectDefinition.isSystem());
 	}
 
+	private void _assertObjectFieldsExist(
+			String objectDefinitionExternalReferenceCode,
+			String... objectFieldNames)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+		for (String objectFieldName : objectFieldNames) {
+			Assert.assertNotNull(
+				_objectFieldLocalService.fetchObjectField(
+					objectDefinition.getObjectDefinitionId(), objectFieldName));
+		}
+	}
+
 	private void _assertObjectRelationshipExists(
 			String deletionType, String externalReferenceCode,
 			String objectDefinitionExternalReferenceCode, String type)
@@ -235,6 +291,9 @@ public class AIHubSiteInitializerTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -79,6 +79,14 @@ public class AIHubSiteInitializerTest {
 		_assertListTypeDefinitionExists(
 			"L_AI_HUB_INSTRUCTION_DEFINITION_SCOPES", "clickToChat", "cms",
 			"everywhere");
+		_assertListTypeDefinitionExists(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_CONFIDENCE_LEVELS", "high",
+			"lowAndAbove", "mediumAndAbove");
+		_assertListTypeDefinitionExists(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_GUARDRAIL_TYPES", "input", "output");
+		_assertListTypeDefinitionExists(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_RAI_LEVELS", "high", "lowAndAbove",
+			"mediumAndAbove", "none");
 
 		_assertObjectDefinitionExists("L_AI_HUB_AGENT_DEFINITION");
 		_assertObjectDefinitionExists("L_AI_HUB_CHATBOT");
@@ -86,6 +94,7 @@ public class AIHubSiteInitializerTest {
 		_assertObjectDefinitionExists("L_AI_HUB_CRAWLER_JOB");
 		_assertObjectDefinitionExists("L_AI_HUB_INSTRUCTION_DEFINITION");
 		_assertObjectDefinitionExists("L_AI_HUB_MCP_SERVER");
+		_assertObjectDefinitionExists("L_AI_HUB_MODEL_ARMOR_TEMPLATE");
 
 		_assertObjectRelationshipExists(
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
@@ -104,8 +113,17 @@ public class AIHubSiteInitializerTest {
 			"L_ACCOUNT_TO_L_AI_HUB_MCP_SERVERS", "L_ACCOUNT",
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 		_assertObjectRelationshipExists(
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"L_ACCOUNT_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES", "L_ACCOUNT",
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_assertObjectRelationshipExists(
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			"L_AI_HUB_AGENT_DEFINITIONS_TO_L_AI_HUB_CONTENT_RETRIEVERS",
+			"L_AI_HUB_AGENT_DEFINITION",
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		_assertObjectRelationshipExists(
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"L_AI_HUB_AGENT_DEFINITIONS_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES",
 			"L_AI_HUB_AGENT_DEFINITION",
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 		_assertObjectRelationshipExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/02_agent-builder/page-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/02_agent-builder/page-definition.json
@@ -67,7 +67,7 @@
 								"key": "BASIC_COMPONENT-tabs"
 							},
 							"fragmentConfig": {
-								"numberOfTabs": 3,
+								"numberOfTabs": 4,
 								"persistSelectedTab": true
 							},
 							"fragmentFields": [
@@ -103,6 +103,18 @@
 										"text": {
 											"value_i18n": {
 												"en_US": "Data Sources"
+											}
+										}
+									}
+								},
+								{
+									"id": "title4",
+									"value": {
+										"fragmentLink": {
+										},
+										"text": {
+											"value_i18n": {
+												"en_US": "Guardrails"
 											}
 										}
 									}
@@ -162,6 +174,27 @@
 										"definition": {
 											"fragment": {
 												"key": "com.liferay.ai.hub.web.internal.fragment.renderer.ViewContentRetrieversFragmentRenderer"
+											},
+											"fragmentConfig": {
+											},
+											"fragmentFields": [
+											],
+											"indexed": true
+										},
+										"type": "Fragment"
+									}
+								],
+								"type": "FragmentDropZone"
+							},
+							{
+								"definition": {
+									"fragmentDropZoneId": "4"
+								},
+								"pageElements": [
+									{
+										"definition": {
+											"fragment": {
+												"key": "com.liferay.ai.hub.web.internal.fragment.renderer.ViewModelArmorTemplatesFragmentRenderer"
 											},
 											"fragmentConfig": {
 											},

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page-definition.json
@@ -1,0 +1,26 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "com.liferay.ai.hub.web.internal.fragment.renderer.EditModelArmorTemplateFragmentRenderer"
+					},
+					"fragmentConfig": {
+					},
+					"fragmentFields": [
+					],
+					"indexed": true
+				},
+				"type": "Fragment"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"masterPage": {
+			"key": "ai-hub-form-master"
+		}
+	},
+	"version": 1.0
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
@@ -1,0 +1,18 @@
+{
+	"friendlyURL": "/model-armor-template",
+	"hidden": true,
+	"name_i18n": {
+		"en_US": "Model Armor Template"
+	},
+	"permissions": [
+		{
+			"actionIds": [
+			],
+			"roleName": "Guest",
+			"scope": 4
+		}
+	],
+	"private": false,
+	"system": false,
+	"type": "Content"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-confidence-levels-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-confidence-levels-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_CONFIDENCE_LEVELS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "HIGH",
+			"key": "high",
+			"name": "High",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "LOW_AND_ABOVE",
+			"key": "lowAndAbove",
+			"name": "Low and Above",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "MEDIUM_AND_ABOVE",
+			"key": "mediumAndAbove",
+			"name": "Medium and Above",
+			"system": true
+		}
+	],
+	"name": "AI Hub Model Armor Template Confidence Levels",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-guardrail-types-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-guardrail-types-list-type-definition.json
@@ -1,0 +1,19 @@
+{
+	"externalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_GUARDRAIL_TYPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "INPUT",
+			"key": "input",
+			"name": "Input",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "OUTPUT",
+			"key": "output",
+			"name": "Output",
+			"system": true
+		}
+	],
+	"name": "AI Hub Model Armor Template Guardrail Types",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-rai-levels-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/model-armor-template-rai-levels-list-type-definition.json
@@ -1,0 +1,31 @@
+{
+	"externalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "HIGH",
+			"key": "high",
+			"name": "High",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "LOW_AND_ABOVE",
+			"key": "lowAndAbove",
+			"name": "Low and Above",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "MEDIUM_AND_ABOVE",
+			"key": "mediumAndAbove",
+			"name": "Medium and Above",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "NONE",
+			"key": "none",
+			"name": "None",
+			"system": true
+		}
+	],
+	"name": "AI Hub Model Armor Template Responsible AI Levels",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/model-armor-template-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/model-armor-template-object-definition.json
@@ -1,0 +1,251 @@
+{
+	"accountEntryRestricted": true,
+	"accountEntryRestrictedObjectFieldName": "r_accountToAIHubModelArmorTemplates_accountEntryId",
+	"className": "com.liferay.object.model.ObjectDefinition#MA1T",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"enableObjectEntryHistory": true,
+	"externalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "Model Armor Template"
+	},
+	"modifiable": true,
+	"name": "AIHubModelArmorTemplate",
+	"objectFields": [
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "ACCOUNT_TO_AI_HUB_MODEL_ARMOR_TEMPLATES",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Account to Model Armor Templates"
+			},
+			"name": "r_accountToAIHubModelArmorTemplates_accountEntryId",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "AccountEntry"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_accountToAIHubModelArmorTemplates_accountEntryERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_ACCOUNT_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES",
+			"readOnly": false,
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": true,
+			"externalReferenceCode": "ACTIVE",
+			"indexed": true,
+			"label": {
+				"en_US": "Active"
+			},
+			"name": "active",
+			"system": true,
+			"type": "Boolean"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "DESCRIPTION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Description"
+			},
+			"name": "description",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "input",
+			"externalReferenceCode": "GUARDRAIL_TYPE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Guardrail Type"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_GUARDRAIL_TYPES",
+			"name": "guardrailType",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "LOCATION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Location"
+			},
+			"name": "location",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": false,
+			"externalReferenceCode": "MALICIOUS_URI_FILTER_ENABLED",
+			"indexed": true,
+			"label": {
+				"en_US": "Malicious URI Filter Enabled"
+			},
+			"name": "maliciousUriFilterEnabled",
+			"system": true,
+			"type": "Boolean"
+		},
+		{
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": false,
+			"externalReferenceCode": "MULTI_LANGUAGE_DETECTION_ENABLED",
+			"indexed": true,
+			"label": {
+				"en_US": "Multi-Language Detection Enabled"
+			},
+			"name": "multiLanguageDetectionEnabled",
+			"system": true,
+			"type": "Boolean"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "mediumAndAbove",
+			"externalReferenceCode": "PROMPT_INJECTION_AND_JAILBREAK_CONFIDENCE_LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Prompt Injection and Jailbreak Confidence Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_CONFIDENCE_LEVELS",
+			"name": "piAndJailbreakConfidenceLevel",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": false,
+			"externalReferenceCode": "PROMPT_INJECTION_AND_JAILBREAK_FILTER_ENABLED",
+			"indexed": true,
+			"label": {
+				"en_US": "Prompt Injection and Jailbreak Filter Enabled"
+			},
+			"name": "piAndJailbreakFilterEnabled",
+			"system": true,
+			"type": "Boolean"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "none",
+			"externalReferenceCode": "RESPONSIBLE_AI_DANGEROUS_LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Responsible AI Dangerous Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS",
+			"name": "raiDangerousLevel",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "none",
+			"externalReferenceCode": "RESPONSIBLE_AI_HARASSMENT_LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Responsible AI Harassment Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS",
+			"name": "raiHarassmentLevel",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "none",
+			"externalReferenceCode": "RESPONSIBLE_AI_HATE_SPEECH_LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Responsible AI Hate Speech Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS",
+			"name": "raiHateSpeechLevel",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "none",
+			"externalReferenceCode": "RESPONSIBLE_AI_SEXUALLY_EXPLICIT_LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Responsible AI Sexually Explicit Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS",
+			"name": "raiSexuallyExplicitLevel",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": false,
+			"externalReferenceCode": "SENSITIVE_DATA_PROTECTION_FILTER_ENABLED",
+			"indexed": true,
+			"label": {
+				"en_US": "Sensitive Data Protection Filter Enabled"
+			},
+			"name": "sdpFilterEnabled",
+			"system": true,
+			"type": "Boolean"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "TITLE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Title"
+			},
+			"localized": true,
+			"name": "title",
+			"required": true,
+			"system": true,
+			"type": "String"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "Model Armor Templates"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "title"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/agent-definition-object-relationship-4.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/agent-definition-object-relationship-4.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "disassociate",
+	"externalReferenceCode": "L_AI_HUB_AGENT_DEFINITIONS_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES",
+	"label": {
+		"en_US": "Agent Definitions to Model Armor Templates"
+	},
+	"name": "agentDefinitionsToModelArmorTemplates",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AIHubAgentDefinition$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:AIHubModelArmorTemplate$]",
+	"objectDefinitionName2": "AIHubModelArmorTemplate",
+	"system": true,
+	"type": "manyToMany"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/model-armor-template-object-relationship.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/model-armor-template-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_ACCOUNT_TO_L_AI_HUB_MODEL_ARMOR_TEMPLATES",
+	"label": {
+		"en_US": "Account to Model Armor Templates"
+	},
+	"name": "accountToAIHubModelArmorTemplates",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AccountEntry$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:AIHubModelArmorTemplate$]",
+	"objectDefinitionName2": "AIHubModelArmorTemplate",
+	"system": true,
+	"type": "oneToMany"
+}


### PR DESCRIPTION
The naming convention for the Object Fields from the Model Armor Template Object Definition was based on: https://docs.cloud.google.com/model-armor/reference/rest/v1/projects.locations.templates.

Also, this was made to avoid passing the max characters for a name of a Object Field (41 characters).