### PR TITLE
LPD-92276 Show a fallback message when the AI assistant has no response

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -244,8 +244,17 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 				SupervisorResponseStrategy.SCORED
 			).build();
 
+		String response = supervisorAgent.invoke(message);
+
+		if (Validator.isBlank(response)) {
+			response = _language.get(
+				agentContext.getDTOConverterContext(
+				).getLocale(),
+				"i-cannot-fulfill-this-request");
+		}
+
 		SseUtil.send(
-			supervisorAgent.invoke(message), "Chat Message Sent", null,
+			response, "Chat Message Sent", null,
 			agentContext.getSseEventSinkKey());
 	}
 


### PR DESCRIPTION
## Summary
- When the AI Assistant's supervisor returns a blank response (the planner resolves to `done` and the `SCORED` strategy selects no sub-agent output), the chat rendered an empty message bubble with no feedback to the user.
- `SupervisorAgentImpl._invoke` now guards the blank result and sends the localized `i-cannot-fulfill-this-request` fallback instead of an empty string.

## Ticket
https://liferay.atlassian.net/browse/LPD-92276

## Test plan
- [x] Manually verified: a request the assistant declines now shows "I cannot fulfill this request." instead of an empty bubble.