### PR TITLE
LPD-91800 Add ActivityMetrics types, mock service, and polling hook

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/package.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/package.json
@@ -15,6 +15,7 @@
 		"@clayui/provider": "^3.163.0",
 		"@clayui/toolbar": "^3.163.0",
 		"@liferay/frontend-data-set-web": "*",
+		"@liferay/frontend-js-react-web": "*",
 		"@liferay/object-js-components-web": "*",
 		"classnames": "2.3.1",
 		"dynamic-data-mapping-form-field-type": "*",

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/constants.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const POLL_INTERVAL_MS = 30_000;
+
+export const REST_BASE_URL = '/o/ai-hub/v1.0';

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/hooks/useActivityMetrics.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/hooks/useActivityMetrics.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	useBrowserTabVisibility,
+	useInterval,
+	useIsMounted,
+} from '@liferay/frontend-js-react-web';
+import {useCallback, useEffect, useState} from 'react';
+
+import {POLL_INTERVAL_MS} from '../constants';
+import {getActivityMetrics} from '../services/ActivityMetricsService';
+import {ActivityMetrics} from '../types/ActivityMetrics';
+
+type Result = {
+	data: ActivityMetrics | null;
+	error: Error | null;
+	loading: boolean;
+	refetch: () => Promise<void>;
+};
+
+export default function useActivityMetrics(
+	accountEntryExternalReferenceCode: string | undefined
+): Result {
+	const [data, setData] = useState<ActivityMetrics | null>(null);
+	const [error, setError] = useState<Error | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	const isMounted = useIsMounted();
+	const isVisible = useBrowserTabVisibility();
+	const schedule = useInterval();
+
+	const fetchMetrics = useCallback(async () => {
+		if (accountEntryExternalReferenceCode === undefined) {
+			return;
+		}
+
+		try {
+			const result = await getActivityMetrics(
+				accountEntryExternalReferenceCode
+			);
+
+			if (isMounted()) {
+				setData(result);
+				setError(null);
+			}
+		}
+		catch (caught) {
+			if (isMounted()) {
+				setError(caught as Error);
+			}
+		}
+		finally {
+			if (isMounted()) {
+				setLoading(false);
+			}
+		}
+	}, [accountEntryExternalReferenceCode, isMounted]);
+
+	useEffect(() => {
+		if (accountEntryExternalReferenceCode === undefined) {
+			setLoading(false);
+
+			return;
+		}
+
+		if (!isVisible) {
+			return;
+		}
+
+		fetchMetrics();
+
+		return schedule(fetchMetrics, POLL_INTERVAL_MS);
+	}, [accountEntryExternalReferenceCode, fetchMetrics, isVisible, schedule]);
+
+	return {data, error, loading, refetch: fetchMetrics};
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/services/ActivityMetricsService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/services/ActivityMetricsService.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ActivityMetrics} from '../types/ActivityMetrics';
+
+const MOCK_ACTIVITY_METRICS: ActivityMetrics = {
+	agentsCount: 18,
+	averageResponseTimeMs: 2600,
+	chatbotsCount: 4,
+	monthlyAllowanceLRT: 10_000,
+	monthlyConsumedLRT: 8972,
+	prepaidBalanceLRT: 2500,
+	prepaidExpiresAt: '2027-05-21T00:00:00Z',
+	totalInteractions: 1245,
+};
+
+export async function getActivityMetrics(
+	accountEntryExternalReferenceCode: string | undefined
+): Promise<ActivityMetrics> {
+	void accountEntryExternalReferenceCode;
+
+	return Promise.resolve(MOCK_ACTIVITY_METRICS);
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/types/ActivityMetrics.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/types/ActivityMetrics.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export type ActivityMetrics = {
+	agentsCount: number;
+	averageResponseTimeMs: number;
+	chatbotsCount: number;
+	monthlyAllowanceLRT: number;
+	monthlyConsumedLRT: number;
+	prepaidBalanceLRT: number;
+	prepaidExpiresAt: string | null;
+	totalInteractions: number;
+};

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b4d3896375ce6c83d89bca92b11bf3415462463e",
+	"@generated": "3d7f9bdccf9294c2848740ccbde802f65ef608a4",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/frontend-data-set-web": [
 				"../../../../../../../../../apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts"
+			],
+			"@liferay/frontend-js-react-web": [
+				"../../../../../../../../../apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"@liferay/object-js-components-web": [
 				"../../../../../../../../../apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -51,6 +54,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../../../apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../../../apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../../../apps/object/object-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/hooks/useActivityMetrics.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/hooks/useActivityMetrics.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, renderHook, waitFor} from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+
+import useActivityMetrics from '../../../../src/main/resources/META-INF/resources/js/activity_dashboard/hooks/useActivityMetrics';
+import {ActivityMetrics} from '../../../../src/main/resources/META-INF/resources/js/activity_dashboard/types/ActivityMetrics';
+
+const mockGetActivityMetrics = jest.fn();
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/activity_dashboard/services/ActivityMetricsService',
+	() => ({
+		getActivityMetrics: (...args: any[]) => mockGetActivityMetrics(...args),
+	})
+);
+
+const SAMPLE_METRICS: ActivityMetrics = {
+	agentsCount: 18,
+	averageResponseTimeMs: 2600,
+	chatbotsCount: 4,
+	monthlyAllowanceLRT: 10_000,
+	monthlyConsumedLRT: 8972,
+	prepaidBalanceLRT: 2500,
+	prepaidExpiresAt: '2027-05-21T00:00:00Z',
+	totalInteractions: 1245,
+};
+
+function setTabVisible(visible: boolean) {
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true,
+		value: visible ? 'visible' : 'hidden',
+	});
+
+	document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('useActivityMetrics', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		mockGetActivityMetrics.mockReset();
+		mockGetActivityMetrics.mockResolvedValue(SAMPLE_METRICS);
+		setTabVisible(true);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('does not fetch when the account ERC is undefined', async () => {
+		const {result} = renderHook(() => useActivityMetrics(undefined));
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(mockGetActivityMetrics).not.toHaveBeenCalled();
+		expect(result.current.data).toBeNull();
+		expect(result.current.error).toBeNull();
+	});
+
+	it('exposes a refetch function that triggers an extra fetch', async () => {
+		const {result} = renderHook(() => useActivityMetrics('ACCOUNT_ERC'));
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(1)
+		);
+
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		expect(mockGetActivityMetrics).toHaveBeenCalledTimes(2);
+	});
+
+	it('fetches metrics on mount and exposes the result', async () => {
+		const {result} = renderHook(() => useActivityMetrics('ACCOUNT_ERC'));
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.data).toEqual(SAMPLE_METRICS);
+		expect(result.current.error).toBeNull();
+		expect(mockGetActivityMetrics).toHaveBeenCalledWith('ACCOUNT_ERC');
+	});
+
+	it('pauses polling while the tab is hidden', async () => {
+		renderHook(() => useActivityMetrics('ACCOUNT_ERC'));
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(1)
+		);
+
+		act(() => {
+			setTabVisible(false);
+		});
+
+		act(() => {
+			jest.advanceTimersByTime(120_000);
+		});
+
+		expect(mockGetActivityMetrics).toHaveBeenCalledTimes(1);
+	});
+
+	it('polls every 30 seconds', async () => {
+		renderHook(() => useActivityMetrics('ACCOUNT_ERC'));
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(1)
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(30_000);
+		});
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(2)
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(30_000);
+		});
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(3)
+		);
+	});
+
+	it('refetches when the tab becomes visible again', async () => {
+		renderHook(() => useActivityMetrics('ACCOUNT_ERC'));
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(1)
+		);
+
+		act(() => {
+			setTabVisible(false);
+		});
+
+		act(() => {
+			setTabVisible(true);
+		});
+
+		await waitFor(() =>
+			expect(mockGetActivityMetrics).toHaveBeenCalledTimes(2)
+		);
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/services/ActivityMetricsService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/services/ActivityMetricsService.test.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getActivityMetrics} from '../../../../src/main/resources/META-INF/resources/js/activity_dashboard/services/ActivityMetricsService';
+
+describe('ActivityMetricsService', () => {
+	it('returns the mocked ActivityMetrics shape', async () => {
+		const metrics = await getActivityMetrics('ACCOUNT_ERC');
+
+		expect(metrics).toEqual({
+			agentsCount: expect.any(Number),
+			averageResponseTimeMs: expect.any(Number),
+			chatbotsCount: expect.any(Number),
+			monthlyAllowanceLRT: expect.any(Number),
+			monthlyConsumedLRT: expect.any(Number),
+			prepaidBalanceLRT: expect.any(Number),
+			prepaidExpiresAt: expect.any(String),
+			totalInteractions: expect.any(Number),
+		});
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/tsconfig.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0e21499ddf2a1ddc29a8f2d17b476728b3d850d1",
+	"@generated": "fd973f33bec835305e7b1177dc6458ec3c4882d0",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/frontend-data-set-web": [
 				"../../../../../apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts"
+			],
+			"@liferay/frontend-js-react-web": [
+				"../../../../../apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"@liferay/object-js-components-web": [
 				"../../../../../apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -53,6 +56,9 @@
 	"references": [
 		{
 			"path": "../../../../../apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../apps/object/object-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91800

## What is being fixed

The Activity Dashboard needs a typed data layer the cards will consume in the upcoming subtasks. The contract shape and the polling cadence belong here, before any card lands. This PR is independent of LPD-91799 and goes to master on its own.

## How it is being fixed

Four small commits add the layered foundation.

1. `ActivityMetrics` type plus module constants (`REST_BASE_URL`, `POLL_INTERVAL_MS = 30_000`). The `package.json` picks up `@liferay/frontend-js-react-web` for the visibility and interval helpers.
2. `tsconfig.json` regeneration (auto-generated from the new dependency).
3. `ActivityMetricsService` exposes `getActivityMetrics(accountEntryExternalReferenceCode)` returning a deterministic mock. One line swap to `fetch` when LPD-91668 / LPD-91669 ship the endpoint.
4. `useActivityMetrics(erc)` polls the service every 30 seconds **only while the tab is the active foreground tab**. Polling pauses on tab switch, on window minimise, and on any other transition that flips `document.visibilityState` to `hidden`. Returning to the tab triggers an immediate refetch and resumes the 30 second cadence. When `accountEntryExternalReferenceCode` is `undefined` (no account on the request) the hook short-circuits and never calls the service.

### Why 30 seconds, and why only when the tab is active

Token usage is monotonic and not real time critical, so a 30 second cadence is enough to feel fresh without burning admin time or backend capacity. Pausing while the tab is hidden means a customer who left a stale Activity page open in a background tab does not generate background traffic. Liferay's `useInterval` + `useBrowserTabVisibility` already implement this pause-on-hidden pattern with proper cleanup on unmount, so the hook stays small and reuses existing infrastructure.

## Tests

Seven Jest tests cover every relevant transition explicitly, no mock-internal invariants. Tests are ordered alphabetically inside the suite.

- Service test asserts the response matches the `ActivityMetrics` type. Survives the swap to a real backend.
- Hook does not fetch when the account ERC is undefined.
- Hook exposes a `refetch()` callback that triggers an on-demand fetch.
- Hook fetches on mount and exposes the result.
- Hook pauses polling while the tab is hidden (no extra fetch across two minutes of simulated time).
- Hook polls every 30 seconds while the tab is visible.
- Hook refetches immediately when the tab becomes visible again.