### PR TITLE
LPD-90899 Authenticate Click to Chat widget against DXP

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
@@ -52,6 +52,7 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 			options.addPart(
 				"client_secret", _aiHubCellConfiguration.clientSecret());
 			options.addPart("grant_type", "client_credentials");
+			options.addPart("scope", "Liferay.AI.Hub.REST.everything");
 			options.setLocation(
 				_aiHubCellConfiguration.serviceURL() + "/o/oauth2/token");
 			options.setPost(true);

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
@@ -52,7 +52,6 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 			options.addPart(
 				"client_secret", _aiHubCellConfiguration.clientSecret());
 			options.addPart("grant_type", "client_credentials");
-			options.addPart("scope", "Liferay.AI.Hub.REST.everything");
 			options.setLocation(
 				_aiHubCellConfiguration.serviceURL() + "/o/oauth2/token");
 			options.setPost(true);

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/aihub.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/aihub.jsp
@@ -38,6 +38,10 @@ String clickToChatAIHubServiceURL = (String)request.getAttribute(ClickToChatWebK
 			'chatbot-external-reference-code',
 			'<%= clickToChatChatProviderAccountId %>'
 		);
+		scriptElement.setAttribute(
+			'liferay-dxp-url',
+			'<%= HtmlUtil.escapeJS(themeDisplay.getPortalURL()) %>'
+		);
 
 		document.body.appendChild(scriptElement);
 	})();

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/index.html
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/index.html
@@ -9,6 +9,6 @@
 	</head>
 
 	<body>
-	<script ai-hub-url="http://localhost:8080" chatbot-external-reference-code="CHATBOT-ERC" id="aihub-chatbot-widget-script" src="/src/index.tsx" type="module"></script>
+	<script ai-hub-url="http://localhost:8080" chatbot-external-reference-code="CHATBOT-ERC" id="aihub-chatbot-widget-script" liferay-dxp-url="http://localhost:8080" src="/src/index.tsx" type="module"></script>
 	</body>
 </html>

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -11,22 +11,25 @@ const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
 const AUTHORIZATION_TOKEN_TTL = 9 * 60 * 1000;
 
+let aiHubURL = '';
 let cachedAuthorizationToken: AuthorizationToken | null = null;
 let cachedAuthorizationTokenMintedAt = 0;
 let pendingAuthorizationTokenPromise: Promise<AuthorizationToken | null> | null =
 	null;
 
+export function setAIHubURL(url: string) {
+	aiHubURL = url;
+}
+
 async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 	try {
-		const authToken = (
-			window as unknown as {Liferay?: {authToken?: string}}
-		).Liferay?.authToken;
+		const csrfToken = (window as any).Liferay?.authToken;
 
 		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			`${aiHubURL}/o/ai-hub-cell/v1.0/authorization-tokens`,
 			{
-				headers: authToken
-					? new Headers({'x-csrf-token': authToken})
+				headers: csrfToken
+					? new Headers({'x-csrf-token': csrfToken})
 					: undefined,
 				method: 'POST',
 			}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -9,13 +9,7 @@ import type {AuthorizationToken, ChatbotConfiguration} from './types';
 
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
-const AUTHORIZATION_TOKEN_TTL = 9 * 60 * 1000;
-
 let aiHubURL = '';
-let cachedAuthorizationToken: AuthorizationToken | null = null;
-let cachedAuthorizationTokenMintedAt = 0;
-let pendingAuthorizationTokenPromise: Promise<AuthorizationToken | null> | null =
-	null;
 
 export function setAIHubURL(url: string) {
 	aiHubURL = url;
@@ -64,38 +58,10 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 	}
 }
 
