### PR TITLE
LPD-93676 LPD-93696 LPD-93870 Harden the AI Hub chatbot widget

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.ai.hub.cell.rest.internal.security.JWTTokenUtil;
 import com.liferay.ai.hub.cell.rest.internal.web.cache.AIHubCellAccessTokenWebCacheItem;
 import com.liferay.ai.hub.cell.rest.resource.v1_0.AuthorizationTokenResource;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 
@@ -42,6 +43,10 @@ public class AuthorizationTokenResourceImpl
 
 		JSONObject jsonObject = AIHubCellAccessTokenWebCacheItem.get(
 			aiHubCellConfiguration, contextCompany.getCompanyId());
+
+		if (jsonObject == null) {
+			throw new PortalException("Unable to get an access token");
+		}
 
 		return new AuthorizationToken() {
 			{

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
@@ -15,10 +15,16 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webcache.WebCacheItem;
 import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
 import java.net.HttpURLConnection;
+
+import java.util.Date;
 
 /**
  * @author Manuele Castro
@@ -28,13 +34,22 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 	public static JSONObject get(
 		AIHubCellConfiguration aiHubCellConfiguration, long companyId) {
 
+		String key = StringBundler.concat(
+			AIHubCellAccessTokenWebCacheItem.class.getName(), StringPool.POUND,
+			companyId, StringPool.POUND, aiHubCellConfiguration.clientId(),
+			StringPool.POUND, aiHubCellConfiguration.serviceURL());
+
+		JSONObject jsonObject = (JSONObject)WebCachePoolUtil.get(
+			key, new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
+
+		if (!_isExpired(jsonObject)) {
+			return jsonObject;
+		}
+
+		WebCachePoolUtil.remove(key);
+
 		return (JSONObject)WebCachePoolUtil.get(
-			StringBundler.concat(
-				AIHubCellAccessTokenWebCacheItem.class.getName(),
-				StringPool.POUND, companyId, StringPool.POUND,
-				aiHubCellConfiguration.clientId(), StringPool.POUND,
-				aiHubCellConfiguration.serviceURL()),
-			new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
+			key, new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
 	}
 
 	public AIHubCellAccessTokenWebCacheItem(
@@ -74,8 +89,24 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 				responseJSON);
 
-			_refreshTime =
-				(long)(jsonObject.getLong("expires_in") * 0.8 * Time.SECOND);
+			if (Validator.isBlank(jsonObject.getString("access_token"))) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"The token response has no access token: " +
+							responseJSON);
+				}
+
+				return null;
+			}
+
+			long expirationTime = _getExpirationTime(jsonObject);
+
+			if (expirationTime > 0) {
+				jsonObject.put("expirationTime", expirationTime);
+
+				_refreshTime =
+					(long)((expirationTime - System.currentTimeMillis()) * 0.8);
+			}
 
 			return jsonObject;
 		}
@@ -91,6 +122,51 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 	@Override
 	public long getRefreshTime() {
 		return _refreshTime;
+	}
+
+	private static boolean _isExpired(JSONObject jsonObject) {
+		if (jsonObject == null) {
+			return false;
+		}
+
+		long expirationTime = jsonObject.getLong("expirationTime", 0);
+
+		if ((expirationTime > 0) &&
+			(expirationTime <= (System.currentTimeMillis() + Time.MINUTE))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private long _getExpirationTime(JSONObject jsonObject) {
+		try {
+			SignedJWT signedJWT = SignedJWT.parse(
+				jsonObject.getString("access_token"));
+
+			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+
+			Date expirationDate = jwtClaimsSet.getExpirationTime();
+
+			if (expirationDate != null) {
+				return expirationDate.getTime();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to parse and verify the JWT token", exception);
+			}
+		}
+
+		long expiresIn = jsonObject.getLong("expires_in", 0);
+
+		if (expiresIn > 0) {
+			return System.currentTimeMillis() + (expiresIn * Time.SECOND);
+		}
+
+		return 0;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/test/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItemTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/test/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItemTest.java
@@ -1,0 +1,238 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.rest.internal.web.cache;
+
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.webcache.WebCacheItem;
+import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.net.HttpURLConnection;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author José Abelenda
+ */
+public class AIHubCellAccessTokenWebCacheItemTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testConvertWhenAccessTokenIsJWT() throws Exception {
+		long startTime = System.currentTimeMillis();
+
+		long expirationTime =
+			((startTime + Time.HOUR) / Time.SECOND) * Time.SECOND;
+
+		SignedJWT signedJWT = new SignedJWT(
+			new JWSHeader(JWSAlgorithm.HS256),
+			new JWTClaimsSet.Builder(
+			).expirationTime(
+				new Date(expirationTime)
+			).build());
+
+		signedJWT.sign(new MACSigner(new byte[32]));
+
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"access_token", signedJWT.serialize()
+				).put(
+					"expires_in", 86400
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			JSONObject jsonObject =
+				(JSONObject)aiHubCellAccessTokenWebCacheItem.convert(
+					StringPool.BLANK);
+
+			Assert.assertEquals(
+				expirationTime, jsonObject.getLong("expirationTime"));
+
+			long refreshTime =
+				aiHubCellAccessTokenWebCacheItem.getRefreshTime();
+
+			Assert.assertTrue(refreshTime > 0);
+			Assert.assertTrue(
+				refreshTime <= (long)((expirationTime - startTime) * 0.8));
+		}
+	}
+
+	@Test
+	public void testConvertWhenAccessTokenIsMissing() throws Exception {
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"error", "invalid_client"
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			Assert.assertNull(
+				aiHubCellAccessTokenWebCacheItem.convert(StringPool.BLANK));
+		}
+	}
+
+	@Test
+	public void testConvertWhenAccessTokenIsOpaque() throws Exception {
+		long startTime = System.currentTimeMillis();
+
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"access_token", RandomTestUtil.randomString()
+				).put(
+					"expires_in", 600
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			JSONObject jsonObject =
+				(JSONObject)aiHubCellAccessTokenWebCacheItem.convert(
+					StringPool.BLANK);
+
+			long expirationTime = jsonObject.getLong("expirationTime");
+
+			Assert.assertTrue(
+				expirationTime >= (startTime + (600 * Time.SECOND)));
+
+			long refreshTime =
+				aiHubCellAccessTokenWebCacheItem.getRefreshTime();
+
+			Assert.assertTrue(refreshTime > 0);
+			Assert.assertTrue(refreshTime <= (long)(600 * Time.SECOND * 0.8));
+		}
+	}
+
+	@Test
+	public void testGetWhenCachedAccessTokenIsExpired() {
+		try (MockedStatic<WebCachePoolUtil> webCachePoolUtilMockedStatic =
+				Mockito.mockStatic(WebCachePoolUtil.class)) {
+
+			JSONObject expiredJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() - Time.MINUTE);
+			JSONObject freshJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() + Time.HOUR);
+
+			webCachePoolUtilMockedStatic.when(
+				() -> WebCachePoolUtil.get(
+					Mockito.anyString(), Mockito.any(WebCacheItem.class))
+			).thenReturn(
+				expiredJSONObject, freshJSONObject
+			);
+
+			Assert.assertSame(
+				freshJSONObject,
+				AIHubCellAccessTokenWebCacheItem.get(
+					_getAIHubCellConfiguration(), RandomTestUtil.randomLong()));
+
+			webCachePoolUtilMockedStatic.verify(
+				() -> WebCachePoolUtil.remove(Mockito.anyString()));
+		}
+	}
+
+	@Test
+	public void testGetWhenCachedAccessTokenIsNotExpired() {
+		try (MockedStatic<WebCachePoolUtil> webCachePoolUtilMockedStatic =
+				Mockito.mockStatic(WebCachePoolUtil.class)) {
+
+			JSONObject freshJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() + Time.HOUR);
+
+			webCachePoolUtilMockedStatic.when(
+				() -> WebCachePoolUtil.get(
+					Mockito.anyString(), Mockito.any(WebCacheItem.class))
+			).thenReturn(
+				freshJSONObject
+			);
+
+			Assert.assertSame(
+				freshJSONObject,
+				AIHubCellAccessTokenWebCacheItem.get(
+					_getAIHubCellConfiguration(), RandomTestUtil.randomLong()));
+
+			webCachePoolUtilMockedStatic.verify(
+				() -> WebCachePoolUtil.remove(Mockito.anyString()),
+				Mockito.never());
+		}
+	}
+
+	private AIHubCellConfiguration _getAIHubCellConfiguration() {
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
+
+		Mockito.when(
+			aiHubCellConfiguration.clientId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			aiHubCellConfiguration.clientSecret()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			aiHubCellConfiguration.serviceURL()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		return aiHubCellConfiguration;
+	}
+
+	private MockedStatic<HttpUtil> _mockHttpUtil(String responseJSON) {
+		MockedStatic<HttpUtil> httpUtilMockedStatic = Mockito.mockStatic(
+			HttpUtil.class);
+
+		httpUtilMockedStatic.when(
+			() -> HttpUtil.URLtoString(Mockito.any(Http.Options.class))
+		).thenAnswer(
+			invocationOnMock -> {
+				Http.Options options = invocationOnMock.getArgument(0);
+
+				Http.Response response = new Http.Response();
+
+				response.setResponseCode(HttpURLConnection.HTTP_OK);
+
+				options.setResponse(response);
+
+				return responseJSON;
+			}
+		);
+
+		return httpUtilMockedStatic;
+	}
+
+}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -82,27 +82,26 @@ export async function getChatbotConfiguration(
 }
 
 export async function createEventSource(): Promise<EventSource | null> {
-	const headers = new Headers({Accept: 'text/event-stream'});
-
-	if ((window as any).Liferay) {
-		const authorizationToken = await postAuthorizationToken();
-
-		if (!authorizationToken) {
-			return null;
-		}
-
-		headers.set(
-			'Authorization',
-			`Bearer ${authorizationToken.accessToken}`
-		);
-	}
-
 	return new EventSource(`${aiHubURL}${AI_HUB_ENDPOINT}/chats/subscribe`, {
-		fetch: (input, init) =>
-			fetch(input as RequestInfo, {
+		fetch: async (input, init) => {
+			const headers = new Headers({Accept: 'text/event-stream'});
+
+			if ((window as any).Liferay) {
+				const authorizationToken = await postAuthorizationToken();
+
+				if (authorizationToken?.accessToken) {
+					headers.set(
+						'Authorization',
+						`Bearer ${authorizationToken.accessToken}`
+					);
+				}
+			}
+
+			return fetch(input as RequestInfo, {
 				...init,
 				headers,
-			}),
+			});
+		},
 		withCredentials: true,
 	});
 }

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -12,9 +12,26 @@ const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 let aiHubURL = '';
 let liferayDXPURL = '';
 
