### PR TITLE
LPD-93907 Support Gemini 3+ models in the eu multi-region

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -11,6 +11,7 @@ import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.Validator;
 
 import dev.langchain4j.model.vertexai.gemini.HarmCategory;
 import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
@@ -20,11 +21,17 @@ import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * @author Feliphe Marinho
  */
 public class VertexAiGeminiUtil {
+
+	public static final String TOOL_CALLING_LOCATION = "europe-west1";
+
+	public static final String TOOL_CALLING_MODEL_NAME = "gemini-2.5-flash";
 
 	public static VertexAiGeminiChatModel createVertexAiGeminiChatModel(
 			QuotaManager quotaManager, ServiceContext serviceContext)
@@ -37,9 +44,7 @@ public class VertexAiGeminiUtil {
 		VertexAiGeminiChatModel.VertexAiGeminiChatModelBuilder builder =
 			VertexAiGeminiChatModel.builder();
 
-		if (Objects.equals(vertexAIConfiguration.location(), "global")) {
-			builder.apiEndpoint("aiplatform.googleapis.com");
-		}
+		_setAPIEndpoint(builder::apiEndpoint, vertexAIConfiguration.location());
 
 		return builder.listeners(
 			Collections.singletonList(
@@ -60,24 +65,39 @@ public class VertexAiGeminiUtil {
 				QuotaManager quotaManager, ServiceContext serviceContext)
 		throws ConfigurationException {
 
+		return createVertexAiGeminiStreamingChatModel(
+			null, quotaManager, serviceContext);
+	}
+
+	public static VertexAiGeminiStreamingChatModel
+			createVertexAiGeminiStreamingChatModel(
+				String modelName, QuotaManager quotaManager,
+				ServiceContext serviceContext)
+		throws ConfigurationException {
+
 		VertexAIConfiguration vertexAIConfiguration =
 			ConfigurationProviderUtil.getCompanyConfiguration(
 				VertexAIConfiguration.class, serviceContext.getCompanyId());
 
+		String location = TOOL_CALLING_LOCATION;
+
+		if (Validator.isNull(modelName)) {
+			location = vertexAIConfiguration.location();
+			modelName = vertexAIConfiguration.modelName();
+		}
+
 		VertexAiGeminiStreamingChatModel.VertexAiGeminiStreamingChatModelBuilder
 			builder = VertexAiGeminiStreamingChatModel.builder();
 
-		if (Objects.equals(vertexAIConfiguration.location(), "global")) {
-			builder.apiEndpoint("aiplatform.googleapis.com");
-		}
+		_setAPIEndpoint(builder::apiEndpoint, location);
 
 		return builder.listeners(
 			Collections.singletonList(
 				new AIHubChatModelListenerImpl(quotaManager, serviceContext))
 		).location(
-			vertexAIConfiguration.location()
+			location
 		).modelName(
-			vertexAIConfiguration.modelName()
+			modelName
 		).project(
 			vertexAIConfiguration.projectId()
 		).safetySettings(
@@ -85,6 +105,21 @@ public class VertexAiGeminiUtil {
 		).build();
 	}
 
+	private static void _setAPIEndpoint(
+		Consumer<String> apiEndpointConsumer, String location) {
+
+		if (Objects.equals(location, "global")) {
+			apiEndpointConsumer.accept("aiplatform.googleapis.com");
+		}
+		else if (Validator.isNotNull(location) &&
+				 _multiRegionLocations.contains(location)) {
+
+			apiEndpointConsumer.accept(
+				"aiplatform." + location + ".rep.googleapis.com");
+		}
+	}
+
+	private static final Set<String> _multiRegionLocations = Set.of("eu", "us");
 	private static final Map<HarmCategory, SafetyThreshold> _safetyThresholds =
 		Map.of(
 			HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -174,7 +174,8 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				_quotaManager, serviceContext);
+				VertexAiGeminiUtil.TOOL_CALLING_MODEL_NAME, _quotaManager,
+				serviceContext);
 
 		String sseEventSinkKey = GetterUtil.getString(
 			workflowContext.get("sseEventSinkKey"));

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowNodeManager;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -107,12 +108,24 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 
 		AtomicReference<ChatResponse> chatResponseAtomicReference =
 			new AtomicReference<>();
+
 		Map<String, String> kaleoNodeSettingValues =
 			KaleoNodeSettingUtil.getKaleoNodeSettingValuesMap(
 				currentKaleoNode.getKaleoNodeId());
+
+		List<String> mcpServerExternalReferenceCodes =
+			ToolsUtil.getMCPServerExternalReferenceCodes(
+				_jsonFactory, kaleoNodeSettingValues);
+
+		String modelName = null;
+
+		if (ListUtil.isNotEmpty(mcpServerExternalReferenceCodes)) {
+			modelName = VertexAiGeminiUtil.TOOL_CALLING_MODEL_NAME;
+		}
+
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
-				_quotaManager, serviceContext);
+				modelName, _quotaManager, serviceContext);
 
 		String prompt = PromptUtil.composePrompt(
 			kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
@@ -195,10 +208,9 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 				MCPToolProviderUtil.create(
 					kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,
 					kaleoInstanceToken.getGroupId(), serviceContext.getLocale(),
-					ToolsUtil.getMCPServerExternalReferenceCodes(
-						_jsonFactory, kaleoNodeSettingValues),
-					_objectEntryManager, sseEventSinkKey,
-					serviceContext.getUserId(), workflowContext)
+					mcpServerExternalReferenceCodes, _objectEntryManager,
+					sseEventSinkKey, serviceContext.getUserId(),
+					workflowContext)
 			).userMessage(
 				userMessage
 			).vertexAiGeminiStreamingChatModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtilTest.java
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.model;
+
+import com.google.cloud.vertexai.VertexAI;
+import com.google.cloud.vertexai.generativeai.GenerativeModel;
+
+import com.liferay.ai.hub.configuration.VertexAIConfiguration;
+import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Iliyan Peychev
+ */
+public class VertexAiGeminiUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_configurationProviderUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		Mockito.when(
+			_vertexAIConfiguration.location()
+		).thenReturn(
+			"us-central1"
+		);
+
+		Mockito.when(
+			_vertexAIConfiguration.modelName()
+		).thenReturn(
+			"configured-model"
+		);
+
+		Mockito.when(
+			_vertexAIConfiguration.projectId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getCompanyConfiguration(
+				Mockito.eq(VertexAIConfiguration.class), Mockito.anyLong())
+		).thenReturn(
+			_vertexAIConfiguration
+		);
+	}
+
+	@Test
+	public void testCreateVertexAiGeminiStreamingChatModel() throws Exception {
+		try (VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
+				VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
+					_quotaManager, _serviceContext)) {
+
+			Assert.assertEquals(
+				"us-central1", _getLocation(vertexAiGeminiStreamingChatModel));
+			Assert.assertEquals(
+				"configured-model",
+				_getModelName(vertexAiGeminiStreamingChatModel));
+		}
+	}
+
+	@Test
+	public void testCreateVertexAiGeminiStreamingChatModelWithModelName()
+		throws Exception {
+
+		try (VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
+				VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
+					VertexAiGeminiUtil.TOOL_CALLING_MODEL_NAME, _quotaManager,
+					_serviceContext)) {
+
+			Assert.assertEquals(
+				VertexAiGeminiUtil.TOOL_CALLING_LOCATION,
+				_getLocation(vertexAiGeminiStreamingChatModel));
+			Assert.assertEquals(
+				VertexAiGeminiUtil.TOOL_CALLING_MODEL_NAME,
+				_getModelName(vertexAiGeminiStreamingChatModel));
+		}
+	}
+
+	@Test
+	public void testCreateVertexAiGeminiStreamingChatModelWithMultiRegionLocation()
+		throws Exception {
+
+		Mockito.when(
+			_vertexAIConfiguration.location()
+		).thenReturn(
+			"eu"
+		);
+
+		try (VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
+				VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(
+					_quotaManager, _serviceContext)) {
+
+			Assert.assertEquals(
+				"aiplatform.eu.rep.googleapis.com",
+				_getAPIEndpoint(vertexAiGeminiStreamingChatModel));
+			Assert.assertEquals(
+				"eu", _getLocation(vertexAiGeminiStreamingChatModel));
+		}
+	}
+
+	private String _getAPIEndpoint(
+		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
+
+		VertexAI vertexAI = ReflectionTestUtil.getFieldValue(
+			vertexAiGeminiStreamingChatModel, "vertexAI");
+
+		return vertexAI.getApiEndpoint();
+	}
+
+	private String _getLocation(
+		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
+
+		VertexAI vertexAI = ReflectionTestUtil.getFieldValue(
+			vertexAiGeminiStreamingChatModel, "vertexAI");
+
+		return vertexAI.getLocation();
+	}
+
+	private String _getModelName(
+		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
+
+		GenerativeModel generativeModel = ReflectionTestUtil.getFieldValue(
+			vertexAiGeminiStreamingChatModel, "generativeModel");
+
+		String modelName = generativeModel.getModelName();
+
+		return modelName.substring(modelName.lastIndexOf('/') + 1);
+	}
+
+	private static final MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
+
+	private final QuotaManager _quotaManager = Mockito.mock(QuotaManager.class);
+	private final ServiceContext _serviceContext = new ServiceContext();
+	private final VertexAIConfiguration _vertexAIConfiguration = Mockito.mock(
+		VertexAIConfiguration.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93907

## What Is Being Fixed

Switching the AI Hub Vertex AI configuration to a Gemini 3+ model in the `eu` multi-region fails twice over. The Vertex AI SDK derives the API endpoint `eu-aiplatform.googleapis.com` from the location, a host that does not serve the prediction service, so every request fails with an HTTP 404. In addition, langchain4j 1.10.0 does not propagate the thought signatures that Gemini 3+ models require for function calling, so any request that sends tools to such a model fails.

## How It Is Being Fixed

The `eu` and `us` multi-region locations now resolve to their dedicated `aiplatform.<location>.rep.googleapis.com` endpoints, the same way the `global` location already resolves to `aiplatform.googleapis.com`. Tool calling is pinned to Gemini 2.5 Flash in europe-west1 until langchain4j is upgraded: the AI decision node always sends tools, and the LLM node sends tools when MCP servers are configured, so both pass the pinned model instead of the company configured one. Paths that send no tools, such as the chatbot supervisor, keep using the configured model and can move to a Gemini 3+ model.

Verified locally against a Gemini 3.5 Flash configuration in the `eu` multi-region: the chatbot answers through the supervisor and an LLM node on the configured model, and an ai-decision node completes its transition through the pinned model with a tool call.

## PR Check

**pr-check: PASS** — tested on `a6fc700491b0e28fe556e31d263bc8f93067eca6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a6fc700491b0e28fe556e31d263bc8f93067eca6"} -->