### PR TITLE
LPD-92709 When Picklist from AI Hub are created, give them default view permission for the role "User" (individual permission)

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -34,8 +34,12 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -163,6 +167,16 @@ public class AIHubSiteInitializerTest {
 		_assertListTypeDefinitionExists(
 			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS", "high",
 			"lowAndAbove", "mediumAndAbove", "none");
+		_assertListTypeDefinitionUserRoleViewPermission(
+			"L_AI_HUB_CRAWLER_JOB_STATUSES");
+		_assertListTypeDefinitionUserRoleViewPermission(
+			"L_AI_HUB_INSTRUCTION_DEFINITION_SCOPES");
+		_assertListTypeDefinitionUserRoleViewPermission(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_CONFIDENCE_LEVELS");
+		_assertListTypeDefinitionUserRoleViewPermission(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_GUARDRAIL_TYPES");
+		_assertListTypeDefinitionUserRoleViewPermission(
+			"L_AI_HUB_MODEL_ARMOR_TEMPLATE_RESPONSIBLE_AI_LEVELS");
 		_assertNotificationTemplateExists(
 			"L_AI_HUB_ACCOUNT_INVITE_USER_EMAIL_NOTIFICATION_TEMPLATE");
 		_assertObjectDefinitionExists("L_AI_HUB_AGENT_DEFINITION");
@@ -389,6 +403,27 @@ public class AIHubSiteInitializerTest {
 		}
 	}
 
+	private void _assertListTypeDefinitionUserRoleViewPermission(
+			String externalReferenceCode)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition =
+			_listTypeDefinitionLocalService.
+				fetchListTypeDefinitionByExternalReferenceCode(
+					externalReferenceCode, TestPropsValues.getCompanyId());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ListTypeDefinition.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(listTypeDefinition.getListTypeDefinitionId()),
+				role.getRoleId(), ActionKeys.VIEW));
+	}
+
 	private void _assertNotificationTemplateExists(String externalReferenceCode)
 		throws Exception {
 
@@ -556,6 +591,9 @@ public class AIHubSiteInitializerTest {
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
@@ -114,6 +114,51 @@
 	},
 	{
 		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Crawler Job Statuses$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Instruction Definition Scopes$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Confidence Levels$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Guardrail Types$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Responsible AI Levels$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
 			"ADD_OBJECT_ENTRY"
 		],
 		"primKey": "0",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92709

## What Is Being Fixed

When AI Hub provisions its picklists (list type definitions) through the site initializer, only the owner received permissions on them. A regular user holding only the User role could not view the picklists, so fields backed by these picklists did not render their values for those users.

## How It Is Being Fixed

Add an individual-scope view permission for the User role to the AI Hub site initializer's resource-permissions.json, one entry per picklist, keyed by the LIST_TYPE_DEFINITION_ID placeholder the site initializer populates after each definition is created. This grants the User role View on each picklist as it is created, matching the pattern the Commerce site initializer already uses to grant the User role view access to taxonomy categories. An integration test asserts the User role holds the individual-scope view permission on each of the five AI Hub picklists.

## PR Check

**pr-check: PASS** — tested on `a067ea7f52ef5181cf5f793f9d85288807225838`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a067ea7f52ef5181cf5f793f9d85288807225838"} -->