+// Tri-state cache for whether this DXP exposes the AI Hub cell backend:
+// null = not yet probed, true = available, false = absent (404). Prevents
+// re-probing /o/ai-hub-cell on every message once the answer is known.
+
+let cellAuthorizationAvailable: boolean | null = null;
+
 export function setURLs(aiHub: string, liferayDXP: string) {
 	aiHubURL = aiHub;
 	liferayDXPURL = liferayDXP;
+}
+
+// The widget attempts DXP cell authentication only when it is running on a
+// Liferay page and the cell backend has not already been found absent. When
+// it is absent (older DXPs, or Click to Chat's AI Hub not enabled), the
+// widget runs DXP-agnostic.
+
+function shouldUseCellAuthorization(): boolean {
+	return (
+		Boolean((window as any).Liferay) && cellAuthorizationAvailable !== false
+	);
 }
 
 async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
@@ -30,6 +47,16 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 				method: 'POST',
 			}
 		);
+
+		// A 404 means this DXP does not have the AI Hub cell backend
+		// installed. Remember it so the widget stops probing and falls
+		// back to DXP-agnostic mode.
+
+		if (response.status === 404) {
+			cellAuthorizationAvailable = false;
+
+			return null;
+		}
 
 		if (!response.ok) {
 			throw new Error(
@@ -51,11 +78,11 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 			throw new Error('Unable to find service URL.');
 		}
 
+		cellAuthorizationAvailable = true;
+
 		return data as AuthorizationToken;
 	}