-async function getAuthorizationToken(): Promise<AuthorizationToken | null> {
-	const now = Date.now();
-
-	if (
-		cachedAuthorizationToken &&
-		now - cachedAuthorizationTokenMintedAt < AUTHORIZATION_TOKEN_TTL
-	) {
-		return cachedAuthorizationToken;
-	}
-
-	if (!pendingAuthorizationTokenPromise) {
-		pendingAuthorizationTokenPromise = postAuthorizationToken().then(
-			(token) => {
-				if (token) {
-					cachedAuthorizationToken = token;
-					cachedAuthorizationTokenMintedAt = Date.now();
-				}
-
-				pendingAuthorizationTokenPromise = null;
-
-				return token;
-			}
-		);
-	}
-
-	return pendingAuthorizationTokenPromise;
-}
-
 export async function getChatbotConfiguration(
 	chatbotExternalReferenceCode: string
 ): Promise<ChatbotConfiguration> {
-	const authorizationToken = await getAuthorizationToken();
+	const authorizationToken = await postAuthorizationToken();
 
 	if (!authorizationToken) {
 		throw new Error(
@@ -122,7 +88,7 @@ export async function getChatbotConfiguration(
 }
 
 export async function createEventSource(): Promise<EventSource | null> {
-	const authorizationToken = await getAuthorizationToken();
+	const authorizationToken = await postAuthorizationToken();
 
 	if (!authorizationToken) {
 		return null;
@@ -149,7 +115,7 @@ export async function postChatMessage(
 	eventSourceReference: string,
 	text: string
 ): Promise<Response> {
-	const authorizationToken = await getAuthorizationToken();
+	const authorizationToken = await postAuthorizationToken();
 
 	if (!authorizationToken) {
 		throw new Error(

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -58,7 +58,7 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 		return data as AuthorizationToken;
 	}
 	catch (error) {
-		console.warn((error as Error).message);
+		console.warn(error instanceof Error ? error.message : String(error));
 
 		return null;
 	}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -10,9 +10,11 @@ import type {AuthorizationToken, ChatbotConfiguration} from './types';
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
 let aiHubURL = '';
+let liferayDXPURL = '';
 
-export function setAIHubURL(url: string) {
-	aiHubURL = url;
+export function setURLs(aiHub: string, liferayDXP: string) {
+	aiHubURL = aiHub;
+	liferayDXPURL = liferayDXP;
 }
 
 async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
@@ -20,7 +22,7 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 		const csrfToken = (window as any).Liferay?.authToken;
 
 		const response = await fetch(
-			`${aiHubURL}/o/ai-hub-cell/v1.0/authorization-tokens`,
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
 			{
 				headers: csrfToken
 					? new Headers({'x-csrf-token': csrfToken})
@@ -61,16 +63,8 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 export async function getChatbotConfiguration(
 	chatbotExternalReferenceCode: string
 ): Promise<ChatbotConfiguration> {
-	const authorizationToken = await postAuthorizationToken();
-
-	if (!authorizationToken) {
-		throw new Error(
-			'Unable to obtain authorization token for chatbot configuration.'
-		);
-	}
-
 	const response = await fetch(
-		`${authorizationToken.serviceURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
+		`${liferayDXPURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
 		{
 			headers: new Headers({
 				Accept: 'application/json',
@@ -88,26 +82,29 @@ export async function getChatbotConfiguration(
 }
 
 export async function createEventSource(): Promise<EventSource | null> {
-	const authorizationToken = await postAuthorizationToken();
+	const headers = new Headers({Accept: 'text/event-stream'});
 
-	if (!authorizationToken) {
-		return null;
+	if ((window as any).Liferay) {
+		const authorizationToken = await postAuthorizationToken();
+
+		if (!authorizationToken) {
+			return null;
+		}
+
+		headers.set(
+			'Authorization',
+			`Bearer ${authorizationToken.accessToken}`
+		);
 	}
 
-	return new EventSource(
-		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/chats/subscribe`,
-		{
-			fetch: (input, init) =>
-				fetch(input as RequestInfo, {
-					...init,
-					headers: new Headers({
-						Accept: 'text/event-stream',
-						Authorization: `Bearer ${authorizationToken.accessToken}`,
-					}),
-				}),
-			withCredentials: true,
-		}
-	);
+	return new EventSource(`${aiHubURL}${AI_HUB_ENDPOINT}/chats/subscribe`, {
+		fetch: (input, init) =>
+			fetch(input as RequestInfo, {
+				...init,
+				headers,
+			}),
+		withCredentials: true,
+	});
 }
 
 export async function postChatMessage(
@@ -115,16 +112,32 @@ export async function postChatMessage(
 	eventSourceReference: string,
 	text: string
 ): Promise<Response> {
-	const authorizationToken = await postAuthorizationToken();
+	const headers = new Headers({
+		'Accept': 'application/json',
+		'Content-Type': 'application/json',
+	});
 
-	if (!authorizationToken) {
-		throw new Error(
-			'Unable to obtain authorization token for chat message.'
+	if ((window as any).Liferay) {
+		const authorizationToken = await postAuthorizationToken();
+
+		if (!authorizationToken) {
+			throw new Error(
+				'Unable to obtain authorization token for chat message.'
+			);
+		}
+
+		headers.set(
+			'Authorization',
+			`Bearer ${authorizationToken.accessToken}`
+		);
+		headers.set(
+			'Liferay-AI-Hub-Cell-On-Behalf-Of',
+			authorizationToken.userToken
 		);
 	}
 
 	return fetch(
-		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/chats/by-external-reference-code/${eventSourceReference}/messages`,
+		`${aiHubURL}${AI_HUB_ENDPOINT}/chats/by-external-reference-code/${eventSourceReference}/messages`,
 		{
 			body: JSON.stringify({
 				chatbotExternalReferenceCode,
@@ -132,13 +145,7 @@ export async function postChatMessage(
 				instructionDefinitionScope: 'clickToChat',
 				text,
 			}),
-			headers: new Headers({
-				'Accept': 'application/json',
-				'Authorization': `Bearer ${authorizationToken.accessToken}`,
-				'Content-Type': 'application/json',
-				'Liferay-AI-Hub-Cell-On-Behalf-Of':
-					authorizationToken.userToken,
-			}),
+			headers,
 			method: 'POST',
 		}
 	);

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -5,19 +5,103 @@
 
 import {EventSource} from 'eventsource';
 
-import type {ChatbotConfiguration} from './types';
+import type {AuthorizationToken, ChatbotConfiguration} from './types';
 
-let aiHubURL = '';
+const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
-export function setAIHubURL(url: string) {
-	aiHubURL = url;
+const AUTHORIZATION_TOKEN_TTL = 9 * 60 * 1000;
+
+let cachedAuthorizationToken: AuthorizationToken | null = null;
+let cachedAuthorizationTokenMintedAt = 0;
+let pendingAuthorizationTokenPromise: Promise<AuthorizationToken | null> | null =
+	null;
+
+async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
+	try {
+		const authToken = (
+			window as unknown as {Liferay?: {authToken?: string}}
+		).Liferay?.authToken;
+
+		const response = await fetch(
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			{
+				headers: authToken
+					? new Headers({'x-csrf-token': authToken})
+					: undefined,
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Unable to generate authorization token: ${response.statusText}`
+			);
+		}
+
+		const data = (await response.json()) as Partial<AuthorizationToken>;
+
+		if (!data?.accessToken) {
+			throw new Error('Unable to generate authorization token.');
+		}
+
+		if (!data?.userToken) {
+			throw new Error('Unable to generate user token.');
+		}
+
+		if (!data?.serviceURL) {
+			throw new Error('Unable to find service URL.');
+		}
+
+		return data as AuthorizationToken;
+	}
+	catch (error) {
+		console.warn((error as Error).message);
+
+		return null;
+	}
+}
+
+async function getAuthorizationToken(): Promise<AuthorizationToken | null> {
+	const now = Date.now();
+
+	if (
+		cachedAuthorizationToken &&
+		now - cachedAuthorizationTokenMintedAt < AUTHORIZATION_TOKEN_TTL
+	) {
+		return cachedAuthorizationToken;
+	}
+
+	if (!pendingAuthorizationTokenPromise) {
+		pendingAuthorizationTokenPromise = postAuthorizationToken().then(
+			(token) => {
+				if (token) {
+					cachedAuthorizationToken = token;
+					cachedAuthorizationTokenMintedAt = Date.now();
+				}
+
+				pendingAuthorizationTokenPromise = null;
+
+				return token;
+			}
+		);
+	}
+
+	return pendingAuthorizationTokenPromise;
 }
 
 export async function getChatbotConfiguration(
 	chatbotExternalReferenceCode: string
 ): Promise<ChatbotConfiguration> {
+	const authorizationToken = await getAuthorizationToken();
+
+	if (!authorizationToken) {
+		throw new Error(
+			'Unable to obtain authorization token for chatbot configuration.'
+		);
+	}
+
 	const response = await fetch(
-		`${aiHubURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
+		`${authorizationToken.serviceURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
 		{
 			headers: new Headers({
 				Accept: 'application/json',
@@ -34,26 +118,44 @@ export async function getChatbotConfiguration(
 	return (await response.json()) as ChatbotConfiguration;
 }
 
-export function createEventSource(): EventSource {
-	return new EventSource(`${aiHubURL}/o/ai-hub/v1.0/chats/subscribe`, {
-		fetch: (input, init) =>
-			fetch(input as RequestInfo, {
-				...init,
-				headers: new Headers({
-					Accept: 'text/event-stream',
+export async function createEventSource(): Promise<EventSource | null> {
+	const authorizationToken = await getAuthorizationToken();
+
+	if (!authorizationToken) {
+		return null;
+	}
+
+	return new EventSource(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/chats/subscribe`,
+		{
+			fetch: (input, init) =>
+				fetch(input as RequestInfo, {
+					...init,
+					headers: new Headers({
+						Accept: 'text/event-stream',
+						Authorization: `Bearer ${authorizationToken.accessToken}`,
+					}),
 				}),
-			}),
-		withCredentials: true,
-	});
+			withCredentials: true,
+		}
+	);
 }
 
-export function postChatMessage(
+export async function postChatMessage(
 	chatbotExternalReferenceCode: string,
 	eventSourceReference: string,
 	text: string
 ): Promise<Response> {
+	const authorizationToken = await getAuthorizationToken();
+
+	if (!authorizationToken) {
+		throw new Error(
+			'Unable to obtain authorization token for chat message.'
+		);
+	}
+
 	return fetch(
-		`${aiHubURL}/o/ai-hub/v1.0/chats/by-external-reference-code/${eventSourceReference}/messages`,
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/chats/by-external-reference-code/${eventSourceReference}/messages`,
 		{
 			body: JSON.stringify({
 				chatbotExternalReferenceCode,
@@ -63,7 +165,10 @@ export function postChatMessage(
 			}),
 			headers: new Headers({
 				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
 				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
 			}),
 			method: 'POST',
 		}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -22,7 +22,7 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 		const csrfToken = (window as any).Liferay?.authToken;
 
 		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			`${liferayDXPURL}/o/ai-hub-cell/v1.0/authorization-tokens`,
 			{
 				headers: csrfToken
 					? new Headers({'x-csrf-token': csrfToken})
@@ -64,7 +64,7 @@ export async function getChatbotConfiguration(
 	chatbotExternalReferenceCode: string
 ): Promise<ChatbotConfiguration> {
 	const response = await fetch(
-		`${liferayDXPURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
+		`${aiHubURL}/o/ai-hub/chatbots/by-external-reference-code/${chatbotExternalReferenceCode}`,
 		{
 			headers: new Headers({
 				Accept: 'application/json',

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {EventSource} from 'eventsource';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {
@@ -41,6 +42,7 @@ export default function ChatbotWidget({
 	const [open, setOpen] = useState(false);
 	const [subscribed, setSubscribed] = useState(false);
 
+	const eventSourceRef = useRef<EventSource | null>(null);
 	const eventSourceReference = useRef<string | null>(null);
 	const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null
@@ -63,49 +65,66 @@ export default function ChatbotWidget({
 			return;
 		}
 
-		const eventSource = createEventSource();
+		createEventSource()
+			.then((eventSource) => {
+				if (!eventSource) {
+					return;
+				}
 
-		eventSource.addEventListener('Chat Message Sent', (event) => {
-			if (loadingTimeoutRef.current) {
-				clearTimeout(loadingTimeoutRef.current);
-				loadingTimeoutRef.current = null;
-			}
+				eventSourceRef.current = eventSource;
 
-			try {
-				const data = JSON.parse((event as MessageEvent).data);
+				eventSource.addEventListener('Chat Message Sent', (event) => {
+					if (loadingTimeoutRef.current) {
+						clearTimeout(loadingTimeoutRef.current);
+						loadingTimeoutRef.current = null;
+					}
 
-				setMessages((prev) => [
-					...prev,
-					{sender: 'assistant', text: data.data},
-				]);
-			}
-			catch (error) {
-				console.error('Error parsing chat message:', error);
+					try {
+						const data = JSON.parse((event as MessageEvent).data);
 
-				setMessages((prev) => [...prev, {sender: 'error', text: ''}]);
-			}
+						setMessages((prev) => [
+							...prev,
+							{sender: 'assistant', text: data.data},
+						]);
+					}
+					catch (error) {
+						console.error('Error parsing chat message:', error);
 
-			setLoading(false);
-		});
+						setMessages((prev) => [
+							...prev,
+							{sender: 'error', text: ''},
+						]);
+					}
 
-		eventSource.addEventListener('Subscribe', (event) => {
-			eventSourceReference.current = (event as MessageEvent).data;
-			setSubscribed(true);
-		});
+					setLoading(false);
+				});
 
-		eventSource.addEventListener('error', () => {
-			console.error('EventSource connection error');
+				eventSource.addEventListener('Subscribe', (event) => {
+					eventSourceReference.current = (event as MessageEvent).data;
+					setSubscribed(true);
+				});
 
-			setSubscribed(false);
-			setMessages((prev) => [...prev, {sender: 'error', text: ''}]);
-		});
+				eventSource.addEventListener('error', () => {
+					console.error('EventSource connection error');
+
+					setSubscribed(false);
+					setMessages((prev) => [
+						...prev,
+						{sender: 'error', text: ''},
+					]);
+				});
+			})
+			.catch((error) => {
+				console.error('Failed to create event source:', error);
+			});
 
 		return () => {
 			if (loadingTimeoutRef.current) {
 				clearTimeout(loadingTimeoutRef.current);
 			}
 
-			eventSource.close();
+			eventSourceRef.current?.close();
+			eventSourceRef.current = null;
 			setSubscribed(false);
 		};
 	}, [chatbotConfiguration]);

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
@@ -65,9 +65,23 @@ export default function ChatbotWidget({
 			return;
 		}
 
+		let active = true;
+
 		createEventSource()
 			.then((eventSource) => {
+				if (!active) {
+					eventSource?.close();
+
+					return;
+				}
+
 				if (!eventSource) {
+					setMessages((prev) => [
+						...prev,
+						{sender: 'error', text: ''},
+					]);
+					setLoading(false);
+
 					return;
 				}
 
@@ -112,13 +126,19 @@ export default function ChatbotWidget({
 						...prev,
 						{sender: 'error', text: ''},
 					]);
+					setLoading(false);
 				});
 			})
 			.catch((error) => {
 				console.error('Failed to create event source:', error);
+
+				setMessages((prev) => [...prev, {sender: 'error', text: ''}]);
+				setLoading(false);
 			});
 
 		return () => {
+			active = false;
+
 			if (loadingTimeoutRef.current) {
 				clearTimeout(loadingTimeoutRef.current);
 			}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 
-import {setAIHubURL} from './api';
+import {setURLs} from './api';
 import ChatbotWidget from './components/ChatbotWidget';
 import {WidgetConfiguration} from './types';
 
@@ -27,6 +27,7 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 			aiHubURL: scriptTag.getAttribute('ai-hub-url') || '',
 			chatbotExternalReferenceCode:
 				scriptTag.getAttribute('chatbot-external-reference-code') || '',
+			liferayDXPURL: scriptTag.getAttribute('liferay-dxp-url') || '',
 		};
 
 		const element = document.createElement('div');
@@ -35,7 +36,7 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 
 		document.body.appendChild(element);
 
-		setAIHubURL(widgetConfiguration.aiHubURL);
+		setURLs(widgetConfiguration.aiHubURL, widgetConfiguration.liferayDXPURL);
 
 		createRoot(element).render(
 			<ChatbotWidget widgetConfiguration={widgetConfiguration} />

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
@@ -36,7 +36,10 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 
 		document.body.appendChild(element);
 
-		setURLs(widgetConfiguration.aiHubURL, widgetConfiguration.liferayDXPURL);
+		setURLs(
+			widgetConfiguration.aiHubURL,
+			widgetConfiguration.liferayDXPURL
+		);
 
 		createRoot(element).render(
 			<ChatbotWidget widgetConfiguration={widgetConfiguration} />

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 
-import {setAIHubURL} from './api';
 import ChatbotWidget from './components/ChatbotWidget';
 import {WidgetConfiguration} from './types';
 
@@ -23,18 +22,7 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 		);
 	}
 	else {
-		const aiHubURL =
-			scriptTag.getAttribute('ai-hub-url') ||
-			'https://ai.hub.liferay.com';
-
-		if (!aiHubURL) {
-			console.warn(
-				'Attribute "ai-hub-url" is missing from the widget script tag.'
-			);
-		}
-
 		const widgetConfiguration: WidgetConfiguration = {
-			aiHubURL,
 			chatbotExternalReferenceCode:
 				scriptTag.getAttribute('chatbot-external-reference-code') || '',
 		};
@@ -44,8 +32,6 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 		element.id = CHATBOT_WIDGET_ID;
 
 		document.body.appendChild(element);
-
-		setAIHubURL(widgetConfiguration.aiHubURL);
 
 		createRoot(element).render(
 			<ChatbotWidget widgetConfiguration={widgetConfiguration} />

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/index.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 
+import {setAIHubURL} from './api';
 import ChatbotWidget from './components/ChatbotWidget';
 import {WidgetConfiguration} from './types';
 
@@ -23,6 +24,7 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 	}
 	else {
 		const widgetConfiguration: WidgetConfiguration = {
+			aiHubURL: scriptTag.getAttribute('ai-hub-url') || '',
 			chatbotExternalReferenceCode:
 				scriptTag.getAttribute('chatbot-external-reference-code') || '',
 		};
@@ -32,6 +34,8 @@ if (!document.getElementById(CHATBOT_WIDGET_ID)) {
 		element.id = CHATBOT_WIDGET_ID;
 
 		document.body.appendChild(element);
+
+		setAIHubURL(widgetConfiguration.aiHubURL);
 
 		createRoot(element).render(
 			<ChatbotWidget widgetConfiguration={widgetConfiguration} />

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
@@ -27,5 +27,6 @@ export interface ChatMessage {
 }
 
 export interface WidgetConfiguration {
+	aiHubURL: string;
 	chatbotExternalReferenceCode: string;
 }

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export interface AuthorizationToken {
+	accessToken: string;
+	scope: string;
+	serviceURL: string;
+	userToken: string;
+}
+
 export interface ChatbotConfiguration {
 	active: boolean;
 	companyLogo?: {
@@ -20,6 +27,5 @@ export interface ChatMessage {
 }
 
 export interface WidgetConfiguration {
-	aiHubURL: string;
 	chatbotExternalReferenceCode: string;
 }

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
@@ -29,4 +29,5 @@ export interface ChatMessage {
 export interface WidgetConfiguration {
 	aiHubURL: string;
 	chatbotExternalReferenceCode: string;
+	liferayDXPURL: string;
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90899

## What is being fixed

A signed-in DXP user opening the AI Hub chatbot through Click to Chat lands in a guest-scoped chat session — the AI Hub never receives the user's identity, so the chat loses access to that user's permissions and personalization.

## How it is being fixed

The widget now POSTs to `/o/ai-hub-cell/v1.0/authorization-tokens` against the DXP origin before any AI Hub call, then attaches the resulting access token as a Bearer on every AI Hub request and the user token as `Liferay-AI-Hub-Cell-On-Behalf-Of` on the chat-message POST. The auth-token POST carries `x-csrf-token` (read from `Liferay.authToken`) so the session-based auth verifier honors JSESSIONID; the token is cached client-side and refreshed after 9 minutes to stay ahead of the 10-minute JWT TTL. The AI Hub service URL now flows from `serviceURL` on the token response rather than the script-tag attribute, removing one source of drift.

Two prerequisites travel with the widget change. The AI Hub Cell now sends `scope=Liferay.AI.Hub.REST.everything` on its OAuth2 token request — without it the issued bearer carried no scope claim and every `/o/ai-hub/v1.0/*` call rejected it with HTTP 403. And `ChatbotWidget` is updated to consume the now-async `createEventSource`, storing the resolved `EventSource` in a `useRef` so the effect's cleanup can still close it on unmount.

## Why are there no tests?

Verified manually end-to-end. The `Liferay-AI-Hub-Cell-On-Behalf-Of` JWT now carries `sub: <signed-in user id>` when signed in and `sub: <guest user id>` when not — the canonical proof of the fix. Also exercised the 9-minute token cache refresh and a full chat round-trip against a local AI Hub setup. The widget bundle ships no JS test harness; the matching server-side flow is already covered by `AuthorizationTokenResourceTest`.

## Notes

`pr-check`'s Structural Smoke validation reports two failures that pre-date this branch: `ConfigurationEnvBuilderTest.testBuildContent` missing `portal-osgi-configuration-properties` entries for `AIHubCellConfiguration_secret` and `MCPServerConfiguration_enabled`, and `Log4jConfigUtilTest` failing a coverage threshold. `git diff master..HEAD --stat` confirms neither code path is in this branch's diff. Fix is `ant update-portal-osgi-configuration-properties` against master.