### PR TITLE
LPD-90364 [BE] Create Model Armor based Guardrails template

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/constants/AIHubFDSNames.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/constants/AIHubFDSNames.java
@@ -22,4 +22,7 @@ public class AIHubFDSNames {
 	public static final String INSTRUCTION_DEFINITIONS =
 		AIHubWebConstants.BUNDLE_SYMBOLIC_NAME + "-instructionDefinitions";
 
+	public static final String MODEL_ARMOR_TEMPLATES =
+		AIHubWebConstants.BUNDLE_SYMBOLIC_NAME + "-modelArmorTemplates";
+
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditModelArmorTemplateDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditModelArmorTemplateDisplayContext.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.display.context;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.ai.hub.util.AccountEntryUtil;
+import com.liferay.ai.hub.web.internal.util.ActionUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+/**
+ * @author João Victor Alves
+ */
+public class EditModelArmorTemplateDisplayContext {
+
+	public EditModelArmorTemplateDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest = httpServletRequest;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public Map<String, Object> getReactData() throws Exception {
+		return HashMapBuilder.<String, Object>put(
+			"accountEntryExternalReferenceCode",
+			() -> {
+				AccountEntry accountEntry =
+					AccountEntryUtil.getUserAccountEntry(
+						_themeDisplay.getUserId());
+
+				if (accountEntry == null) {
+					return null;
+				}
+
+				return accountEntry.getExternalReferenceCode();
+			}
+		).put(
+			"backURL", ActionUtil.getAIHubURL(_themeDisplay) + "/agent-builder"
+		).put(
+			"externalReferenceCode",
+			_httpServletRequest.getParameter("externalReferenceCode")
+		).build();
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContext.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.display.context;
+
+import com.liferay.ai.hub.web.internal.util.ActionUtil;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+/**
+ * @author João Victor Alves
+ */
+public class ViewModelArmorTemplatesDisplayContext {
+
+	public ViewModelArmorTemplatesDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest = httpServletRequest;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public String getAPIURL() {
+		return "/o/ai-hub/model-armor-templates";
+	}
+
+	public CreationMenu getCreationMenu() throws Exception {
+		return CreationMenuBuilder.addDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref(
+					ActionUtil.getAIHubURL(_themeDisplay) +
+						"/model-armor-template");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "new-guardrail"));
+			}
+		).build();
+	}
+
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
+		throws Exception {
+
+		return List.of(
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					ActionUtil.getAIHubURL(_themeDisplay),
+					"/model-armor-template",
+					"?externalReferenceCode={externalReferenceCode}"),
+				"view", "view", LanguageUtil.get(_httpServletRequest, "view"),
+				"get", null, null),
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					getAPIURL(), "/by-external-reference-code",
+					"/{externalReferenceCode}"),
+				"trash", "delete",
+				LanguageUtil.get(_httpServletRequest, "delete"), "delete",
+				"delete", "async"));
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditModelArmorTemplateFragmentRenderer.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditModelArmorTemplateFragmentRenderer.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.fragment.renderer;
+
+import com.liferay.ai.hub.web.internal.display.context.EditModelArmorTemplateDisplayContext;
+import com.liferay.fragment.renderer.FragmentRenderer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author João Victor Alves
+ */
+@Component(service = FragmentRenderer.class)
+public class EditModelArmorTemplateFragmentRenderer
+	extends BaseFragmentRenderer<EditModelArmorTemplateDisplayContext> {
+
+	@Override
+	public String getCollectionKey() {
+		return "model-armor-template";
+	}
+
+	@Override
+	protected EditModelArmorTemplateDisplayContext getDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		return new EditModelArmorTemplateDisplayContext(httpServletRequest);
+	}
+
+	@Override
+	protected String getJSPPath() {
+		return "/edit_model_armor_template.jsp";
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/ViewModelArmorTemplatesFragmentRenderer.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/ViewModelArmorTemplatesFragmentRenderer.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.fragment.renderer;
+
+import com.liferay.ai.hub.web.internal.display.context.ViewModelArmorTemplatesDisplayContext;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author João Victor Alves
+ */
+@Component(service = FragmentRenderer.class)
+public class ViewModelArmorTemplatesFragmentRenderer
+	extends BaseFragmentRenderer<ViewModelArmorTemplatesDisplayContext> {
+
+	@Override
+	public String getCollectionKey() {
+		return "sections";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "agent-builder-section");
+	}
+
+	@Override
+	public boolean isSelectable(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Group group = _groupLocalService.fetchGroup(
+			themeDisplay.getScopeGroupId());
+
+		if (group == null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	protected ViewModelArmorTemplatesDisplayContext getDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		return new ViewModelArmorTemplatesDisplayContext(httpServletRequest);
+	}
+
+	@Override
+	protected String getJSPPath() {
+		return "/view_model_armor_templates.jsp";
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/frontend/data/set/view/list/ListFDSView.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/frontend/data/set/view/list/ListFDSView.java
@@ -19,7 +19,8 @@ import org.osgi.service.component.annotations.Component;
 		"frontend.data.set.name=" + AIHubFDSNames.AGENT_DEFINITIONS,
 		"frontend.data.set.name=" + AIHubFDSNames.CHATBOTS,
 		"frontend.data.set.name=" + AIHubFDSNames.CONTENT_RETRIEVERS,
-		"frontend.data.set.name=" + AIHubFDSNames.INSTRUCTION_DEFINITIONS
+		"frontend.data.set.name=" + AIHubFDSNames.INSTRUCTION_DEFINITIONS,
+		"frontend.data.set.name=" + AIHubFDSNames.MODEL_ARMOR_TEMPLATES
 	},
 	service = FDSView.class
 )

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/init.jsp
@@ -20,10 +20,12 @@ page import="com.liferay.ai.hub.web.internal.display.context.EditAgentDefinition
 page import="com.liferay.ai.hub.web.internal.display.context.EditChatbotDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.EditContentRetrieverDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.EditInstructionDefinitionDisplayContext" %><%@
+page import="com.liferay.ai.hub.web.internal.display.context.EditModelArmorTemplateDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewAgentDefinitionsDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewChatbotsDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewContentRetrieversDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewInstructionDefinitionsDisplayContext" %><%@
+page import="com.liferay.ai.hub.web.internal.display.context.ViewModelArmorTemplatesDisplayContext" %><%@
 page import="com.liferay.portal.workflow.constants.WorkflowPortletKeys" %>
 
 <liferay-frontend:defineObjects />


### PR DESCRIPTION
## Summary

Backend half of LPD-90364, split out from #395 so it can be reviewed independently from the frontend (#409).

Adds the Java side of the Model Armor template UI: display contexts that feed the new JSPs, fragment renderers that register them in the AI Hub admin, the FDS view that wires the list to the headless endpoint, plus the two `init.jsp` imports that follow the existing AI Hub admin convention.

- `AIHubFDSNames` — adds the `MODEL_ARMOR_TEMPLATES` constant.
- `EditModelArmorTemplateDisplayContext` / `ViewModelArmorTemplatesDisplayContext` — request-scoped view models for the edit form and list view.
- `EditModelArmorTemplateFragmentRenderer` / `ViewModelArmorTemplatesFragmentRenderer` — OSGi `FragmentRenderer` services that mount the JSPs.
- `ListFDSView` — registers `MODEL_ARMOR_TEMPLATES` as another FDS-named list view.
- `init.jsp` — imports the two new display contexts so the model-armor JSPs can resolve them through the shared include, matching the pattern used by every other AI Hub admin feature.