### PR TITLE
LPD-93664 Add VIEW permission to AI Hub pages for all site members

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/02_agent-builder/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/02_agent-builder/page.json
@@ -34,6 +34,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/03_agent/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/03_agent/page.json
@@ -34,6 +34,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/04_workflow_definition/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/04_workflow_definition/page.json
@@ -27,6 +27,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/05_content-retriever/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/05_content-retriever/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/06_instruction/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/06_instruction/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/07_chatbots/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/07_chatbots/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/08_chatbot/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/08_chatbot/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/10_account-management/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/10_account-management/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/11_configuration/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/11_configuration/page.json
@@ -20,6 +20,7 @@
 		},
 		{
 			"actionIds": [
+				"VIEW"
 			],
 			"roleName": "Site Member",
 			"scope": 4


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93664

## What Is Being Fixed

Site members of the AI Hub site had no VIEW permission on any of the site's pages. The site initializer explicitly listed the `Site Member` role with an empty `actionIds` array for pages 02–11, meaning authenticated members without a specific AI Hub role (Administrator, Agent Administrator, etc.) received a 403 error when trying to access any page.

## How It Is Being Fixed

The `Site Member` role's `actionIds` in each of the 10 affected `page.json` files now includes `"VIEW"`, allowing any authenticated site member to navigate all AI Hub pages. Object-level resource permissions are unchanged — data-layer access control (who can create, update, or delete objects) is unaffected.

## PR Check

**pr-check: FAIL** — tested on `6a02a3af6c6b9787f60ca46a9ba5eee44262dbd9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | FAIL |

`Log4jConfigUtilTest` fails with the same result on `master` without these changes — the failure is pre-existing and unrelated to the `page.json` edits in this PR.

<!-- pr-check {"result": "failure", "sha": "6a02a3af6c6b9787f60ca46a9ba5eee44262dbd9"} -->