### PR TITLE
LPD-91664 Reconcile quota usage via a chat model listener

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
@@ -15,10 +15,12 @@ public interface QuotaManager {
 	public void addQuotas(long accountEntryId, long companyId, long userId)
 		throws PortalException;
 
-	public void checkUsage(long companyId, String text, long userId)
+	public long checkUsage(long companyId, String text, long userId)
 		throws PortalException;
 
-	public void updateUsage(long companyId, long tokensCount, long userId)
+	public void updateUsage(
+			long companyId, long inputTokensCount, long outputTokensCount,
+			long preDebitedTokens, long userId)
 		throws PortalException;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -72,16 +72,29 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 					PermissionChecker originalPermissionChecker =
 						PermissionThreadLocal.getPermissionChecker();
 
-					try (VertexAiGeminiChatModel vertexAiGeminiChatModel =
-							VertexAiGeminiUtil.createVertexAiGeminiChatModel(
-								agentContext.getCompanyId())) {
-
+					try {
 						PermissionThreadLocal.setPermissionChecker(
 							permissionChecker);
 
-						_invoke(
-							agentContext, internalAgents,
-							vertexAiGeminiChatModel);
+						String message = MapUtil.getString(
+							agentContext.getInput(), "message");
+
+						long preDebitedTokens = _quotaManager.checkUsage(
+							agentContext.getCompanyId(), message,
+							agentContext.getUserId());
+
+						try (VertexAiGeminiChatModel vertexAiGeminiChatModel =
+								VertexAiGeminiUtil.
+									createVertexAiGeminiChatModel(
+										agentContext.getCompanyId(),
+										preDebitedTokens,
+										agentContext.getUserId(),
+										_quotaManager)) {
+
+							_invoke(
+								agentContext, internalAgents, message,
+								vertexAiGeminiChatModel);
+						}
 					}
 					catch (Exception exception) {
 						_handleException(agentContext, exception);
@@ -220,13 +233,8 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 	private void _invoke(
 			AgentContext agentContext, InternalAgent[] internalAgents,
-			VertexAiGeminiChatModel vertexAiGeminiChatModel)
+			String message, VertexAiGeminiChatModel vertexAiGeminiChatModel)
 		throws PortalException {
-
-		String message = MapUtil.getString(agentContext.getInput(), "message");
-
-		_quotaManager.checkUsage(
-			agentContext.getCompanyId(), message, agentContext.getUserId());
 
 		dev.langchain4j.agentic.supervisor.SupervisorAgent supervisorAgent =
 			AgenticServices.supervisorBuilder(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/AIHubQuotaChatModelListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/AIHubQuotaChatModelListener.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.model;
+
+import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class AIHubQuotaChatModelListener implements ChatModelListener {
+
+	public AIHubQuotaChatModelListener(
+		long companyId, long preDebitedTokens, long userId,
+		QuotaManager quotaManager) {
+
+		_companyId = companyId;
+		_preDebitedTokens = preDebitedTokens;
+		_userId = userId;
+		_quotaManager = quotaManager;
+	}
+
+	@Override
+	public void onError(ChatModelErrorContext chatModelErrorContext) {
+		_log.error(chatModelErrorContext.error());
+
+		if (_preDebitedTokens <= 0L) {
+			return;
+		}
+
+		try {
+			_quotaManager.updateUsage(
+				_companyId, 0, 0, _preDebitedTokens, _userId);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	@Override
+	public void onResponse(ChatModelResponseContext chatModelResponseContext) {
+		ChatResponse chatResponse = chatModelResponseContext.chatResponse();
+
+		if (chatResponse == null) {
+			return;
+		}
+
+		TokenUsage tokenUsage = chatResponse.tokenUsage();
+
+		if (tokenUsage == null) {
+			return;
+		}
+
+		Integer inputTokenCount = tokenUsage.inputTokenCount();
+		Integer totalTokenCount = tokenUsage.totalTokenCount();
+
+		if ((inputTokenCount == null) || (totalTokenCount == null)) {
+			return;
+		}
+
+		try {
+			_quotaManager.updateUsage(
+				_companyId, inputTokenCount.intValue(),
+				totalTokenCount.intValue() - inputTokenCount.intValue(),
+				_preDebitedTokens, _userId);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AIHubQuotaChatModelListener.class);
+
+	private final long _companyId;
+	private final long _preDebitedTokens;
+	private final QuotaManager _quotaManager;
+	private final long _userId;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.ai.hub.internal.model;
 
 import com.liferay.ai.hub.configuration.VertexAIConfiguration;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 
@@ -14,6 +15,7 @@ import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,7 +25,8 @@ import java.util.Objects;
 public class VertexAiGeminiUtil {
 
 	public static VertexAiGeminiChatModel createVertexAiGeminiChatModel(
-			long companyId)
+			long companyId, long preDebitedTokens, long userId,
+			QuotaManager quotaManager)
 		throws ConfigurationException {
 
 		VertexAIConfiguration vertexAIConfiguration =
@@ -37,7 +40,11 @@ public class VertexAiGeminiUtil {
 			builder.apiEndpoint("aiplatform.googleapis.com");
 		}
 
-		return builder.location(
+		return builder.listeners(
+			List.of(
+				new AIHubQuotaChatModelListener(
+					companyId, preDebitedTokens, userId, quotaManager))
+		).location(
 			vertexAIConfiguration.location()
 		).modelName(
 			vertexAIConfiguration.modelName()
@@ -49,7 +56,9 @@ public class VertexAiGeminiUtil {
 	}
 
 	public static VertexAiGeminiStreamingChatModel
-			createVertexAiGeminiStreamingChatModel(long companyId)
+			createVertexAiGeminiStreamingChatModel(
+				long companyId, long preDebitedTokens, long userId,
+				QuotaManager quotaManager)
 		throws ConfigurationException {
 
 		VertexAIConfiguration vertexAIConfiguration =
@@ -63,7 +72,11 @@ public class VertexAiGeminiUtil {
 			builder.apiEndpoint("aiplatform.googleapis.com");
 		}
 
-		return builder.location(
+		return builder.listeners(
+			List.of(
+				new AIHubQuotaChatModelListener(
+					companyId, preDebitedTokens, userId, quotaManager))
+		).location(
 			vertexAIConfiguration.location()
 		).modelName(
 			vertexAIConfiguration.modelName()

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
@@ -22,11 +22,14 @@ public class DummyQuotaManagerImpl implements QuotaManager {
 	}
 
 	@Override
-	public void checkUsage(long companyId, String text, long userId) {
+	public long checkUsage(long companyId, String text, long userId) {
+		return 0L;
 	}
 
 	@Override
-	public void updateUsage(long companyId, long tokensCount, long userId) {
+	public void updateUsage(
+		long companyId, long inputTokensCount, long outputTokensCount,
+		long preDebitedTokens, long userId) {
 	}
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -184,7 +184,10 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				serviceContext.getCompanyId());
+				serviceContext.getCompanyId(),
+				GetterUtil.getLong(
+					workflowContext.get("quotaPreDebitedTokens")),
+				serviceContext.getUserId(), _quotaManager);
 
 		String sseEventSinkKey = GetterUtil.getString(
 			workflowContext.get("sseEventSinkKey"));
@@ -221,9 +224,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 						GetterUtil.getString(workflowContext.get("reason")),
 						prompt, executionContext.getServiceContext(),
 						userMessage);
-
-					QuotaUtil.updateUsage(
-						response, _quotaManager, serviceContext);
 				}
 			).onErrorConsumer(
 				throwable -> {

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -129,7 +129,10 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				serviceContext.getCompanyId());
+				serviceContext.getCompanyId(),
+				GetterUtil.getLong(
+					workflowContext.get("quotaPreDebitedTokens")),
+				serviceContext.getUserId(), _quotaManager);
 
 		AtomicReference<ChatResponse> chatResponseAtomicReference =
 			new AtomicReference<>();
@@ -277,9 +280,6 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 		KaleoLogUtil.addNodeUsageKaleoLog(
 			chatResponse, kaleoInstanceToken, aiMessage.text(), prompt,
 			executionContext.getServiceContext(), userMessage);
-
-		QuotaUtil.updateUsage(
-			chatResponse, _quotaManager, executionContext.getServiceContext());
 
 		List<KaleoTransition> kaleoTransitions =
 			kaleoNode.getKaleoTransitions();

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
@@ -10,12 +10,8 @@ import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBusUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
-
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.TokenUsage;
 
 import java.io.Serializable;
 
@@ -33,7 +29,10 @@ public class QuotaUtil {
 		throws PortalException {
 
 		try {
-			quotaManager.checkUsage(companyId, text, userId);
+			long preDebitedTokens = quotaManager.checkUsage(
+				companyId, text, userId);
+
+			workflowContext.put("quotaPreDebitedTokens", preDebitedTokens);
 
 			return false;
 		}
@@ -54,22 +53,6 @@ public class QuotaUtil {
 		}
 
 		return true;
-	}
-
-	public static void updateUsage(
-		ChatResponse chatResponse, QuotaManager quotaManager,
-		ServiceContext serviceContext) {
-
-		try {
-			TokenUsage tokenUsage = chatResponse.tokenUsage();
-
-			quotaManager.updateUsage(
-				serviceContext.getCompanyId(), tokenUsage.outputTokenCount(),
-				serviceContext.getUserId());
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
-		}
 	}
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/AIHubQuotaChatModelListenerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/AIHubQuotaChatModelListenerTest.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.model;
+
+import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class AIHubQuotaChatModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testOnErrorRefundsPreDebit() throws Exception {
+		QuotaManager quotaManager = Mockito.mock(QuotaManager.class);
+
+		long preDebitedTokens = 200L;
+
+		AIHubQuotaChatModelListener aiHubQuotaChatModelListener =
+			new AIHubQuotaChatModelListener(
+				_COMPANY_ID, preDebitedTokens, _USER_ID, quotaManager);
+
+		ChatModelErrorContext chatModelErrorContext = Mockito.mock(
+			ChatModelErrorContext.class);
+
+		Mockito.when(
+			chatModelErrorContext.error()
+		).thenReturn(
+			new RuntimeException()
+		);
+
+		aiHubQuotaChatModelListener.onError(chatModelErrorContext);
+
+		Mockito.verify(
+			quotaManager
+		).updateUsage(
+			_COMPANY_ID, 0, 0, preDebitedTokens, _USER_ID
+		);
+	}
+
+	@Test
+	public void testOnErrorWithoutPreDebitDoesNothing() throws Exception {
+		QuotaManager quotaManager = Mockito.mock(QuotaManager.class);
+
+		AIHubQuotaChatModelListener aiHubQuotaChatModelListener =
+			new AIHubQuotaChatModelListener(
+				_COMPANY_ID, 0L, _USER_ID, quotaManager);
+
+		ChatModelErrorContext chatModelErrorContext = Mockito.mock(
+			ChatModelErrorContext.class);
+
+		Mockito.when(
+			chatModelErrorContext.error()
+		).thenReturn(
+			new RuntimeException()
+		);
+
+		aiHubQuotaChatModelListener.onError(chatModelErrorContext);
+
+		Mockito.verifyNoInteractions(quotaManager);
+	}
+
+	@Test
+	public void testOnResponseReconcilesUsage() throws Exception {
+		QuotaManager quotaManager = Mockito.mock(QuotaManager.class);
+
+		long preDebitedTokens = 200L;
+
+		AIHubQuotaChatModelListener aiHubQuotaChatModelListener =
+			new AIHubQuotaChatModelListener(
+				_COMPANY_ID, preDebitedTokens, _USER_ID, quotaManager);
+
+		TokenUsage tokenUsage = Mockito.mock(TokenUsage.class);
+
+		Mockito.when(
+			tokenUsage.inputTokenCount()
+		).thenReturn(
+			180
+		);
+
+		Mockito.when(
+			tokenUsage.totalTokenCount()
+		).thenReturn(
+			320
+		);
+
+		ChatResponse chatResponse = Mockito.mock(ChatResponse.class);
+
+		Mockito.when(
+			chatResponse.tokenUsage()
+		).thenReturn(
+			tokenUsage
+		);
+
+		ChatModelResponseContext chatModelResponseContext = Mockito.mock(
+			ChatModelResponseContext.class);
+
+		Mockito.when(
+			chatModelResponseContext.chatResponse()
+		).thenReturn(
+			chatResponse
+		);
+
+		aiHubQuotaChatModelListener.onResponse(chatModelResponseContext);
+
+		Mockito.verify(
+			quotaManager
+		).updateUsage(
+			_COMPANY_ID, 180, 140, preDebitedTokens, _USER_ID
+		);
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -1021,6 +1021,10 @@ public class AgentInstanceResourceTest
 			).put(
 				"limit", 100
 			).put(
+				"lrtLimit", 64L
+			).put(
+				"lrtUsage", 0L
+			).put(
 				"r_accountToAIHubQuotas_accountEntryId",
 				_accountEntry.getAccountEntryId()
 			).put(


### PR DESCRIPTION
## What

Public AI Hub side of the token pre-debit and Liferay token (LRT) accounting flow. This is the counterpart to the AI Hub Pricing change in `liferay-portal-ee` (PR liferay-ai-hub/liferay-portal-ee#4).

- `QuotaManager.checkUsage` now returns the number of pre-debited input tokens, and `updateUsage` takes the raw input and output token counts plus the pre-debited amount so the quota implementation can reconcile both the token and LRT usage.
- A new `AIHubQuotaChatModelListener`, attached to the Vertex AI chat models, reconciles the pre-debit on response and refunds it on error, replacing the explicit post-response `updateUsage` calls in the node executors.
- `DummyQuotaManagerImpl` (the fallback used when AI Hub Pricing is not deployed) is updated to the new signatures.

## Notes

- Requires the matching `liferay-portal-ee` change (`AIHubPricingQuotaManagerImpl`) to perform the actual LRT conversion and accounting; without it the `DummyQuotaManager` no-ops.
- The `AgentInstanceResourceTest` exhausted-quota integration test now seeds `lrtLimit`/`lrtUsage`; its numeric expectations should be validated against a configured Vertex bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)