-	catch (error) {
-		console.warn(error instanceof Error ? error.message : String(error));
-
+	catch {
 		return null;
 	}
 }
@@ -86,7 +113,7 @@ export async function createEventSource(): Promise<EventSource | null> {
 		fetch: async (input, init) => {
 			const headers = new Headers({Accept: 'text/event-stream'});
 
-			if ((window as any).Liferay) {
+			if (shouldUseCellAuthorization()) {
 				const authorizationToken = await postAuthorizationToken();
 
 				if (authorizationToken?.accessToken) {
@@ -116,23 +143,19 @@ export async function postChatMessage(
 		'Content-Type': 'application/json',
 	});
 
-	if ((window as any).Liferay) {
+	if (shouldUseCellAuthorization()) {
 		const authorizationToken = await postAuthorizationToken();
 
-		if (!authorizationToken) {
-			throw new Error(
-				'Unable to obtain authorization token for chat message.'
+		if (authorizationToken) {
+			headers.set(
+				'Authorization',
+				`Bearer ${authorizationToken.accessToken}`
+			);
+			headers.set(
+				'Liferay-AI-Hub-Cell-On-Behalf-Of',
+				authorizationToken.userToken
 			);
 		}
-
-		headers.set(
-			'Authorization',
-			`Bearer ${authorizationToken.accessToken}`
-		);
-		headers.set(
-			'Liferay-AI-Hub-Cell-On-Behalf-Of',
-			authorizationToken.userToken
-		);
 	}
 
 	return fetch(

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
@@ -120,14 +120,26 @@ export default function ChatbotWidget({
 				});
 
 				eventSource.addEventListener('error', () => {
-					console.error('EventSource connection error');
-
 					setSubscribed(false);
-					setMessages((prev) => [
-						...prev,
-						{sender: 'error', text: ''},
-					]);
-					setLoading(false);
+
+					if (loadingTimeoutRef.current) {
+						clearTimeout(loadingTimeoutRef.current);
+						loadingTimeoutRef.current = null;
+
+						setMessages((prev) => [
+							...prev,
+							{sender: 'error', text: ''},
+						]);
+						setLoading(false);
+					}
+					else if (eventSource.readyState === EventSource.CLOSED) {
+						console.error('EventSource connection closed');
+
+						setMessages((prev) => [
+							...prev,
+							{sender: 'error', text: ''},
+						]);
+					}
 				});
 			})
 			.catch((error) => {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/vite.config.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/vite.config.ts
@@ -8,10 +8,17 @@ import {defineConfig} from 'vite';
 
 export default defineConfig({
 	build: {
+		cssCodeSplit: false,
 		outDir: 'build/vite',
 		rollupOptions: {
 			output: {
-				assetFileNames: '[name][extname]',
+				assetFileNames: (assetInfo) => {
+					const name = assetInfo.names?.[0] ?? '';
+
+					return name.endsWith('.css')
+						? 'index.css'
+						: '[name][extname]';
+				},
 				banner:
 					'/*!\n' +
 					' * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com\n' +
@@ -19,6 +26,9 @@ export default defineConfig({
 					' */',
 				chunkFileNames: '[name]-[hash].js',
 				entryFileNames: 'index.js',
+				format: 'iife',
+				inlineDynamicImports: true,
+				name: 'liferayAIHubChatbot',
 			},
 		},
 	},

--- a/workspaces/liferay-aihub-workspace/package.json
+++ b/workspaces/liferay-aihub-workspace/package.json
@@ -13,22 +13,7 @@
 	"private": true,
 	"workspaces": {
 		"packages": [
-			"client-extensions/liferay-sample-commerce-checkout-step",
-			"client-extensions/liferay-sample-custom-element-2",
-			"client-extensions/liferay-sample-custom-element-3",
-			"client-extensions/liferay-sample-custom-element-4",
-			"client-extensions/liferay-sample-custom-element-5",
-			"client-extensions/liferay-sample-editor-config-contributor",
-			"client-extensions/liferay-sample-etc-node",
-			"client-extensions/liferay-sample-fds-cell-renderer",
-			"client-extensions/liferay-sample-fds-filter",
-			"client-extensions/liferay-sample-theme-css-1",
-			"client-extensions/liferay-sample-theme-css-2",
-			"client-extensions/liferay-sample-theme-spritemap-2",
-			"client-extensions/liferay-sample-custom-element-6",
-			"client-extensions/liferay-sample-etc-frontend",
-			"client-extensions/liferay-sample-js-import-maps-entry",
-			"client-extensions/liferay-sample-theme-css-3"
+			"client-extensions/liferay-aihub-custom-element"
 		]
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93696
https://liferay.atlassian.net/browse/LPD-93870
https://liferay.atlassian.net/browse/LPD-93676

## What Is Being Fixed

The AI Hub chatbot widget (liferay-aihub-custom-element) had two defects that surface when it runs outside a fully AI-Hub-enabled Liferay DXP:

- **LPD-93696** — The widget decided whether to authenticate against the DXP cell backend solely from the presence of `window.Liferay`. On a Liferay DXP without the `ai-hub-cell` module (older versions, or Click to Chat's AI Hub not enabled), it still POSTed to `/o/ai-hub-cell/v1.0/authorization-tokens`, got a 404, never subscribed to the chat stream, and left the input disabled — so the "DXP-agnostic" widget was not actually agnostic inside a DXP.

- **LPD-93870** — The bundle loaded as a classic script with no scope isolation, so its minified top-level functions leaked onto `window`. One of them (`fm`) overwrote Liferay login's global `window.fm`, breaking the login redirect on any page where the widget was embedded.

## How It Is Being Fixed

For LPD-93696, the widget now treats the cell backend as a capability to detect rather than assume. It probes the token endpoint once, treats a 404 as "cell backend absent," caches the result so it never re-probes, and otherwise proceeds anonymously — authenticating when the cell backend is present and silently running DXP-agnostic when it is not. The auth helper was renamed to `shouldUseCellAuthorization` so it is not mistaken for a React Hook.

For LPD-93870, the Vite build now emits an IIFE (`output.format: 'iife'`), wrapping the bundle so nothing leaks to the global scope. The CSS stays a separate `index.css` (`cssCodeSplit: false` plus an asset rename), so the embed contract is unchanged and there is no Content-Security-Policy `unsafe-inline` requirement for DXP customers.

## Supersedes #504

This PR also includes the five LPD-93676 commits from liferay-ai-hub/liferay-portal#504 (expired-access-token handling, per-reconnection token renewal, silent transient SSE drops, and workspace registration), with Jose Abelenda retained as their author. It supersedes #504 so all three fixes ship together; #504 is being closed in favor of this PR (coordinated with Jose).

## PR Check

**pr-check: PASS (frontend subset)** — tested on `0eaa66814f3c94a82502c0dc57761f894d9a6055`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Per-Module Deploy, Integration Test Compile, and Java Unit Tests were not run locally — those fire only on the LPD-93676 Java commits, which were already validated on #504. The frontend changes new to this PR are covered by Source Format and Workspace Build.

<!-- pr-check {"result": "success", "sha": "0eaa66814f3c94a82502c0dc57761f894d9a6055"} -->