### PR TITLE
LPD-93069 Track quota usage per source via listener

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
@@ -18,7 +18,8 @@ public interface QuotaManager {
 	public void checkUsage(long companyId, String text, long userId)
 		throws PortalException;
 
-	public void updateUsage(long companyId, long tokensCount, long userId)
+	public void updateUsage(
+			long companyId, Source source, long tokensCount, long userId)
 		throws PortalException;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/Source.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/Source.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.quota;
+
+/**
+ * @author Carolina Barbosa
+ */
+public enum Source {
+
+	EMBEDDING, MODEL_ARMOR, VERTEX_INPUT, VERTEX_OUTPUT
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -74,7 +74,8 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 					try (VertexAiGeminiChatModel vertexAiGeminiChatModel =
 							VertexAiGeminiUtil.createVertexAiGeminiChatModel(
-								agentContext.getCompanyId())) {
+								_quotaManager,
+								agentContext.getServiceContext())) {
 
 						PermissionThreadLocal.setPermissionChecker(
 							permissionChecker);

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -6,14 +6,18 @@
 package com.liferay.ai.hub.internal.model;
 
 import com.liferay.ai.hub.configuration.VertexAIConfiguration;
+import com.liferay.ai.hub.internal.model.chat.listener.AIHubChatModelListener;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.service.ServiceContext;
 
 import dev.langchain4j.model.vertexai.gemini.HarmCategory;
 import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,12 +27,12 @@ import java.util.Objects;
 public class VertexAiGeminiUtil {
 
 	public static VertexAiGeminiChatModel createVertexAiGeminiChatModel(
-			long companyId)
+			QuotaManager quotaManager, ServiceContext serviceContext)
 		throws ConfigurationException {
 
 		VertexAIConfiguration vertexAIConfiguration =
 			ConfigurationProviderUtil.getCompanyConfiguration(
-				VertexAIConfiguration.class, companyId);
+				VertexAIConfiguration.class, serviceContext.getCompanyId());
 
 		VertexAiGeminiChatModel.VertexAiGeminiChatModelBuilder builder =
 			VertexAiGeminiChatModel.builder();
@@ -37,7 +41,10 @@ public class VertexAiGeminiUtil {
 			builder.apiEndpoint("aiplatform.googleapis.com");
 		}
 
-		return builder.location(
+		return builder.listeners(
+			Collections.singletonList(
+				new AIHubChatModelListener(quotaManager, serviceContext))
+		).location(
 			vertexAIConfiguration.location()
 		).modelName(
 			vertexAIConfiguration.modelName()
@@ -49,12 +56,13 @@ public class VertexAiGeminiUtil {
 	}
 
 	public static VertexAiGeminiStreamingChatModel
-			createVertexAiGeminiStreamingChatModel(long companyId)
+			createVertexAiGeminiStreamingChatModel(
+				QuotaManager quotaManager, ServiceContext serviceContext)
 		throws ConfigurationException {
 
 		VertexAIConfiguration vertexAIConfiguration =
 			ConfigurationProviderUtil.getCompanyConfiguration(
-				VertexAIConfiguration.class, companyId);
+				VertexAIConfiguration.class, serviceContext.getCompanyId());
 
 		VertexAiGeminiStreamingChatModel.VertexAiGeminiStreamingChatModelBuilder
 			builder = VertexAiGeminiStreamingChatModel.builder();
@@ -63,7 +71,10 @@ public class VertexAiGeminiUtil {
 			builder.apiEndpoint("aiplatform.googleapis.com");
 		}
 
-		return builder.location(
+		return builder.listeners(
+			Collections.singletonList(
+				new AIHubChatModelListener(quotaManager, serviceContext))
+		).location(
 			vertexAIConfiguration.location()
 		).modelName(
 			vertexAIConfiguration.modelName()

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/chat/listener/AIHubChatModelListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/chat/listener/AIHubChatModelListener.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.model.chat.listener;
+
+import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.ai.hub.quota.Source;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class AIHubChatModelListener implements ChatModelListener {
+
+	public AIHubChatModelListener(
+		QuotaManager quotaManager, ServiceContext serviceContext) {
+
+		_quotaManager = quotaManager;
+
+		_companyId = serviceContext.getCompanyId();
+		_userId = serviceContext.getUserId();
+	}
+
+	@Override
+	public void onResponse(ChatModelResponseContext chatModelResponseContext) {
+		ChatResponse chatResponse = chatModelResponseContext.chatResponse();
+
+		if (chatResponse == null) {
+			return;
+		}
+
+		TokenUsage tokenUsage = chatResponse.tokenUsage();
+
+		if (tokenUsage == null) {
+			return;
+		}
+
+		try {
+			_quotaManager.updateUsage(
+				_companyId, Source.VERTEX_INPUT,
+				GetterUtil.getInteger(tokenUsage.inputTokenCount()), _userId);
+			_quotaManager.updateUsage(
+				_companyId, Source.VERTEX_OUTPUT,
+				GetterUtil.getInteger(tokenUsage.outputTokenCount()), _userId);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AIHubChatModelListener.class);
+
+	private final long _companyId;
+	private final QuotaManager _quotaManager;
+	private final long _userId;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.ai.hub.internal.quota;
 
 import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.ai.hub.quota.Source;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -26,7 +27,8 @@ public class DummyQuotaManagerImpl implements QuotaManager {
 	}
 
 	@Override
-	public void updateUsage(long companyId, long tokensCount, long userId) {
+	public void updateUsage(
+		long companyId, Source source, long tokensCount, long userId) {
 	}
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -184,7 +184,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				serviceContext.getCompanyId());
+				_quotaManager, serviceContext);
 
 		String sseEventSinkKey = GetterUtil.getString(
 			workflowContext.get("sseEventSinkKey"));
@@ -221,9 +221,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 						GetterUtil.getString(workflowContext.get("reason")),
 						prompt, executionContext.getServiceContext(),
 						userMessage);
-
-					QuotaUtil.updateUsage(
-						response, _quotaManager, serviceContext);
 				}
 			).onErrorConsumer(
 				throwable -> {

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -129,7 +129,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				serviceContext.getCompanyId());
+				_quotaManager, serviceContext);
 
 		AtomicReference<ChatResponse> chatResponseAtomicReference =
 			new AtomicReference<>();
@@ -277,9 +277,6 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 		KaleoLogUtil.addNodeUsageKaleoLog(
 			chatResponse, kaleoInstanceToken, aiMessage.text(), prompt,
 			executionContext.getServiceContext(), userMessage);
-
-		QuotaUtil.updateUsage(
-			chatResponse, _quotaManager, executionContext.getServiceContext());
 
 		List<KaleoTransition> kaleoTransitions =
 			kaleoNode.getKaleoTransitions();

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
@@ -10,12 +10,8 @@ import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBusUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
-
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.TokenUsage;
 
 import java.io.Serializable;
 
@@ -54,22 +50,6 @@ public class QuotaUtil {
 		}
 
 		return true;
-	}
-
-	public static void updateUsage(
-		ChatResponse chatResponse, QuotaManager quotaManager,
-		ServiceContext serviceContext) {
-
-		try {
-			TokenUsage tokenUsage = chatResponse.tokenUsage();
-
-			quotaManager.updateUsage(
-				serviceContext.getCompanyId(), tokenUsage.outputTokenCount(),
-				serviceContext.getUserId());
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
-		}
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93069

## What Is Being Fixed

Quota usage was tracked as a single token count per chat completion, with no distinction between input tokens, output tokens, embeddings, or Model Armor usage. The count was recorded by an explicit `QuotaUtil.updateUsage` call invoked after each LLM/decision workflow node completed, which left no hook for failure paths.

## How It Is Being Fixed

A new `Source` enum (`EMBEDDING`, `MODEL_ARMOR`, `VERTEX_INPUT`, `VERTEX_OUTPUT`) is added to `com.liferay.ai.hub.quota`, and `QuotaManager.updateUsage` now takes that source so every record carries its origin. A new `AIHubChatModelListener` is attached to the Vertex Gemini chat models inside `VertexAiGeminiUtil`; it records `VERTEX_INPUT` and `VERTEX_OUTPUT` separately on every chat response. The post-call `QuotaUtil.updateUsage` helper and its workflow-node callers are removed since the listener fires on every response.
