### PR TITLE
LPD-91799 Set up the Activity Dashboard page scaffold

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_activity/page-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_activity/page-definition.json
@@ -1,0 +1,26 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "com.liferay.ai.hub.web.internal.fragment.renderer.ViewActivityDashboardFragmentRenderer"
+					},
+					"fragmentConfig": {
+					},
+					"fragmentFields": [
+					],
+					"indexed": true
+				},
+				"type": "Fragment"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"masterPage": {
+			"key": "ai-hub-master"
+		}
+	},
+	"version": 1.0
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_activity/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_activity/page.json
@@ -1,0 +1,18 @@
+{
+	"friendlyURL": "/activity",
+	"hidden": false,
+	"name_i18n": {
+		"en_US": "Activity"
+	},
+	"permissions": [
+		{
+			"actionIds": [
+			],
+			"roleName": "Guest",
+			"scope": 4
+		}
+	],
+	"private": false,
+	"system": false,
+	"type": "Content"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/site-navigation-menus.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/site-navigation-menus.json
@@ -19,6 +19,12 @@
 				"friendlyURL": "/chatbots",
 				"privateLayout": false,
 				"type": "layout"
+			},
+			{
+				"externalReferenceCode": "AIHUBPRIMARYNAVIGATION4",
+				"friendlyURL": "/activity",
+				"privateLayout": false,
+				"type": "layout"
 			}
 		],
 		"name": "AI Hub Navigation Menu"

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewActivityDashboardDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewActivityDashboardDisplayContext.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.display.context;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.ai.hub.util.AccountEntryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+/**
+ * @author Igor Franca
+ */
+public class ViewActivityDashboardDisplayContext {
+
+	public ViewActivityDashboardDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public Map<String, Object> getProperties() {
+		return HashMapBuilder.<String, Object>put(
+			"accountEntryExternalReferenceCode",
+			() -> {
+				AccountEntry accountEntry =
+					AccountEntryUtil.getUserAccountEntry(
+						_themeDisplay.getUserId());
+
+				if (accountEntry == null) {
+					return null;
+				}
+
+				return accountEntry.getExternalReferenceCode();
+			}
+		).build();
+	}
+
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/ViewActivityDashboardFragmentRenderer.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/ViewActivityDashboardFragmentRenderer.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.fragment.renderer;
+
+import com.liferay.ai.hub.web.internal.display.context.ViewActivityDashboardDisplayContext;
+import com.liferay.fragment.renderer.FragmentRenderer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Igor Franca
+ */
+@Component(service = FragmentRenderer.class)
+public class ViewActivityDashboardFragmentRenderer
+	extends BaseFragmentRenderer<ViewActivityDashboardDisplayContext> {
+
+	@Override
+	public String getCollectionKey() {
+		return "sections";
+	}
+
+	@Override
+	protected ViewActivityDashboardDisplayContext getDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		return new ViewActivityDashboardDisplayContext(httpServletRequest);
+	}
+
+	@Override
+	protected String getJSPPath() {
+		return "/view_activity_dashboard.jsp";
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@ page import="com.liferay.ai.hub.web.internal.display.context.EditChatbotDisplayC
 page import="com.liferay.ai.hub.web.internal.display.context.EditContentRetrieverDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.EditInstructionDefinitionDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.HomeDashboardDisplayContext" %><%@
+page import="com.liferay.ai.hub.web.internal.display.context.ViewActivityDashboardDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewAgentDefinitionsDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewChatbotsDisplayContext" %><%@
 page import="com.liferay.ai.hub.web.internal.display.context.ViewContentRetrieversDisplayContext" %><%@

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/ActivityDashboard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/ActivityDashboard.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+export default function ActivityDashboard({
+	accountEntryExternalReferenceCode,
+}: {
+	accountEntryExternalReferenceCode: string | null;
+}) {
+	void accountEntryExternalReferenceCode;
+
+	return <ClayLayout.ContainerFluid />;
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as ActivityDashboard} from './activity_dashboard/ActivityDashboard';
 export {default as AgentDefinitionForm} from './agent_definition_form/AgentDefinitionForm';
 export {default as AgentDefinitionItemTitlePropsTransformer} from './agent_definition_item_title/AgentDefinitionItemTitlePropsTransformer';
 export {default as ChatbotForm} from './chatbot_form/ChatbotForm';

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/view_activity_dashboard.jsp
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/view_activity_dashboard.jsp
@@ -1,0 +1,19 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ViewActivityDashboardDisplayContext viewActivityDashboardDisplayContext = (ViewActivityDashboardDisplayContext)request.getAttribute(ViewActivityDashboardDisplayContext.class.getName());
+%>
+
+<div>
+	<react:component
+		module="{ActivityDashboard} from ai-hub-web"
+		props="<%= viewActivityDashboardDisplayContext.getProperties() %>"
+	/>
+</div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91799

## What is being fixed

LPD-91326 needs an Activity page inside AI Hub to host the token meter cards.

## How it is being fixed

The PR lands the rendering plumbing: the Java fragment renderer plus display context, the React entry mounted through the JSP, and the site initializer layout with the nav menu entry. The display context exposes accountEntryExternalReferenceCode.

## Why are there no tests?

The scaffold has no behavior. The React entry returns an empty ClayLayout.ContainerFluid and the fragment renderer just wires its display context. The first real Jest tests land in LPD-91800 with the service and polling hook.