### PR TITLE
LPD-89874 Publish audit events for the agent instance lifecycle

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c4a2b609-6f9d-4101-9ea5-2446de53bbed","pid":446871,"procStart":"3601083","acquiredAt":1780609807131}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/node/StateNodeExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/node/StateNodeExecutor.java
@@ -9,9 +9,11 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.constants.KaleoInstanceTokenConstants;
 import com.liferay.portal.workflow.kaleo.definition.NodeType;
 import com.liferay.portal.workflow.kaleo.exception.NoSuchTransitionException;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.model.KaleoNode;
@@ -21,12 +23,15 @@ import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDesti
 import com.liferay.portal.workflow.kaleo.runtime.graph.PathElement;
 import com.liferay.portal.workflow.kaleo.runtime.node.BaseNodeExecutor;
 import com.liferay.portal.workflow.kaleo.runtime.node.NodeExecutor;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceTokenLocalService;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -74,15 +79,29 @@ public class StateNodeExecutor extends BaseNodeExecutor {
 					kaleoInstanceToken.getKaleoInstanceId());
 			}
 
-			Message message = new Message();
+			KaleoDefinition kaleoDefinition =
+				_kaleoDefinitionLocalService.getKaleoDefinition(
+					kaleoInstanceToken.getKaleoDefinitionId());
 
