### PR TITLE
LPD-93589 Description of the avatar field not showing correct info

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -201,6 +201,9 @@ public class AIHubSiteInitializerTest {
 			"L_AI_HUB_INSTRUCTION_DEFINITION", "L_AI_HUB_PII_NONGENERATION");
 		_assertObjectEntryExists(
 			"L_AI_HUB_INSTRUCTION_DEFINITION", "L_AI_HUB_PROHIBITED_PRACTICES");
+		_assertObjectFieldSettingValue(
+			"L_AI_HUB_CHATBOT", "avatar",
+			ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE, "512000");
 		_assertObjectFieldDefaultValue(
 			"L_AI_HUB_GUARDRAIL", "location", "europe-west1");
 		_assertObjectFieldsExist(
@@ -503,6 +506,27 @@ public class AIHubSiteInitializerTest {
 			_objectFieldSettingLocalService.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(),
 				ObjectFieldSettingConstants.NAME_DEFAULT_VALUE);
+
+		Assert.assertEquals(value, objectFieldSetting.getValue());
+	}
+
+	private void _assertObjectFieldSettingValue(
+			String objectDefinitionExternalReferenceCode,
+			String objectFieldName, String objectFieldSettingName, String value)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), objectFieldName);
+
+		ObjectFieldSetting objectFieldSetting =
+			_objectFieldSettingLocalService.fetchObjectFieldSetting(
+				objectField.getObjectFieldId(), objectFieldSettingName);
 
 		Assert.assertEquals(value, objectFieldSetting.getValue());
 	}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/chatbot-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/chatbot-object-definition.json
@@ -45,7 +45,7 @@
 				},
 				{
 					"name": "maximumFileSize",
-					"value": 0
+					"value": 512000
 				},
 				{
 					"name": "fileSource",

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContext.java
@@ -13,10 +13,13 @@ import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -33,11 +36,13 @@ public class EditChatbotDisplayContext {
 
 	public EditChatbotDisplayContext(
 		AttachmentManager attachmentManager,
-		HttpServletRequest httpServletRequest, Language language) {
+		HttpServletRequest httpServletRequest, Language language,
+		ObjectFieldSettingLocalService objectFieldSettingLocalService) {
 
 		_attachmentManager = attachmentManager;
 		_httpServletRequest = httpServletRequest;
 		_language = language;
+		_objectFieldSettingLocalService = objectFieldSettingLocalService;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -54,8 +59,12 @@ public class EditChatbotDisplayContext {
 				ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS,
 				objectField);
 
-			maximumFileSize = _attachmentManager.getMaximumFileSize(
-				objectField.getObjectFieldId(), _themeDisplay.isSignedIn());
+			ObjectFieldSetting objectFieldSetting =
+				_objectFieldSettingLocalService.fetchObjectFieldSetting(
+					objectField.getObjectFieldId(),
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE);
+
+			maximumFileSize = GetterUtil.getLong(objectFieldSetting.getValue());
 		}
 
 		return HashMapBuilder.<String, Object>put(
@@ -132,6 +141,8 @@ public class EditChatbotDisplayContext {
 	private final AttachmentManager _attachmentManager;
 	private final HttpServletRequest _httpServletRequest;
 	private final Language _language;
+	private final ObjectFieldSettingLocalService
+		_objectFieldSettingLocalService;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditChatbotFragmentRenderer.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditChatbotFragmentRenderer.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.web.internal.fragment.renderer;
 import com.liferay.ai.hub.web.internal.display.context.EditChatbotDisplayContext;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.object.field.attachment.AttachmentManager;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +33,8 @@ public class EditChatbotFragmentRenderer
 		HttpServletRequest httpServletRequest) {
 
 		return new EditChatbotDisplayContext(
-			_attachmentManager, httpServletRequest, _language);
+			_attachmentManager, httpServletRequest, _language,
+			_objectFieldSettingLocalService);
 	}
 
 	@Override
@@ -45,5 +47,8 @@ public class EditChatbotFragmentRenderer
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContextTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContextTest.java
@@ -10,9 +10,12 @@ import com.liferay.ai.hub.web.internal.test.util.DisplayContextTestUtil;
 import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,6 +43,8 @@ public class EditChatbotDisplayContextTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_setUpPortalUtil();
+
 		HttpServletRequest httpServletRequest =
 			DisplayContextTestUtil.setUpHttpServletRequest();
 
@@ -49,13 +54,20 @@ public class EditChatbotDisplayContextTest {
 
 		_editChatbotDisplayContext = new EditChatbotDisplayContext(
 			Mockito.mock(AttachmentManager.class), httpServletRequest,
-			Mockito.mock(Language.class));
+			Mockito.mock(Language.class),
+			Mockito.mock(ObjectFieldSettingLocalService.class));
 	}
 
 	@Test
 	public void testGetReactData() throws Exception {
 		_testGetReactData(true, false);
 		_testGetReactData(false, true);
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
 	}
 
 	private void _testGetReactData(
@@ -89,5 +101,6 @@ public class EditChatbotDisplayContextTest {
 	}
 
 	private EditChatbotDisplayContext _editChatbotDisplayContext;
+	private final Portal _portal = Mockito.mock(Portal.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93589

## What Is Being Fixed

The avatar upload field in the AI Hub chatbot editor displayed incorrect file-size information. The chatbot object definition set the avatar field's maximum file size to 0, which means no limit, so the upload tip and maximum file size shown to the user did not reflect any real constraint. The display context also derived the value from AttachmentManager.getMaximumFileSize rather than from the maximum file size configured on the object field, so the description never matched the field's actual setting.

## How It Is Being Fixed

The avatar object field's maximumFileSize setting is set to 512000 bytes (500 KB) in the chatbot object definition so the field carries a real limit. EditChatbotDisplayContext now reads that maximumFileSize object field setting directly through ObjectFieldSettingLocalService and parses it with GetterUtil, so the value, label, and upload tip exposed to the React component reflect the configured limit. EditChatbotFragmentRenderer wires the new ObjectFieldSettingLocalService reference into the display context. The AIHubSiteInitializerTest integration test asserts the avatar field's maximumFileSize setting equals 512000, and the EditChatbotDisplayContext unit test is updated for the new constructor dependency.

## PR Check

**pr-check: PASS** — tested on `9e2c098d9f9bab1505e3514f18f3215cea2bef59`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9e2c098d9f9bab1505e3514f18f3215cea2bef59"} -->