### PR TITLE
LPD-93674 Fix undefined chatbot avatar after companyLogo field rename

### DIFF
--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/AssistantMessage.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/AssistantMessage.tsx
@@ -10,13 +10,13 @@ import ChatbotAvatar from './ChatbotAvatar';
 import {StarsIcon} from './Icons';
 
 interface AssistantMessageProps {
-	companyLogo?: string;
+	avatar?: string;
 	text: string;
 	title: string;
 }
 
 export default function AssistantMessage({
-	companyLogo,
+	avatar,
 	text,
 	title,
 }: AssistantMessageProps) {
@@ -24,8 +24,8 @@ export default function AssistantMessage({
 		<div className="aihub-msg-assistant">
 			<div className="aihub-msg-assistant-icon">
 				<ChatbotAvatar
+					avatar={avatar}
 					className="aihub-msg-assistant-company-logo"
-					companyLogo={companyLogo}
 					fallback={<StarsIcon />}
 					title={title}
 				/>

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotAvatar.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotAvatar.tsx
@@ -6,22 +6,22 @@
 import React from 'react';
 
 interface ChatbotAvatarProps {
+	avatar?: string;
 	className?: string;
-	companyLogo?: string;
 	fallback: React.ReactNode;
 	title: string;
 }
 
 export default function ChatbotAvatar({
+	avatar,
 	className,
-	companyLogo,
 	fallback,
 	title,
 }: ChatbotAvatarProps) {
-	if (companyLogo) {
+	if (avatar) {
 		return (
 			<div className={className}>
-				<img alt={title} src={companyLogo} />
+				<img alt={title} src={avatar} />
 			</div>
 		);
 	}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotHeader.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotHeader.tsx
@@ -10,21 +10,21 @@ import {CloseIcon} from './Icons';
 import Logo from './Logo';
 
 interface ChatbotHeaderProps {
-	companyLogo?: string;
+	avatar?: string;
 	onClose: () => void;
 	title: string;
 }
 
 export default function ChatbotHeader({
-	companyLogo,
+	avatar,
 	onClose,
 	title,
 }: ChatbotHeaderProps) {
 	return (
 		<div className="aihub-header">
 			<ChatbotAvatar
+				avatar={avatar}
 				className="aihub-header-logo"
-				companyLogo={companyLogo}
 				fallback={<Logo className="aihub-header-logo" />}
 				title={title}
 			/>

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotIntro.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotIntro.tsx
@@ -9,21 +9,21 @@ import ChatbotAvatar from './ChatbotAvatar';
 import Logo from './Logo';
 
 interface ChatbotIntroProps {
-	companyLogo?: string;
+	avatar?: string;
 	introMessage: string;
 	title: string;
 }
 
 export default function ChatbotIntro({
-	companyLogo,
+	avatar,
 	introMessage,
 	title,
 }: ChatbotIntroProps) {
 	return (
 		<div className="aihub-intro">
 			<ChatbotAvatar
+				avatar={avatar}
 				className="aihub-intro-logo"
-				companyLogo={companyLogo}
 				fallback={<Logo className="aihub-intro-logo" />}
 				title={title}
 			/>

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
@@ -232,7 +232,7 @@ export default function ChatbotWidget({
 		return null;
 	}
 
-	const companyLogoURL = chatbotConfiguration.companyLogo?.fileURL;
+	const avatarURL = chatbotConfiguration.avatar?.fileURL;
 
 	return (
 		<>
@@ -242,14 +242,14 @@ export default function ChatbotWidget({
 				tabIndex={-1}
 			>
 				<ChatbotHeader
-					companyLogo={companyLogoURL}
+					avatar={avatarURL}
 					onClose={handleToggle}
 					title={localized.title}
 				/>
 
 				<div aria-live="polite" className="aihub-messages">
 					<ChatbotIntro
-						companyLogo={companyLogoURL}
+						avatar={avatarURL}
 						introMessage={localized.introMessage}
 						title={localized.title}
 					/>
@@ -258,7 +258,7 @@ export default function ChatbotWidget({
 						if (msg.sender === 'assistant') {
 							return (
 								<AssistantMessage
-									companyLogo={companyLogoURL}
+									avatar={avatarURL}
 									key={index}
 									text={msg.text}
 									title={localized.title}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/types.ts
@@ -12,7 +12,7 @@ export interface AuthorizationToken {
 
 export interface ChatbotConfiguration {
 	active: boolean;
-	companyLogo?: {
+	avatar?: {
 		fileURL: string;
 	};
 	defaultLanguageId: string;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93674

## What Is Being Fixed

The AI Hub chatbot avatar configured in the chatbot form was never displayed in the embedded chatbot widget. The chatbot object definition and form field had been renamed from `companyLogo` to `avatar`, but the `liferay-aihub-custom-element` client extension still read the old `companyLogo` property from the chatbot configuration REST response, so the resolved avatar URL was always `undefined` and the widget fell back to the default logo/icon in the header, intro, and assistant message icons.

## How It Is Being Fixed

The client extension is updated to read the renamed `avatar` field. `ChatbotConfiguration.companyLogo` becomes `avatar` in `types.ts`, and `ChatbotWidget` resolves the avatar URL from `chatbotConfiguration.avatar?.fileURL`. The `companyLogo` prop threaded through `ChatbotHeader`, `ChatbotIntro`, `AssistantMessage`, and `ChatbotAvatar` is renamed to `avatar` to keep the naming consistent with the backend field.

## Why Are There No Tests?

The change is a one-to-one identifier rename to match the renamed backend field, verified by `tsc --noEmit` and the workspace build. The affected components are presentational and the custom-element client extension has no unit-test harness wired for them.

## PR Check

**pr-check: PASS** — tested on `88f4ea3543f5e448ee02abf2887602c2f8986ea0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "88f4ea3543f5e448ee02abf2887602c2f8986ea0"} -->