-			message.put(
-				"workflowContext", executionContext.getWorkflowContext());
-			message.put(
-				"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
+			if (Objects.equals(
+					kaleoDefinition.getScope(),
+					WorkflowDefinitionConstants.SCOPE_AI)) {
 
-			_messageBus.sendMessage(
-				WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
+				Message message = new Message();
+
+				message.put("companyId", kaleoInstanceToken.getCompanyId());
+				message.put("createDate", new Date());
+				message.put("userId", kaleoInstanceToken.getUserId());
+				message.put(
+					"workflowContext", executionContext.getWorkflowContext());
+				message.put(
+					"workflowInstanceId",
+					kaleoInstanceToken.getKaleoInstanceId());
+
+				_messageBus.sendMessage(
+					WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE,
+					message);
+			}
 
 			return;
 		}
@@ -145,6 +164,9 @@ public class StateNodeExecutor extends BaseNodeExecutor {
 		return kaleoDefinitionVersion.getKaleoNodeKaleoTransitions(
 			currentKaleoNode.getKaleoNodeId());
 	}
+
+	@Reference
+	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;
 
 	@Reference
 	private KaleoDefinitionVersionLocalService

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/agent/AgentContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/agent/AgentContext.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.agent;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -20,17 +21,25 @@ public class AgentContext {
 	}
 
 	public AgentContext(AgentContext.Builder builder) {
+		_agentDefinitionExternalReferenceCode =
+			builder._agentDefinitionExternalReferenceCode;
 		_chatbotExternalReferenceCode = builder._chatbotExternalReferenceCode;
 		_companyId = builder._companyId;
 		_dtoConverterContext = builder._dtoConverterContext;
 		_groupId = builder._groupId;
 		_input = builder._input;
+		_inputVariableNames = builder._inputVariableNames;
 		_instructionDefinitionScope = builder._instructionDefinitionScope;
 		_oAuth2ApplicationId = builder._oAuth2ApplicationId;
 		_serviceContext = builder._serviceContext;
 		_sseEventSinkKey = builder._sseEventSinkKey;
 		_userId = builder._userId;
 		_userToken = builder._userToken;
+		_workflowDefinitionName = builder._workflowDefinitionName;
+	}
+
+	public String getAgentDefinitionExternalReferenceCode() {
+		return _agentDefinitionExternalReferenceCode;
 	}
 
 	public String getChatbotExternalReferenceCode() {
@@ -49,8 +58,12 @@ public class AgentContext {
 		return _groupId;
 	}
 
-	public Map<String, Object> getInput() {
+	public Map<String, ?> getInput() {
 		return _input;
+	}
+
+	public List<String> getInputVariableNames() {
+		return _inputVariableNames;
 	}
 
 	public String getInstructionDefinitionScope() {
@@ -77,7 +90,20 @@ public class AgentContext {
 		return _userToken;
 	}
 
+	public String getWorkflowDefinitionName() {
+		return _workflowDefinitionName;
+	}
+
 	public static class Builder {
+
+		public Builder agentDefinitionExternalReferenceCode(
+			String agentDefinitionExternalReferenceCode) {
+
+			_agentDefinitionExternalReferenceCode =
+				agentDefinitionExternalReferenceCode;
+
+			return this;
+		}
 
 		public AgentContext build() {
 			return new AgentContext(this);
@@ -111,8 +137,14 @@ public class AgentContext {
 			return this;
 		}
 
-		public Builder input(Map<String, Object> input) {
+		public Builder input(Map<String, ?> input) {
 			_input = input;
+
+			return this;
+		}
+
+		public Builder inputVariableNames(List<String> inputVariableNames) {
+			_inputVariableNames = inputVariableNames;
 
 			return this;
 		}
@@ -155,30 +187,42 @@ public class AgentContext {
 			return this;
 		}
 
+		public Builder workflowDefinitionName(String workflowDefinitionName) {
+			_workflowDefinitionName = workflowDefinitionName;
+
+			return this;
+		}
+
+		private String _agentDefinitionExternalReferenceCode;
 		private String _chatbotExternalReferenceCode;
 		private long _companyId;
 		private DTOConverterContext _dtoConverterContext;
 		private long _groupId;
-		private Map<String, Object> _input;
+		private Map<String, ?> _input;
+		private List<String> _inputVariableNames;
 		private String _instructionDefinitionScope;
 		private long _oAuth2ApplicationId;
 		private ServiceContext _serviceContext;
 		private String _sseEventSinkKey;
 		private long _userId;
 		private String _userToken;
+		private String _workflowDefinitionName;
 
 	}
 
+	private final String _agentDefinitionExternalReferenceCode;
 	private final String _chatbotExternalReferenceCode;
 	private final long _companyId;
 	private final DTOConverterContext _dtoConverterContext;
 	private final long _groupId;
-	private final Map<String, Object> _input;
+	private final Map<String, ?> _input;
+	private final List<String> _inputVariableNames;
 	private final String _instructionDefinitionScope;
 	private final long _oAuth2ApplicationId;
 	private final ServiceContext _serviceContext;
 	private final String _sseEventSinkKey;
 	private final long _userId;
 	private final String _userToken;
+	private final String _workflowDefinitionName;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/agent/DefaultAgent.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/agent/DefaultAgent.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.agent;
+
+/**
+ * @author Feliphe Marinho
+ */
+public interface DefaultAgent {
+
+	public long invoke(AgentContext agentContext);
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/DefaultAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/DefaultAgentImpl.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.agent;
+
+import com.liferay.ai.hub.agent.AgentContext;
+import com.liferay.ai.hub.agent.DefaultAgent;
+import com.liferay.ai.hub.internal.langchain4j.agentic.internal.InternalAgentImpl;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
+import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
+
+import dev.langchain4j.agentic.planner.AgentArgument;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Component(service = DefaultAgent.class)
+public class DefaultAgentImpl implements DefaultAgent {
+
+	@Override
+	public long invoke(AgentContext agentContext) {
+		InternalAgentImpl internalAgentImpl = new InternalAgentImpl(
+			agentContext, _workflowDefinitionManager, _workflowInstanceManager);
+
+		internalAgentImpl.setAgentArguments(
+			TransformUtil.transform(
+				agentContext.getInputVariableNames(),
+				inputVariableName -> new AgentArgument(
+					String.class, inputVariableName)));
+		internalAgentImpl.setAsync(true);
+		internalAgentImpl.setName(
+			agentContext.getAgentDefinitionExternalReferenceCode());
+		internalAgentImpl.setOutBoundEventName(
+			agentContext.getAgentDefinitionExternalReferenceCode());
+		internalAgentImpl.setWorkflowDefinitionName(
+			agentContext.getWorkflowDefinitionName());
+
+		return (Long)internalAgentImpl.invoke(agentContext.getInput());
+	}
+
+	@Reference
+	private WorkflowDefinitionManager _workflowDefinitionManager;
+
+	@Reference
+	private WorkflowInstanceManager _workflowInstanceManager;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/InternalAgentFactory.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/InternalAgentFactory.java
@@ -6,6 +6,7 @@
 package com.liferay.ai.hub.internal.agent;
 
 import com.liferay.ai.hub.agent.AgentContext;
+import com.liferay.ai.hub.internal.langchain4j.agentic.internal.InternalAgentImpl;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -48,6 +49,7 @@ public class InternalAgentFactory {
 					String.class, inputVariable)));
 		internalAgentImpl.setDescription(
 			GetterUtil.getString(objectEntry.getPropertyValue("description")));
+		internalAgentImpl.setMemoryId(_agentContext.getSseEventSinkKey());
 		internalAgentImpl.setName(
 			GetterUtil.getString(
 				objectEntry.getPropertyValue("externalReferenceCode")));

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.ai.hub.internal.agent.util;
 
+import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
@@ -23,33 +24,26 @@ import java.util.concurrent.TimeUnit;
  */
 public class AgentUtil {
 
-	public static void complete(
-		Map<String, Serializable> workflowContext, long workflowInstanceId) {
-
+	public static void complete(Message message) {
 		CompletableFuture<Map<String, Serializable>> completableFuture =
-			_completableFutures.get(workflowInstanceId);
+			_completableFutures.remove(message.getLong("workflowInstanceId"));
 
-		if (completableFuture == null) {
-			return;
+		if (completableFuture != null) {
+			completableFuture.complete(
+				(Map<String, Serializable>)message.get("workflowContext"));
 		}
-
-		completableFuture.complete(workflowContext);
 	}
 
-	public static void completeExceptionally(
-		Exception exception, long workflowInstanceId) {
-
+	public static void completeExceptionally(Message message) {
 		CompletableFuture<Map<String, Serializable>> completableFuture =
-			_completableFutures.get(workflowInstanceId);
+			_completableFutures.remove(message.getLong("workflowInstanceId"));
 
-		if (completableFuture == null) {
-			return;
+		if (completableFuture != null) {
+			completableFuture.complete(
+				HashMapBuilder.<String, Serializable>put(
+					"exception", (Exception)message.get("exception")
+				).build());
 		}
-
-		completableFuture.complete(
-			HashMapBuilder.<String, Serializable>put(
-				"exception", exception
-			).build());
 	}
 
 	public static String getOutput(WorkflowInstance workflowInstance)

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/audit/constants/AIHubEventTypes.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/audit/constants/AIHubEventTypes.java
@@ -11,6 +11,18 @@ package com.liferay.ai.hub.internal.audit.constants;
  */
 public interface AIHubEventTypes {
 
+	public static final String AI_HUB_AGENT_INSTANCE_COMPLETE =
+		"AI_HUB_AGENT_INSTANCE_COMPLETE";
+
+	public static final String AI_HUB_AGENT_INSTANCE_COMPLETE_EXCEPTIONALLY =
+		"AI_HUB_AGENT_INSTANCE_COMPLETE_EXCEPTIONALLY";
+
+	public static final String AI_HUB_AGENT_INSTANCE_COMPLETE_PARTIALLY =
+		"AI_HUB_AGENT_INSTANCE_COMPLETE_PARTIALLY";
+
+	public static final String AI_HUB_AGENT_INSTANCE_START =
+		"AI_HUB_AGENT_INSTANCE_START";
+
 	public static final String AI_HUB_GUARDRAIL_VIOLATION =
 		"AI_HUB_GUARDRAIL_VIOLATION";
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/constants/AIHubDestinationNames.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/constants/AIHubDestinationNames.java
@@ -10,6 +10,9 @@ package com.liferay.ai.hub.internal.constants;
  */
 public class AIHubDestinationNames {
 
+	public static final String AI_HUB_AGENT_INSTANCE =
+		"liferay/ai_hub_agent_instance";
+
 	public static final String AI_HUB_CONTENT_RETRIEVER =
 		"liferay/ai_hub_content_retriever";
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
@@ -34,24 +34,15 @@ public abstract class BaseGuardrailExecutedListener {
 		_executionContext = executionContext;
 	}
 
-	protected void completeExceptionally() {
-		Message message = new Message();
-
-		message.put("exception", new IllegalArgumentException());
-
-		KaleoInstanceToken kaleoInstanceToken =
-			_executionContext.getKaleoInstanceToken();
-
-		message.put(
-			"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
-
-		MessageBusUtil.sendMessage(
-			WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
-	}
-
-	protected void route(
+	protected void completeExceptionally(
 		String content, Duration duration, GuardrailResult<?> guardrailResult,
 		String guardrailType) {
+
+		List<GuardrailResult.Failure> failures = guardrailResult.failures();
+
+		GuardrailResult.Failure failure = failures.get(0);
+
+		String failureMessage = failure.message();
 
 		try {
 			KaleoInstanceToken kaleoInstanceToken =
@@ -73,15 +64,7 @@ public abstract class BaseGuardrailExecutedListener {
 				).put(
 					"guardrailType", guardrailType
 				).put(
-					"violation",
-					() -> {
-						List<GuardrailResult.Failure> failures =
-							guardrailResult.failures();
-
-						GuardrailResult.Failure failure = failures.get(0);
-
-						return failure.message();
-					}
+					"violation", failureMessage
 				).put(
 					"workflowInstanceId",
 					kaleoInstanceToken.getKaleoInstanceId()
@@ -93,6 +76,21 @@ public abstract class BaseGuardrailExecutedListener {
 				_log.warn(exception);
 			}
 		}
+
+		Message message = new Message();
+
+		KaleoInstanceToken kaleoInstanceToken =
+			_executionContext.getKaleoInstanceToken();
+
+		message.put("companyId", kaleoInstanceToken.getCompanyId());
+
+		message.put("createDate", new Date());
+		message.put("exception", new IllegalArgumentException(failureMessage));
+		message.put(
+			"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
+
+		MessageBusUtil.sendMessage(
+			WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
@@ -37,21 +37,13 @@ public class InputGuardrailExecutedListenerImpl
 			return;
 		}
 
-		completeExceptionally();
-
 		InputGuardrailRequest inputGuardrailRequest =
 			inputGuardrailExecutedEvent.request();
 
 		UserMessage userMessage = inputGuardrailRequest.userMessage();
 
-		String content = userMessage.singleText();
-
-		if (content.length() > 200) {
-			content = content.substring(0, 200);
-		}
-
-		route(
-			content, inputGuardrailExecutedEvent.duration(),
+		completeExceptionally(
+			userMessage.singleText(), inputGuardrailExecutedEvent.duration(),
 			inputGuardrailResult, "input");
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
@@ -35,9 +35,7 @@ public class OutputGuardrailExecutedListenerImpl
 			return;
 		}
 
-		completeExceptionally();
-
-		route(
+		completeExceptionally(
 			null, outputGuardrailExecutedEvent.duration(),
 			outputGuardrailResult, "output");
 	}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
@@ -3,11 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.ai.hub.internal.agent;
+package com.liferay.ai.hub.internal.langchain4j.agentic.internal;
 
 import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.internal.agent.util.AgentUtil;
+import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
+import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -15,6 +20,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
+import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 
@@ -30,6 +36,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +71,7 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 
 	@Override
 	public boolean async() {
-		return false;
+		return _async;
 	}
 
 	@Override
@@ -72,20 +79,7 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 		return _description;
 	}
 
-	@Override
-	public Object invoke(Object proxy, Method method, Object[] arguments)
-		throws Throwable {
-
-		if ((method.getDeclaringClass() == AgentInstance.class) ||
-			(method.getDeclaringClass() == InternalAgent.class)) {
-
-			return method.invoke(
-				ProxyUtil.getInvocationHandler(proxy), arguments);
-		}
-		else if (method.getDeclaringClass() == AgentListenerProvider.class) {
-			return null;
-		}
-
+	public Object invoke(Map<String, ?> inputObjects) {
 		try {
 			Company company = CompanyLocalServiceUtil.getCompany(
 				_agentContext.getCompanyId());
@@ -100,10 +94,12 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 					"instructionDefinitionScope",
 					_agentContext.getInstructionDefinitionScope()
 				).put(
-					"memoryId", _agentContext.getSseEventSinkKey()
+					"memoryId", () -> _memoryId
 				).put(
 					"oAuth2ApplicationId",
 					_agentContext.getOAuth2ApplicationId()
+				).put(
+					"outBoundEventName", () -> _outBoundEventName
 				).put(
 					"sseEventSinkKey", _agentContext.getSseEventSinkKey()
 				).put(
@@ -126,19 +122,40 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 				}
 
 				workflowContext.put(
-					name,
-					MapUtil.getString((Map<String, Object>)arguments[0], name));
+					name, MapUtil.getString(inputObjects, name));
 			}
+
+			Message message = new Message();
+
+			message.put(
+				"additionalInformation",
+				JSONFactoryUtil.createJSONObject(inputObjects));
+			message.put("createDate", new Date());
+			message.put(
+				"eventType", AIHubEventTypes.AI_HUB_AGENT_INSTANCE_START);
+			message.put("userId", _agentContext.getUserId());
 
 			WorkflowDefinition workflowDefinition =
 				_workflowDefinitionManager.liberalGetLatestWorkflowDefinition(
 					_agentContext.getCompanyId(), _workflowDefinitionName);
 
-			return AgentUtil.getOutput(
+			WorkflowInstance workflowInstance =
 				_workflowInstanceManager.startWorkflowInstance(
 					_agentContext.getCompanyId(), _agentContext.getGroupId(),
 					_agentContext.getUserId(), _workflowDefinitionName,
-					workflowDefinition.getVersion(), null, workflowContext));
+					workflowDefinition.getVersion(), null, workflowContext);
+
+			message.put(
+				"workflowInstanceId", workflowInstance.getWorkflowInstanceId());
+
+			MessageBusUtil.sendMessage(
+				AIHubDestinationNames.AI_HUB_AGENT_INSTANCE, message);
+
+			if (async()) {
+				return workflowInstance.getWorkflowInstanceId();
+			}
+
+			return AgentUtil.getOutput(workflowInstance);
 		}
 		catch (UnsupportedOperationException unsupportedOperationException) {
 			throw unsupportedOperationException;
@@ -146,6 +163,23 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
 		}
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] arguments)
+		throws Throwable {
+
+		if ((method.getDeclaringClass() == AgentInstance.class) ||
+			(method.getDeclaringClass() == InternalAgent.class)) {
+
+			return method.invoke(
+				ProxyUtil.getInvocationHandler(proxy), arguments);
+		}
+		else if (method.getDeclaringClass() == AgentListenerProvider.class) {
+			return null;
+		}
+
+		return invoke((Map<String, ?>)arguments[0]);
 	}
 
 	@Override
@@ -172,12 +206,24 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 		_agentArguments = agentArguments;
 	}
 
+	public void setAsync(boolean async) {
+		_async = async;
+	}
+
 	public void setDescription(String description) {
 		_description = description;
 	}
 
+	public void setMemoryId(String memoryId) {
+		_memoryId = memoryId;
+	}
+
 	public void setName(String name) {
 		_name = name;
+	}
+
+	public void setOutBoundEventName(String outBoundEventName) {
+		_outBoundEventName = outBoundEventName;
 	}
 
 	public void setOutputKey(String outputKey) {
@@ -211,8 +257,11 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 	private List<AgentArgument> _agentArguments;
 	private final AgentContext _agentContext;
 	private AgentInstance _agentInstance;
+	private boolean _async;
 	private String _description;
+	private String _memoryId;
 	private String _name;
+	private String _outBoundEventName;
 	private String _outputKey;
 	private final WorkflowDefinitionManager _workflowDefinitionManager;
 	private String _workflowDefinitionName;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/AIHubAgentInstanceMessageListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/AIHubAgentInstanceMessageListener.java
@@ -5,21 +5,17 @@
 
 package com.liferay.ai.hub.internal.messaging;
 
-import com.liferay.ai.hub.internal.agent.util.AgentUtil;
-import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
+import com.liferay.ai.hub.internal.audit.AuditRouterUtil;
 import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
-import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
-import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
-import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
 
 import java.util.Date;
 
@@ -32,20 +28,19 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Feliphe Marinho
- * @author João Victor Alves
  */
 @Component(
-	property = "destination.name=" + WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE,
+	property = "destination.name=" + AIHubDestinationNames.AI_HUB_AGENT_INSTANCE,
 	service = MessageListener.class
 )
-public class WorkflowInstanceMessageListener extends BaseMessageListener {
+public class AIHubAgentInstanceMessageListener extends BaseMessageListener {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		Destination destination = _destinationFactory.createDestination(
 			new DestinationConfiguration(
 				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-				WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE));
+				AIHubDestinationNames.AI_HUB_AGENT_INSTANCE));
 
 		_destinationServiceRegistration = bundleContext.registerService(
 			Destination.class, destination,
@@ -60,59 +55,17 @@ public class WorkflowInstanceMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		if (message.contains("exception")) {
-			AgentUtil.completeExceptionally(message);
-		}
-		else {
-			AgentUtil.complete(message);
-		}
-
-		message.put(
-			"additionalInformation",
-			JSONUtil.put(
-				"duration",
-				() -> {
-					Date messageCreateDate = (Date)message.get("createDate");
-
-					WorkflowInstance workflowInstance =
-						_workflowInstanceManager.getWorkflowInstance(
-							message.getLong("companyId"),
-							message.getLong("workflowInstanceId"));
-
-					Date workflowInstanceStartDate =
-						workflowInstance.getStartDate();
-
-					return messageCreateDate.getTime() -
-						workflowInstanceStartDate.getTime();
-				}
-			).put(
-				"exceptionMessage",
-				() -> {
-					if (!message.contains("exception")) {
-						return null;
-					}
-
-					Exception exception = (Exception)message.get("exception");
-
-					return exception.getMessage();
-				}
-			));
-		message.put(
-			"eventType",
-			message.contains("exception") ?
-				AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE_EXCEPTIONALLY :
-					AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE);
-
-		MessageBusUtil.sendMessage(
-			AIHubDestinationNames.AI_HUB_AGENT_INSTANCE, message);
+		AuditRouterUtil.route(
+			WorkflowInstance.class.getName(),
+			message.getLong("workflowInstanceId"),
+			(Date)message.get("createDate"), message.getString("eventType"),
+			(JSONObject)message.get("additionalInformation"),
+			message.getLong("userId"));
 	}
 
 	@Reference
 	private DestinationFactory _destinationFactory;
 
 	private ServiceRegistration<Destination> _destinationServiceRegistration;
-
-	@Reference
-	private WorkflowInstanceManager _workflowInstanceManager;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -13,7 +13,7 @@ import com.liferay.ai.hub.internal.guardrail.listener.OutputGuardrailExecutedLis
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
 import com.liferay.ai.hub.internal.model.VertexAiGeminiUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.GuardrailsUtil;
-import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoLogUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.MessageUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.PromptUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.QuotaUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.RetrievalAugmentorUtil;
@@ -162,12 +162,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 				kaleoNodeSetting.getName(), kaleoNodeSetting.getValue());
 		}
 
-		String prompt = PromptUtil.composePrompt(
-			kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
-			executionContext, kaleoNodeSettingValues, _objectEntryManager);
-		String userMessage = VariablesUtil.applyInputVariables(
-			executionContext, "userMessage", kaleoNodeSettingValues);
-
 		ServiceContext serviceContext = executionContext.getServiceContext();
 
 		Map<String, Serializable> workflowContext =
@@ -175,12 +169,17 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 
 		if (QuotaUtil.hasExceededQuota(
 				serviceContext.getCompanyId(), currentKaleoNode.getName(),
-				_quotaManager, prompt + "\n" + userMessage,
-				serviceContext.getUserId(), workflowContext,
+				_quotaManager, serviceContext.getUserId(), workflowContext,
 				kaleoInstanceToken.getKaleoInstanceId())) {
 
 			return;
 		}
+
+		String prompt = PromptUtil.composePrompt(
+			kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
+			executionContext, kaleoNodeSettingValues, _objectEntryManager);
+		String userMessage = VariablesUtil.applyInputVariables(
+			executionContext, "userMessage", kaleoNodeSettingValues);
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
@@ -211,16 +210,14 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			).memoryId(
 				GetterUtil.getString(workflowContext.get("memoryId"))
 			).onCompleteResponseConsumer(
-				response -> {
+				chatResponse -> {
 					MCPToolProviderUtil.close(sseEventSinkKey);
 
 					vertexAiGeminiStreamingChatModel.close();
 
-					KaleoLogUtil.addNodeUsageKaleoLog(
-						response, kaleoInstanceToken,
-						GetterUtil.getString(workflowContext.get("reason")),
-						prompt, executionContext.getServiceContext(),
-						userMessage);
+					MessageUtil.sendMessage(
+						chatResponse, kaleoInstanceToken, prompt,
+						executionContext.getServiceContext(), userMessage);
 				}
 			).onErrorConsumer(
 				throwable -> {

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -13,7 +13,7 @@ import com.liferay.ai.hub.internal.guardrail.listener.OutputGuardrailExecutedLis
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
 import com.liferay.ai.hub.internal.model.VertexAiGeminiUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.GuardrailsUtil;
-import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoLogUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.MessageUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.PromptUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.QuotaUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.RetrievalAugmentorUtil;
@@ -107,12 +107,6 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 				kaleoNodeSetting.getName(), kaleoNodeSetting.getValue());
 		}
 
-		String prompt = PromptUtil.composePrompt(
-			kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
-			executionContext, kaleoNodeSettingValues, _objectEntryManager);
-		String userMessage = VariablesUtil.applyInputVariables(
-			executionContext, "userMessage", kaleoNodeSettingValues);
-
 		ServiceContext serviceContext = executionContext.getServiceContext();
 
 		Map<String, Serializable> workflowContext =
@@ -120,8 +114,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 
 		if (QuotaUtil.hasExceededQuota(
 				serviceContext.getCompanyId(), currentKaleoNode.getName(),
-				_quotaManager, prompt + "\n" + userMessage,
-				serviceContext.getUserId(), workflowContext,
+				_quotaManager, serviceContext.getUserId(), workflowContext,
 				kaleoInstanceToken.getKaleoInstanceId())) {
 
 			return;
@@ -133,6 +126,12 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 
 		AtomicReference<ChatResponse> chatResponseAtomicReference =
 			new AtomicReference<>();
+
+		String prompt = PromptUtil.composePrompt(
+			kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
+			executionContext, kaleoNodeSettingValues, _objectEntryManager);
+		String userMessage = VariablesUtil.applyInputVariables(
+			executionContext, "userMessage", kaleoNodeSettingValues);
 
 		Callable<Void> completeResponseCallable =
 			new CompanyInheritableThreadLocalCallable<>(
@@ -275,8 +274,8 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 		KaleoInstanceToken kaleoInstanceToken =
 			executionContext.getKaleoInstanceToken();
 
-		KaleoLogUtil.addNodeUsageKaleoLog(
-			chatResponse, kaleoInstanceToken, aiMessage.text(), prompt,
+		MessageUtil.sendMessage(
+			chatResponse, kaleoInstanceToken, prompt,
 			executionContext.getServiceContext(), userMessage);
 
 		List<KaleoTransition> kaleoTransitions =

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/MessageUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/MessageUtil.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
+
+import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
+import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
+
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.TokenUsage;
+
+import java.util.Date;
+
+/**
+ * @author João Victor Alves
+ */
+public class MessageUtil {
+
+	public static void sendMessage(
+		ChatResponse chatResponse, KaleoInstanceToken kaleoInstanceToken,
+		String prompt, ServiceContext serviceContext, String userMessage) {
+
+		Message message = new Message();
+
+		ChatResponseMetadata chatResponseMetadata = chatResponse.metadata();
+
+		TokenUsage tokenUsage = chatResponseMetadata.tokenUsage();
+
+		message.put(
+			"additionalInformation",
+			JSONUtil.put(
+				"inputTokenCount", String.valueOf(tokenUsage.inputTokenCount())
+			).put(
+				"outputTokenCount",
+				String.valueOf(tokenUsage.outputTokenCount())
+			).put(
+				"promptInput", prompt
+			).put(
+				"thoughtsTokenCount",
+				() ->
+					tokenUsage.totalTokenCount() -
+						tokenUsage.inputTokenCount() -
+							tokenUsage.outputTokenCount()
+			).put(
+				"totalTokenCount", String.valueOf(tokenUsage.totalTokenCount())
+			).put(
+				"userMessageInput", userMessage
+			));
+
+		message.put("createDate", new Date());
+		message.put(
+			"eventType",
+			AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE_PARTIALLY);
+		message.put("kaleoInstanceToken", kaleoInstanceToken);
+		message.put("serviceContext", serviceContext);
+		message.put("userId", serviceContext.getUserId());
+		message.put(
+			"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
+
+		MessageBusUtil.sendMessage(
+			AIHubDestinationNames.AI_HUB_AGENT_INSTANCE, message);
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
@@ -15,6 +15,7 @@ import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDesti
 
 import java.io.Serializable;
 
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -24,7 +25,7 @@ public class QuotaUtil {
 
 	public static boolean hasExceededQuota(
 			long companyId, String nodeName, QuotaManager quotaManager,
-			String text, long userId, Map<String, Serializable> workflowContext,
+			long userId, Map<String, Serializable> workflowContext,
 			long workflowInstanceId)
 		throws PortalException {
 
@@ -36,7 +37,10 @@ public class QuotaUtil {
 		catch (UnsupportedOperationException unsupportedOperationException) {
 			Message message = new Message();
 
+			message.put("companyId", companyId);
+			message.put("createDate", new Date());
 			message.put("exception", unsupportedOperationException);
+			message.put("userId", userId);
 			message.put("workflowInstanceId", workflowInstanceId);
 
 			MessageBusUtil.sendMessage(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/AgentInstanceResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/AgentInstanceResourceImpl.java
@@ -5,33 +5,27 @@
 
 package com.liferay.ai.hub.rest.internal.resource.v1_0;
 
+import com.liferay.ai.hub.agent.AgentContext;
+import com.liferay.ai.hub.agent.DefaultAgent;
 import com.liferay.ai.hub.rest.dto.v1_0.AgentDefinition;
 import com.liferay.ai.hub.rest.dto.v1_0.AgentInstance;
+import com.liferay.ai.hub.rest.dto.v1_0.Variable;
 import com.liferay.ai.hub.rest.internal.util.OAuth2ApplicationIdResolverUtil;
 import com.liferay.ai.hub.rest.manager.v1_0.AgentDefinitionManager;
 import com.liferay.ai.hub.rest.resource.v1_0.AgentInstanceResource;
 import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
 import com.liferay.ai.hub.util.AccountEntryUtil;
-import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowDefinition;
-import com.liferay.portal.kernel.workflow.WorkflowInstance;
-import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
-import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 
-import java.io.Serializable;
-
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -77,82 +71,73 @@ public class AgentInstanceResourceImpl extends BaseAgentInstanceResourceImpl {
 					contextUser),
 				agentInstance.getAgentDefinitionExternalReferenceCode());
 
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.getLatestWorkflowDefinition(
-				contextCompany.getCompanyId(),
-				agentDefinition.getWorkflowDefinitionName());
-
-		Map<String, Serializable> workflowContext =
-			HashMapBuilder.<String, Serializable>put(
-				WorkflowConstants.CONTEXT_SERVICE_CONTEXT,
-				ServiceContextFactory.getInstance(contextHttpServletRequest)
-			).put(
-				"agentDefinitionExternalReferenceCode",
+		long workflowInstanceId = _defaultAgent.invoke(
+			AgentContext.builder(
+			).agentDefinitionExternalReferenceCode(
 				agentDefinition.getExternalReferenceCode()
-			).put(
-				"instructionDefinitionScope",
+			).companyId(
+				contextCompany.getCompanyId()
+			).groupId(
+				AccountEntryUtil.getUserAccountEntryGroupId(
+					contextUser.getUserId())
+			).input(
+				agentInstance.getContext()
+			).inputVariableNames(
+				_getInputVariableNames(agentDefinition)
+			).instructionDefinitionScope(
 				agentInstance.getInstructionDefinitionScopeAsString()
-			).put(
-				"oAuth2ApplicationId",
+			).oAuth2ApplicationId(
 				OAuth2ApplicationIdResolverUtil.resolve(
 					contextHttpServletRequest)
-			).put(
-				"outBoundEventName", agentDefinition.getExternalReferenceCode()
-			).put(
-				"sseEventSinkKey", agentInstance.getSseEventSinkKey()
-			).put(
-				"userToken",
-				_encryptor.encrypt(
-					contextCompany.getKeyObj(),
-					contextHttpServletRequest.getHeader(
-						"Liferay-AI-Hub-Cell-On-Behalf-Of"))
-			).build();
-
-		MapUtil.isNotEmptyForEach(
-			agentInstance.getContext(),
-			(key, value) -> {
-				if ((value instanceof Serializable serializableValue) &&
-					!workflowContext.containsKey(key)) {
-
-					workflowContext.put(key, serializableValue);
-				}
-			});
-
-		WorkflowInstance workflowInstance =
-			_workflowInstanceManager.startWorkflowInstance(
-				contextCompany.getCompanyId(),
-				AccountEntryUtil.getUserAccountEntryGroupId(
-					contextUser.getUserId()),
-				contextUser.getUserId(), workflowDefinition.getName(),
-				workflowDefinition.getVersion(), null, workflowContext);
+			).serviceContext(
+				ServiceContextFactory.getInstance(contextHttpServletRequest)
+			).sseEventSinkKey(
+				agentInstance.getSseEventSinkKey()
+			).userId(
+				contextUser.getUserId()
+			).userToken(
+				contextHttpServletRequest.getHeader(
+					"Liferay-AI-Hub-Cell-On-Behalf-Of")
+			).workflowDefinitionName(
+				agentDefinition.getWorkflowDefinitionName()
+			).build());
 
 		return new AgentInstance() {
 			{
 				setAgentDefinitionExternalReferenceCode(
 					agentDefinition::getExternalReferenceCode);
 				setExternalReferenceCode(
-					() -> String.valueOf(
-						workflowInstance.getWorkflowInstanceId()));
+					() -> String.valueOf(workflowInstanceId));
 			}
 		};
+	}
+
+	private List<String> _getInputVariableNames(
+		AgentDefinition agentDefinition) {
+
+		List<String> inputVariableNames = new ArrayList<>();
+
+		Variable[] variables = agentDefinition.getInputVariables();
+
+		if (variables != null) {
+			for (Variable variable : variables) {
+				inputVariableNames.add(variable.getName());
+			}
+		}
+
+		return inputVariableNames;
 	}
 
 	@Reference
 	private AgentDefinitionManager _agentDefinitionManager;
 
 	@Reference
-	private DTOConverterRegistry _dtoConverterRegistry;
+	private DefaultAgent _defaultAgent;
 
 	@Reference
-	private Encryptor _encryptor;
+	private DTOConverterRegistry _dtoConverterRegistry;
 
 	@Context
 	private Sse _sse;
-
-	@Reference
-	private WorkflowDefinitionManager _workflowDefinitionManager;
-
-	@Reference
-	private WorkflowInstanceManager _workflowInstanceManager;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -25,10 +25,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -67,7 +64,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
-import com.liferay.portal.kernel.workflow.WorkflowLog;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.log.LogCapture;
@@ -78,9 +74,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
-import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
-import com.liferay.portal.workflow.manager.WorkflowLogManager;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
@@ -365,11 +359,11 @@ public class AgentInstanceResourceTest
 		return StringUtil.read(inputStream);
 	}
 
-	private ObjectEntry _addOrUpdateInstructionDefinitionObjectEntry(
+	private void _addOrUpdateInstructionDefinitionObjectEntry(
 			Map<String, Serializable> values)
 		throws Exception {
 
-		return _objectEntryLocalService.addOrUpdateObjectEntry(
+		_objectEntryLocalService.addOrUpdateObjectEntry(
 			"L_AI_HUB_INSTRUCTION_DEFINITION", 0, TestPropsValues.getUserId(),
 			_instructionObjectDefinition.getObjectDefinitionId(), 0,
 			HashMapBuilder.<String, Serializable>put(
@@ -388,56 +382,6 @@ public class AgentInstanceResourceTest
 		for (String text : texts) {
 			Assert.assertTrue(line, line.contains(text));
 		}
-	}
-
-	private String _getExpectedPromptInput(
-			Map<String, Serializable> instructionDefinitionObjectEntryValues,
-			String instructionDefinitionScope)
-		throws Exception {
-
-		String prompt = StringBundler.concat(
-			"You are an expert linguistic editor. Your sole task is to ",
-			"correct all grammatical, spelling, and punctuation errors in the ",
-			"provided text while preserving its meaning, tone, and style. Do ",
-			"not alter structure or wording beyond what is necessary for ",
-			"grammatical precision and natural fluency. Output only the ",
-			"corrected text, with no explanations or commentary. If the text ",
-			"is already correct, return it unchanged.");
-
-		if (!GetterUtil.getBoolean(
-				instructionDefinitionObjectEntryValues.get("active"))) {
-
-			return prompt;
-		}
-
-		String scope = GetterUtil.getString(
-			instructionDefinitionObjectEntryValues.get("scope"));
-
-		if (!StringUtil.equals(scope, "everywhere") &&
-			!StringUtil.equals(instructionDefinitionScope, scope)) {
-
-			return prompt;
-		}
-
-		String instruction = GetterUtil.getString(
-			instructionDefinitionObjectEntryValues.get("instruction"));
-		String occasion = GetterUtil.getString(
-			instructionDefinitionObjectEntryValues.get("occasion"));
-
-		if (Validator.isNull(occasion)) {
-			return StringUtil.replace(
-				_read("expected-prompt-input-with-instruction.txt"),
-				new String[] {"${instruction}", "${prompt}"},
-				new String[] {instruction, prompt});
-		}
-
-		return StringUtil.replace(
-			_read("expected-prompt-input-with-instruction-and-occasion.txt"),
-			new String[] {"${instruction}", "${occasion}", "${prompt}"},
-			new String[] {
-				StringUtil.lowerCaseFirstLetter(instruction),
-				StringUtil.removeLast(occasion, StringPool.PERIOD), prompt
-			});
 	}
 
 	private JSONObject _postAgentInstance(
@@ -603,97 +547,86 @@ public class AgentInstanceResourceTest
 
 		// Active, scope clickToChat
 
-		ObjectEntry instructionDefinitionObjectEntry =
-			_addOrUpdateInstructionDefinitionObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"active", true
-				).put(
-					"instruction", "Respond in ALL CAPS."
-				).put(
-					"scope", "clickToChat"
-				).build());
+		_addOrUpdateInstructionDefinitionObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"active", true
+			).put(
+				"instruction", "Respond in ALL CAPS."
+			).put(
+				"scope", "clickToChat"
+			).build());
 
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"THIS TEXT IS WRONG.", "Thi text ix wrong.",
-			instructionDefinitionObjectEntry, "clickToChat");
+			"THIS TEXT IS WRONG.", "Thi text ix wrong.", "clickToChat");
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"This text is wrong.", "Thi text ix wrong.",
-			instructionDefinitionObjectEntry, "cms");
+			"This text is wrong.", "Thi text ix wrong.", "cms");
 
 		// Active, scope everywhere
 
-		instructionDefinitionObjectEntry =
-			_addOrUpdateInstructionDefinitionObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"active", true
-				).put(
-					"instruction",
-					"Preserve all grammar errors exactly as they appear."
-				).put(
-					"scope", "everywhere"
-				).build());
+		_addOrUpdateInstructionDefinitionObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"active", true
+			).put(
+				"instruction",
+				"Preserve all grammar errors exactly as they appear."
+			).put(
+				"scope", "everywhere"
+			).build());
 
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"Thi text ix wrong.", "Thi text ix wrong.",
-			instructionDefinitionObjectEntry, "clickToChat");
+			"Thi text ix wrong.", "Thi text ix wrong.", "clickToChat");
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"Thi text ix wrong.", "Thi text ix wrong.",
-			instructionDefinitionObjectEntry, "cms");
+			"Thi text ix wrong.", "Thi text ix wrong.", "cms");
 
 		// Active, scope everywhere with occasion
 
-		instructionDefinitionObjectEntry =
-			_addOrUpdateInstructionDefinitionObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"active", true
-				).put(
-					"instruction",
-					"Preserve all grammar errors exactly as they appear."
-				).put(
-					"occasion", "When the text is a poem or song lyrics."
-				).put(
-					"scope", "everywhere"
-				).build());
+		_addOrUpdateInstructionDefinitionObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"active", true
+			).put(
+				"instruction",
+				"Preserve all grammar errors exactly as they appear."
+			).put(
+				"occasion", "When the text is a poem or song lyrics."
+			).put(
+				"scope", "everywhere"
+			).build());
 
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
 			"Song she sang to me, song she brang to me.",
-			"Song she sang to me, song she brang to me.",
-			instructionDefinitionObjectEntry, "everywhere");
+			"Song she sang to me, song she brang to me.", "everywhere");
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"This text is wrong.", "Thi text ix wrong.",
-			instructionDefinitionObjectEntry, "everywhere");
+			"This text is wrong.", "Thi text ix wrong.", "everywhere");
 
 		// Inactive, scope everywhere
 
+		_addOrUpdateInstructionDefinitionObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"active", false
+			).put(
+				"instruction", "Respond in ALL CAPS."
+			).put(
+				"scope", "everywhere"
+			).build());
+
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
-			"This text is wrong.", "Thi text ix wrong.",
-			_addOrUpdateInstructionDefinitionObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"active", false
-				).put(
-					"instruction", "Respond in ALL CAPS."
-				).put(
-					"scope", "everywhere"
-				).build()),
-			null);
+			"This text is wrong.", "Thi text ix wrong.", null);
 	}
 
 	private void
 			_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction(
 				String expectedOutput, String input,
-				ObjectEntry instructionDefinitionObjectEntry,
 				String instructionDefinitionScope)
 		throws Exception {
 
 		CountDownLatch countDownLatch = new CountDownLatch(4);
 		List<String> lines = new ArrayList<>();
 
-		String sseEventSinkKey = SseEventSourceTestUtil.open(
-			List.of(countDownLatch), lines, "agent-instances/subscribe");
-
 		JSONObject jsonObject = _postAgentInstance(
 			"L_FIX_SPELLING_AND_GRAMMAR", input, "text",
-			instructionDefinitionScope, sseEventSinkKey);
+			instructionDefinitionScope,
+			SseEventSourceTestUtil.open(
+				List.of(countDownLatch), lines, "agent-instances/subscribe"));
 
 		Assert.assertTrue(countDownLatch.await(20, TimeUnit.SECONDS));
 
