### PR TITLE
LPD-91801 Add the MetricCard primitive

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/components/MetricCard.scss
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/components/MetricCard.scss
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+.ai-hub-metric-card {
+	background-color: #ffffff;
+	border: 1px solid #cdcfd4;
+	border-radius: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 20px;
+}
+
+.ai-hub-metric-card-header {
+	align-items: flex-start;
+	display: flex;
+	justify-content: space-between;
+}
+
+.ai-hub-metric-card-title {
+	color: #272833;
+	font-size: 14px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.ai-hub-metric-card-icon {
+	flex-shrink: 0;
+}
+
+.ai-hub-metric-card-value {
+	color: #272833;
+	font-size: 32px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.ai-hub-metric-card-footer {
+	margin-top: auto;
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/components/MetricCard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/activity_dashboard/components/MetricCard.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {ReactNode} from 'react';
+
+import './MetricCard.scss';
+
+export default function MetricCard({
+	children,
+	icon,
+	title,
+	value,
+}: {
+	children?: ReactNode;
+	icon?: ReactNode;
+	title: string;
+	value: ReactNode;
+}) {
+	return (
+		<article className="ai-hub-metric-card">
+			<header className="ai-hub-metric-card-header">
+				<h3 className="ai-hub-metric-card-title">{title}</h3>
+
+				{icon ? (
+					<span className="ai-hub-metric-card-icon">{icon}</span>
+				) : null}
+			</header>
+
+			<div className="ai-hub-metric-card-value">{value}</div>
+
+			{children ? (
+				<div className="ai-hub-metric-card-footer">{children}</div>
+			) : null}
+		</article>
+	);
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/components/MetricCard.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/activity_dashboard/components/MetricCard.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import MetricCard from '../../../../src/main/resources/META-INF/resources/js/activity_dashboard/components/MetricCard';
+
+describe('MetricCard', () => {
+	it('renders the children area when children are provided', () => {
+		render(
+			<MetricCard title="Prepaid Balance" value="2,500 LRT">
+				<span>Expires on May 21, 2027</span>
+			</MetricCard>
+		);
+
+		expect(screen.getByText('Expires on May 21, 2027')).toBeInTheDocument();
+	});
+
+	it('renders the icon when provided', () => {
+		render(
+			<MetricCard icon={<span>sticker</span>} title="Agents" value="18" />
+		);
+
+		expect(screen.getByText('sticker')).toBeInTheDocument();
+	});
+
+	it('renders the title as a level three heading', () => {
+		render(<MetricCard title="Agents" value="18" />);
+
+		expect(
+			screen.getByRole('heading', {level: 3, name: 'Agents'})
+		).toBeInTheDocument();
+	});
+
+	it('renders the value', () => {
+		render(<MetricCard title="Agents" value="18" />);
+
+		expect(screen.getByText('18')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91801

## What is being fixed

The Activity Dashboard cards (LPD-91802, LPD-91803, LPD-91804) all share the same outer shape in the Figma: a header row with a title and a sticker icon, a large value below, and an optional footer area for label chips or a progress bar. Each card today would have to re-implement that layout.

## How it is being fixed

One small commit adds `MetricCard`, a presentational primitive with four slots.

```tsx
type Props = {
    children?: ReactNode;  // label chip, progress bar, CTA, etc.
    icon?: ReactNode;      // top-right sticker
    title: string;
    value: ReactNode;      // string or styled element
};
```

The card owns the layout (header on top, value below, children area at the bottom) and the default typography (title 14, value 32, charcoal `#272833`). It does not own any threshold logic. When LPD-91803 lands the Monthly LRT card, the consumer will style the value red on capped and drop a colored `<ProgressBar>` into `children` without changing the primitive.

Scoped SCSS in `MetricCard.scss`. No `status` enum, no skeleton, no `null` defaulting that would duplicate the consumer's job.

## Tests

Four Jest tests, alphabetical, accessibility-first locators.

- Renders the children area when children are provided.
- Renders the icon when provided.
- Renders the title as a level three heading.
- Renders the value.