### PR TITLE
LPD-91809 Show localized server error in chatbot form toast

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
@@ -151,9 +151,7 @@ export default function ChatbotForm({
 					)
 				);
 			})
-			.catch((error) => {
-				console.error(error);
-			})
+			.catch(() => {})
 			.finally(() => {
 				setAgentDefinitionsLoaded(true);
 			});
@@ -338,8 +336,6 @@ export default function ChatbotForm({
 			});
 		}
 		catch (error) {
-			console.error(error);
-
 			openToast({
 				message:
 					(error instanceof Error && error.message) ||

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
@@ -341,7 +341,9 @@ export default function ChatbotForm({
 			console.error(error);
 
 			openToast({
-				message: Liferay.Language.get('an-unexpected-error-occurred'),
+				message:
+					(error instanceof Error && error.message) ||
+					Liferay.Language.get('an-unexpected-error-occurred'),
 				type: 'danger',
 			});
 		}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
@@ -11,8 +11,15 @@ const CHATBOT_BASE_URI = '/o/ai-hub/chatbots';
 
 const CHATBOT_BY_ERC_URI = `${CHATBOT_BASE_URI}/by-external-reference-code/`;
 
+const HEADERS = new Headers({
+	'Accept': 'application/json',
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+	'Content-Type': 'application/json',
+});
+
 async function getChatbots() {
 	const response = await fetch(CHATBOT_BASE_URI, {
+		headers: HEADERS,
 		method: 'GET',
 	});
 
@@ -27,6 +34,7 @@ async function getChatbot(externalReferenceCode: string) {
 	const response = await fetch(
 		`${CHATBOT_BY_ERC_URI}${externalReferenceCode}?nestedFields=agentDefinitionsToChatbots`,
 		{
+			headers: HEADERS,
 			method: 'GET',
 		}
 	);
@@ -41,14 +49,14 @@ async function getChatbot(externalReferenceCode: string) {
 async function postChatbot(chatbot: Chatbot) {
 	const response = await fetch(CHATBOT_BASE_URI, {
 		body: JSON.stringify(chatbot),
-		headers: {
-			'Content-Type': 'application/json',
-		},
+		headers: HEADERS,
 		method: 'POST',
 	});
 
 	if (!response.ok) {
-		throw new Error();
+		const {message, title} = await response.json().catch(() => ({}));
+
+		throw new Error(title || message || '');
 	}
 
 	return response.json();
@@ -62,15 +70,15 @@ async function putChatbot(
 		`${CHATBOT_BY_ERC_URI}${existingExternalReferenceCode}`,
 		{
 			body: JSON.stringify(chatbot),
-			headers: {
-				'Content-Type': 'application/json',
-			},
+			headers: HEADERS,
 			method: 'PUT',
 		}
 	);
 
 	if (!response.ok) {
-		throw new Error();
+		const {message, title} = await response.json().catch(() => ({}));
+
+		throw new Error(title || message || '');
 	}
 
 	return response.json();
@@ -82,7 +90,10 @@ async function deleteChatbotAgentDefinitionRelationship(
 ) {
 	return fetch(
 		`${CHATBOT_BY_ERC_URI}${chatbotERC}/agentDefinitionsToChatbots/${agentERC}`,
-		{method: 'DELETE'}
+		{
+			headers: HEADERS,
+			method: 'DELETE',
+		}
 	);
 }
 
@@ -92,7 +103,10 @@ async function putChatbotAgentDefinitionRelationship(
 ) {
 	return fetch(
 		`${CHATBOT_BY_ERC_URI}${chatbotERC}/agentDefinitionsToChatbots/${agentERC}`,
-		{method: 'PUT'}
+		{
+			headers: HEADERS,
+			method: 'PUT',
+		}
 	);
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91809

## What is being fixed

The chatbot admin form's save-error toast showed a generic "An
unexpected error occurred" regardless of what the server actually
reported. Server-provided error titles (e.g. "This external reference
code is already in use." on a duplicate-ERC create) were dropped
silently.

The form also relied on the browser's Accept-Language for REST calls,
so error titles came back in the browser language rather than the
user's portal account language.

## How it is being fixed

`ChatbotService.ts` now sets `Accept-Language: Liferay.ThemeDisplay.getBCP47LanguageId()` on every chatbot REST call (mirroring `object-web/.../ApiHelper.ts:8-12`), so error responses arrive localized to the user's portal locale. `postChatbot` and `putChatbot` parse the response body's `{title, message}` (matching `ApiHelper.ts:151-153`) and throw an Error carrying the localized title. The form's `handleSubmit` catch block prefers `error.message` over the generic Language key, falling back only when the server didn't provide a title. Also drops two `console.error` calls in the form's catch blocks for consistency with `object-web/.../EditObjectField.tsx`.

## Why are there no tests?

The chatbot form's save flow is already covered by tests on the main LPD-91809 PR (liferay-ai-hub/liferay-portal#439). This follow-up only swaps in a localized error message and removes log noise — no new behavior surface to test. Verified by smoke-testing a duplicate-ERC create: toast now shows the localized server title.