### PR TITLE
LPD-93651 Remove liferayDXPURL from provisioning endpoint

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/ProvisioningRequest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/ProvisioningRequest.java
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 @Generated("")
 @GraphQLName("ProvisioningRequest")
 @io.swagger.v3.oas.annotations.media.Schema(
-	requiredProperties = {"accountEntryName", "liferayDXPURL", "userAccounts"}
+	requiredProperties = {"accountEntryName", "userAccounts"}
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "ProvisioningRequest")
@@ -184,48 +184,6 @@ public class ProvisioningRequest implements Serializable {
 	private Supplier<String> _accountEntryNameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
-	public String getLiferayDXPURL() {
-		if (_liferayDXPURLSupplier != null) {
-			liferayDXPURL = _liferayDXPURLSupplier.get();
-
-			_liferayDXPURLSupplier = null;
-		}
-
-		return liferayDXPURL;
-	}
-
-	public void setLiferayDXPURL(String liferayDXPURL) {
-		this.liferayDXPURL = liferayDXPURL;
-
-		_liferayDXPURLSupplier = null;
-	}
-
-	@JsonIgnore
-	public void setLiferayDXPURL(
-		UnsafeSupplier<String, Exception> liferayDXPURLUnsafeSupplier) {
-
-		_liferayDXPURLSupplier = () -> {
-			try {
-				return liferayDXPURLUnsafeSupplier.get();
-			}
-			catch (RuntimeException runtimeException) {
-				throw runtimeException;
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		};
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	@NotEmpty
-	protected String liferayDXPURL;
-
-	@JsonIgnore
-	private Supplier<String> _liferayDXPURLSupplier;
-
-	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public UserAccount[] getUserAccounts() {
 		if (_userAccountsSupplier != null) {
@@ -336,22 +294,6 @@ public class ProvisioningRequest implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(accountEntryName));
-
-			sb.append("\"");
-		}
-
-		String liferayDXPURL = getLiferayDXPURL();
-
-		if (liferayDXPURL != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"liferayDXPURL\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(liferayDXPURL));
 
 			sb.append("\"");
 		}
@@ -479,4 +421,4 @@ public class ProvisioningRequest implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1760398742
+// LIFERAY-REST-BUILDER-HASH:958440568

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/ProvisioningRequest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/ProvisioningRequest.java
@@ -93,27 +93,6 @@ public class ProvisioningRequest implements Cloneable, Serializable {
 
 	protected String accountEntryName;
 
-	public String getLiferayDXPURL() {
-		return liferayDXPURL;
-	}
-
-	public void setLiferayDXPURL(String liferayDXPURL) {
-		this.liferayDXPURL = liferayDXPURL;
-	}
-
-	public void setLiferayDXPURL(
-		UnsafeSupplier<String, Exception> liferayDXPURLUnsafeSupplier) {
-
-		try {
-			liferayDXPURL = liferayDXPURLUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected String liferayDXPURL;
-
 	public UserAccount[] getUserAccounts() {
 		return userAccounts;
 	}
@@ -167,4 +146,4 @@ public class ProvisioningRequest implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:626501838
+// LIFERAY-REST-BUILDER-HASH:1830339160

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ProvisioningRequestSerDes.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ProvisioningRequestSerDes.java
@@ -90,20 +90,6 @@ public class ProvisioningRequestSerDes {
 			sb.append("\"");
 		}
 
-		if (provisioningRequest.getLiferayDXPURL() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"liferayDXPURL\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(provisioningRequest.getLiferayDXPURL()));
-
-			sb.append("\"");
-		}
-
 		if (provisioningRequest.getUserAccounts() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -179,15 +165,6 @@ public class ProvisioningRequestSerDes {
 				String.valueOf(provisioningRequest.getAccountEntryName()));
 		}
 
-		if (provisioningRequest.getLiferayDXPURL() == null) {
-			map.put("liferayDXPURL", null);
-		}
-		else {
-			map.put(
-				"liferayDXPURL",
-				String.valueOf(provisioningRequest.getLiferayDXPURL()));
-		}
-
 		if (provisioningRequest.getUserAccounts() == null) {
 			map.put("userAccounts", null);
 		}
@@ -226,9 +203,6 @@ public class ProvisioningRequestSerDes {
 			else if (Objects.equals(jsonParserFieldName, "accountEntryName")) {
 				return false;
 			}
-			else if (Objects.equals(jsonParserFieldName, "liferayDXPURL")) {
-				return false;
-			}
 			else if (Objects.equals(jsonParserFieldName, "userAccounts")) {
 				return false;
 			}
@@ -258,12 +232,6 @@ public class ProvisioningRequestSerDes {
 			else if (Objects.equals(jsonParserFieldName, "accountEntryName")) {
 				if (jsonParserFieldValue != null) {
 					provisioningRequest.setAccountEntryName(
-						(String)jsonParserFieldValue);
-				}
-			}
-			else if (Objects.equals(jsonParserFieldName, "liferayDXPURL")) {
-				if (jsonParserFieldValue != null) {
-					provisioningRequest.setLiferayDXPURL(
 						(String)jsonParserFieldValue);
 				}
 			}
@@ -364,4 +332,4 @@ public class ProvisioningRequestSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:371244096
+// LIFERAY-REST-BUILDER-HASH:1878769754

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -189,15 +189,12 @@ components:
                     type: integer
                 accountEntryName:
                     type: string
-                liferayDXPURL:
-                    type: string
                 userAccounts:
                     items:
                         $ref: "#/components/schemas/UserAccount"
                     type: array
             required:
                 -   accountEntryName
-                -   liferayDXPURL
                 -   userAccounts
             type: object
         Site:

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
@@ -95,7 +95,6 @@ public class ProvisioningRequestManagerImpl
 					customerAccountEntry::getExternalReferenceCode);
 				setAccountEntryId(customerAccountEntry::getAccountEntryId);
 				setAccountEntryName(customerAccountEntry::getName);
-				setLiferayDXPURL(provisioningRequest::getLiferayDXPURL);
 				setUserAccounts(
 					() -> TransformUtil.transformToArray(
 						users, user -> _toUserAccount(user),
@@ -149,8 +148,8 @@ public class ProvisioningRequestManagerImpl
 			user.getUserId(), OAuth2SecureRandomGenerator.generateClientId(),
 			ClientProfile.HEADLESS_SERVER.id(),
 			OAuth2SecureRandomGenerator.generateClientSecret(), null, List.of(),
-			provisioningRequest.getLiferayDXPURL(), 0, null,
-			provisioningRequest.getAccountEntryName(), null, null, false,
+			null, 0, null, provisioningRequest.getAccountEntryName(), null,
+			null, false,
 			Arrays.asList(
 				"Liferay.AI.Hub.REST.everything",
 				"Liferay.AI.Hub.REST.everything.read",

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseProvisioningRequestResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseProvisioningRequestResourceImpl.java
@@ -45,7 +45,7 @@ public abstract class BaseProvisioningRequestResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/provisioning' -d $'{"accountEntryExternalReferenceCode": ___, "accountEntryName": ___, "liferayDXPURL": ___, "userAccounts": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/provisioning' -d $'{"accountEntryExternalReferenceCode": ___, "accountEntryName": ___, "userAccounts": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -511,4 +511,4 @@ public abstract class BaseProvisioningRequestResourceImpl
 		LogFactoryUtil.getLog(BaseProvisioningRequestResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:978919054
+// LIFERAY-REST-BUILDER-HASH:375836036

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseProvisioningRequestResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseProvisioningRequestResourceTestCase.java
@@ -170,7 +170,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 
 		provisioningRequest.setAccountEntryExternalReferenceCode(regex);
 		provisioningRequest.setAccountEntryName(regex);
-		provisioningRequest.setLiferayDXPURL(regex);
 
 		String json = ProvisioningRequestSerDes.toJSON(provisioningRequest);
 
@@ -181,7 +180,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 		Assert.assertEquals(
 			regex, provisioningRequest.getAccountEntryExternalReferenceCode());
 		Assert.assertEquals(regex, provisioningRequest.getAccountEntryName());
-		Assert.assertEquals(regex, provisioningRequest.getLiferayDXPURL());
 	}
 
 	@Test
@@ -316,14 +314,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 
 			if (Objects.equals("accountEntryName", additionalAssertFieldName)) {
 				if (provisioningRequest.getAccountEntryName() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("liferayDXPURL", additionalAssertFieldName)) {
-				if (provisioningRequest.getLiferayDXPURL() == null) {
 					valid = false;
 				}
 
@@ -490,17 +480,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 				if (!Objects.deepEquals(
 						provisioningRequest1.getAccountEntryName(),
 						provisioningRequest2.getAccountEntryName())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("liferayDXPURL", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						provisioningRequest1.getLiferayDXPURL(),
-						provisioningRequest2.getLiferayDXPURL())) {
 
 					return false;
 				}
@@ -725,52 +704,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 			return sb.toString();
 		}
 
-		if (entityFieldName.equals("liferayDXPURL")) {
-			Object object = provisioningRequest.getLiferayDXPURL();
-
-			String value = String.valueOf(object);
-
-			if (operator.equals("contains")) {
-				sb = new StringBundler();
-
-				sb.append("contains(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 2)) {
-					sb.append(value.substring(1, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else if (operator.equals("startswith")) {
-				sb = new StringBundler();
-
-				sb.append("startswith(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 1)) {
-					sb.append(value.substring(0, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else {
-				sb.append("'");
-				sb.append(value);
-				sb.append("'");
-			}
-
-			return sb.toString();
-		}
-
 		if (entityFieldName.equals("userAccounts")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -827,8 +760,6 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 					RandomTestUtil.randomString());
 				accountEntryId = RandomTestUtil.randomLong();
 				accountEntryName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				liferayDXPURL = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 			}
 		};
@@ -1059,4 +990,4 @@ public abstract class BaseProvisioningRequestResourceTestCase {
 		_provisioningRequestResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-817635622
+// LIFERAY-REST-BUILDER-HASH:-654804364

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ProvisioningRequestResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ProvisioningRequestResourceTest.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -148,8 +147,7 @@ public class ProvisioningRequestResourceTest
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"accountEntryExternalReferenceCode", "accountEntryName",
-			"liferayDXPURL"
+			"accountEntryExternalReferenceCode", "accountEntryName"
 		};
 	}
 
@@ -160,8 +158,6 @@ public class ProvisioningRequestResourceTest
 		ProvisioningRequest provisioningRequest =
 			super.randomProvisioningRequest();
 
-		provisioningRequest.setLiferayDXPURL(
-			"http://localhost:" + PortalUtil.getPortalServerPort(false));
 		provisioningRequest.setUserAccounts(userAccounts);
 
 		return provisioningRequest;
@@ -281,9 +277,6 @@ public class ProvisioningRequestResourceTest
 		Assert.assertEquals(
 			Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 			oAuth2Application.getAllowedGrantTypesList());
-		Assert.assertEquals(
-			provisioningRequest.getLiferayDXPURL(),
-			oAuth2Application.getHomePageURL());
 		Assert.assertEquals(
 			provisioningRequest.getAccountEntryName(),
 			oAuth2Application.getName());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93651

## What Is Being Fixed

The provisioning endpoint's `ProvisioningRequest` DTO exposed a `liferayDXPURL` field that was being forwarded to the OAuth2 application's home page URL. This property is no longer needed and should be removed from the API contract.

## How It Is Being Fixed

The `liferayDXPURL` property is removed from `rest-openapi.yaml`, which regenerates the DTO, client, SerDes, and base resource classes via `buildREST`. In `ProvisioningRequestManagerImpl`, the OAuth2 application is now created with `null` as the home page URL instead of the value from the request. The integration test is updated to drop the field from the assert fields list and from the random provisioning request builder.

## PR Check

**pr-check: FAIL** — tested on `993d44f9589dcabdb43baff34ba098bc9ed6336f`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | FAIL (`Log4jConfigUtilTest` — pre-existing on `master`, unrelated to ai-hub changes) |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "failure", "sha": "993d44f9589dcabdb43baff34ba098bc9ed6336f"} -->