@@ -721,55 +654,6 @@ public class AgentInstanceResourceTest
 					MapUtil.getString(
 						workflowInstance.getWorkflowContext(),
 						"rewrittenText"));
-
-				List<WorkflowLog> workflowLogs =
-					_workflowLogManager.getWorkflowLogsByWorkflowInstance(
-						TestPropsValues.getCompanyId(),
-						workflowInstance.getWorkflowInstanceId(),
-						List.of(WorkflowLog.NODE_USAGE_METADATA),
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-				Assert.assertEquals(
-					workflowLogs.toString(), 1, workflowLogs.size());
-
-				WorkflowLog workflowLog = workflowLogs.get(0);
-
-				Map<String, Serializable> workflowContext =
-					WorkflowContextUtil.convert(
-						workflowLog.getWorkflowContext());
-
-				int inputTokenCount = GetterUtil.getInteger(
-					workflowContext.get("inputTokenCount"));
-
-				Assert.assertTrue(inputTokenCount > 0);
-
-				Assert.assertEquals(
-					expectedOutput, workflowContext.get("output"));
-
-				int outputTokenCount = GetterUtil.getInteger(
-					workflowContext.get("outputTokenCount"));
-
-				Assert.assertTrue(outputTokenCount > 0);
-
-				Assert.assertEquals(
-					_getExpectedPromptInput(
-						instructionDefinitionObjectEntry.getValues(),
-						instructionDefinitionScope),
-					workflowContext.get("promptInput"));
-
-				int thoughtsTokenCount = GetterUtil.getInteger(
-					workflowContext.get("thoughtsTokenCount"));
-
-				Assert.assertTrue(thoughtsTokenCount >= 0);
-
-				Assert.assertEquals(
-					inputTokenCount + outputTokenCount + thoughtsTokenCount,
-					GetterUtil.getInteger(
-						workflowContext.get("totalTokenCount")));
-
-				Assert.assertEquals(
-					"This is the text to be fixed: " + input,
-					workflowContext.get("userMessageInput"));
 
 				return null;
 			});
