### PR TITLE
LPD-92235 Set default threshold settings in AI Hub

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -9,9 +9,12 @@ import com.liferay.ai.hub.internal.configuration.VertexAIConfiguration;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 
+import dev.langchain4j.model.vertexai.gemini.HarmCategory;
+import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -40,6 +43,8 @@ public class VertexAiGeminiUtil {
 			vertexAIConfiguration.modelName()
 		).project(
 			vertexAIConfiguration.projectId()
+		).safetySettings(
+			_safetySettings
 		).build();
 	}
 
@@ -64,7 +69,20 @@ public class VertexAiGeminiUtil {
 			vertexAIConfiguration.modelName()
 		).project(
 			vertexAIConfiguration.projectId()
+		).safetySettings(
+			_safetySettings
 		).build();
 	}
+
+	private static final Map<HarmCategory, SafetyThreshold> _safetySettings =
+		Map.of(
+			HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+			SafetyThreshold.BLOCK_MEDIUM_AND_ABOVE,
+			HarmCategory.HARM_CATEGORY_HARASSMENT,
+			SafetyThreshold.BLOCK_MEDIUM_AND_ABOVE,
+			HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+			SafetyThreshold.BLOCK_MEDIUM_AND_ABOVE,
+			HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+			SafetyThreshold.BLOCK_MEDIUM_AND_ABOVE);
 
 }


### PR DESCRIPTION
## Summary
- Enable Vertex AI native `safetySettings(BLOCK_MEDIUM_AND_ABOVE)` on all four harm categories (HARASSMENT, HATE_SPEECH, DANGEROUS_CONTENT, SEXUALLY_EXPLICIT) for both the streaming and non-streaming Gemini chat models in `VertexAiGeminiUtil`.
- The factory is the single chokepoint for Gemini model creation, so this applies a deterministic safety filter at the model boundary for every AI Hub Gemini call.

## Ticket
https://liferay.atlassian.net/browse/LPD-92235

## Test plan
- [x] Verified via langchain4j response logging that the safety settings are applied and per-category safety ratings are present on Gemini responses.