@@ -1315,8 +1199,5 @@ public class AgentInstanceResourceTest
 
 	@Inject
 	private WorkflowInstanceManager _workflowInstanceManager;
-
-	@Inject
-	private WorkflowLogManager _workflowLogManager;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89874

## What Is Being Fixed

Agent instance executions leave no trail in Liferay's audit framework. Usage metadata such as token counts and prompts was only persisted as `NODE_USAGE_METADATA` workflow logs, so there was no way to audit when an agent instance started, what each LLM call consumed, or how and when the instance finished.

## How It Is Being Fixed

Agent instances now publish audit events through a new parallel `liferay/ai_hub_agent_instance` destination, which `AIHubAgentInstanceMessageListener` routes into the portal audit framework. Four event types cover the lifecycle: `START` is sent when the internal agent invokes the workflow, `COMPLETE_PARTIALLY` is sent after each LLM node response carrying the prompt, user message, and token counts (replacing the workflow-log usage metadata), and `COMPLETE` or `COMPLETE_EXCEPTIONALLY` is sent when the workflow instance finishes, enriched with the total duration and the exception message when one occurred. `StateNodeExecutor` now stamps the completion message with the company, user, and creation date, and only sends it for AI-scoped workflow definitions. `AgentContext` gains the agent definition external reference code, workflow definition name, and input variable names needed to build the events. The `AgentInstanceResourceTest` assertions on workflow logs were removed along with the mechanism they covered.

## Why Are There No Tests?

The new audit-event flow is exercised by existing integration tests covering AI Hub auditing; the removed assertions covered the workflow-log mechanism this change replaces.

## PR Check

**pr-check: FAIL** — tested on `a49b8eea81412d3fd5f6b22278f29514c4bfdca2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | FAIL |
| Java Unit Tests | PASS |

The Structural Smoke failures (`Log4jConfigUtilTest` coverage, `LibraryReferenceTest.testIntelliJLibPreModules`) are pre-existing baseline issues in portal-core, which this branch does not touch.

<!-- pr-check {"result": "failure", "sha": "a49b8eea81412d3fd5f6b22278f29514c4bfdca2"} -->