### PR TITLE
LPD-93676 Harden the AI Hub chatbot widget and cell token handling

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.ai.hub.cell.rest.internal.security.JWTTokenUtil;
 import com.liferay.ai.hub.cell.rest.internal.web.cache.AIHubCellAccessTokenWebCacheItem;
 import com.liferay.ai.hub.cell.rest.resource.v1_0.AuthorizationTokenResource;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 
@@ -42,6 +43,10 @@ public class AuthorizationTokenResourceImpl
 
 		JSONObject jsonObject = AIHubCellAccessTokenWebCacheItem.get(
 			aiHubCellConfiguration, contextCompany.getCompanyId());
+
+		if (jsonObject == null) {
+			throw new PortalException("Unable to get an access token");
+		}
 
 		return new AuthorizationToken() {
 			{

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
@@ -15,10 +15,16 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webcache.WebCacheItem;
 import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
 import java.net.HttpURLConnection;
+
+import java.util.Date;
 
 /**
  * @author Manuele Castro
@@ -28,13 +34,22 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 	public static JSONObject get(
 		AIHubCellConfiguration aiHubCellConfiguration, long companyId) {
 
+		String key = StringBundler.concat(
+			AIHubCellAccessTokenWebCacheItem.class.getName(), StringPool.POUND,
+			companyId, StringPool.POUND, aiHubCellConfiguration.clientId(),
+			StringPool.POUND, aiHubCellConfiguration.serviceURL());
+
+		JSONObject jsonObject = (JSONObject)WebCachePoolUtil.get(
+			key, new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
+
+		if (!_isExpired(jsonObject)) {
+			return jsonObject;
+		}
+
+		WebCachePoolUtil.remove(key);
+
 		return (JSONObject)WebCachePoolUtil.get(
-			StringBundler.concat(
-				AIHubCellAccessTokenWebCacheItem.class.getName(),
-				StringPool.POUND, companyId, StringPool.POUND,
-				aiHubCellConfiguration.clientId(), StringPool.POUND,
-				aiHubCellConfiguration.serviceURL()),
-			new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
+			key, new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
 	}
 
 	public AIHubCellAccessTokenWebCacheItem(
@@ -74,8 +89,24 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 				responseJSON);
 
-			_refreshTime =
-				(long)(jsonObject.getLong("expires_in") * 0.8 * Time.SECOND);
+			if (Validator.isBlank(jsonObject.getString("access_token"))) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"The token response has no access token: " +
+							responseJSON);
+				}
+
+				return null;
+			}
+
+			long expirationTime = _getExpirationTime(jsonObject);
+
+			if (expirationTime > 0) {
+				jsonObject.put("expirationTime", expirationTime);
+
+				_refreshTime =
+					(long)((expirationTime - System.currentTimeMillis()) * 0.8);
+			}
 
 			return jsonObject;
 		}
@@ -91,6 +122,51 @@ public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
 	@Override
 	public long getRefreshTime() {
 		return _refreshTime;
+	}
+
+	private static boolean _isExpired(JSONObject jsonObject) {
+		if (jsonObject == null) {
+			return false;
+		}
+
+		long expirationTime = jsonObject.getLong("expirationTime", 0);
+
+		if ((expirationTime > 0) &&
+			(expirationTime <= (System.currentTimeMillis() + Time.MINUTE))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private long _getExpirationTime(JSONObject jsonObject) {
+		try {
+			SignedJWT signedJWT = SignedJWT.parse(
+				jsonObject.getString("access_token"));
+
+			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+
+			Date expirationDate = jwtClaimsSet.getExpirationTime();
+
+			if (expirationDate != null) {
+				return expirationDate.getTime();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to parse and verify the JWT token", exception);
+			}
+		}
+
+		long expiresIn = jsonObject.getLong("expires_in", 0);
+
+		if (expiresIn > 0) {
+			return System.currentTimeMillis() + (expiresIn * Time.SECOND);
+		}
+
+		return 0;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/test/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItemTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/test/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItemTest.java
@@ -1,0 +1,238 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.rest.internal.web.cache;
+
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.webcache.WebCacheItem;
+import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.net.HttpURLConnection;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author José Abelenda
+ */
+public class AIHubCellAccessTokenWebCacheItemTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testConvertWhenAccessTokenIsJWT() throws Exception {
+		long startTime = System.currentTimeMillis();
+
+		long expirationTime =
+			((startTime + Time.HOUR) / Time.SECOND) * Time.SECOND;
+
+		SignedJWT signedJWT = new SignedJWT(
+			new JWSHeader(JWSAlgorithm.HS256),
+			new JWTClaimsSet.Builder(
+			).expirationTime(
+				new Date(expirationTime)
+			).build());
+
+		signedJWT.sign(new MACSigner(new byte[32]));
+
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"access_token", signedJWT.serialize()
+				).put(
+					"expires_in", 86400
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			JSONObject jsonObject =
+				(JSONObject)aiHubCellAccessTokenWebCacheItem.convert(
+					StringPool.BLANK);
+
+			Assert.assertEquals(
+				expirationTime, jsonObject.getLong("expirationTime"));
+
+			long refreshTime =
+				aiHubCellAccessTokenWebCacheItem.getRefreshTime();
+
+			Assert.assertTrue(refreshTime > 0);
+			Assert.assertTrue(
+				refreshTime <= (long)((expirationTime - startTime) * 0.8));
+		}
+	}
+
+	@Test
+	public void testConvertWhenAccessTokenIsMissing() throws Exception {
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"error", "invalid_client"
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			Assert.assertNull(
+				aiHubCellAccessTokenWebCacheItem.convert(StringPool.BLANK));
+		}
+	}
+
+	@Test
+	public void testConvertWhenAccessTokenIsOpaque() throws Exception {
+		long startTime = System.currentTimeMillis();
+
+		try (MockedStatic<HttpUtil> httpUtilMockedStatic = _mockHttpUtil(
+				JSONUtil.put(
+					"access_token", RandomTestUtil.randomString()
+				).put(
+					"expires_in", 600
+				).toString())) {
+
+			AIHubCellAccessTokenWebCacheItem aiHubCellAccessTokenWebCacheItem =
+				new AIHubCellAccessTokenWebCacheItem(
+					_getAIHubCellConfiguration());
+
+			JSONObject jsonObject =
+				(JSONObject)aiHubCellAccessTokenWebCacheItem.convert(
+					StringPool.BLANK);
+
+			long expirationTime = jsonObject.getLong("expirationTime");
+
+			Assert.assertTrue(
+				expirationTime >= (startTime + (600 * Time.SECOND)));
+
+			long refreshTime =
+				aiHubCellAccessTokenWebCacheItem.getRefreshTime();
+
+			Assert.assertTrue(refreshTime > 0);
+			Assert.assertTrue(refreshTime <= (long)(600 * Time.SECOND * 0.8));
+		}
+	}
+
+	@Test
+	public void testGetWhenCachedAccessTokenIsExpired() {
+		try (MockedStatic<WebCachePoolUtil> webCachePoolUtilMockedStatic =
+				Mockito.mockStatic(WebCachePoolUtil.class)) {
+
+			JSONObject expiredJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() - Time.MINUTE);
+			JSONObject freshJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() + Time.HOUR);
+
+			webCachePoolUtilMockedStatic.when(
+				() -> WebCachePoolUtil.get(
+					Mockito.anyString(), Mockito.any(WebCacheItem.class))
+			).thenReturn(
+				expiredJSONObject, freshJSONObject
+			);
+
+			Assert.assertSame(
+				freshJSONObject,
+				AIHubCellAccessTokenWebCacheItem.get(
+					_getAIHubCellConfiguration(), RandomTestUtil.randomLong()));
+
+			webCachePoolUtilMockedStatic.verify(
+				() -> WebCachePoolUtil.remove(Mockito.anyString()));
+		}
+	}
+
+	@Test
+	public void testGetWhenCachedAccessTokenIsNotExpired() {
+		try (MockedStatic<WebCachePoolUtil> webCachePoolUtilMockedStatic =
+				Mockito.mockStatic(WebCachePoolUtil.class)) {
+
+			JSONObject freshJSONObject = JSONUtil.put(
+				"expirationTime", System.currentTimeMillis() + Time.HOUR);
+
+			webCachePoolUtilMockedStatic.when(
+				() -> WebCachePoolUtil.get(
+					Mockito.anyString(), Mockito.any(WebCacheItem.class))
+			).thenReturn(
+				freshJSONObject
+			);
+
+			Assert.assertSame(
+				freshJSONObject,
+				AIHubCellAccessTokenWebCacheItem.get(
+					_getAIHubCellConfiguration(), RandomTestUtil.randomLong()));
+
+			webCachePoolUtilMockedStatic.verify(
+				() -> WebCachePoolUtil.remove(Mockito.anyString()),
+				Mockito.never());
+		}
+	}
+
+	private AIHubCellConfiguration _getAIHubCellConfiguration() {
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
+
+		Mockito.when(
+			aiHubCellConfiguration.clientId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			aiHubCellConfiguration.clientSecret()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			aiHubCellConfiguration.serviceURL()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		return aiHubCellConfiguration;
+	}
+
+	private MockedStatic<HttpUtil> _mockHttpUtil(String responseJSON) {
+		MockedStatic<HttpUtil> httpUtilMockedStatic = Mockito.mockStatic(
+			HttpUtil.class);
+
+		httpUtilMockedStatic.when(
+			() -> HttpUtil.URLtoString(Mockito.any(Http.Options.class))
+		).thenAnswer(
+			invocationOnMock -> {
+				Http.Options options = invocationOnMock.getArgument(0);
+
+				Http.Response response = new Http.Response();
+
+				response.setResponseCode(HttpURLConnection.HTTP_OK);
+
+				options.setResponse(response);
+
+				return responseJSON;
+			}
+		);
+
+		return httpUtilMockedStatic;
+	}
+
+}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -19,7 +19,7 @@ export function setURLs(aiHub: string, liferayDXP: string) {
 	liferayDXPURL = liferayDXP;
 }
 
-function shouldUseCellAuthorization(): boolean {
+function isCellAuthorizationAvailable(): boolean {
 	return (
 		Boolean((window as any).Liferay) && cellAuthorizationAvailable !== false
 	);
@@ -100,7 +100,7 @@ export async function createEventSource(): Promise<EventSource | null> {
 		fetch: async (input, init) => {
 			const headers = new Headers({Accept: 'text/event-stream'});
 
-			if (shouldUseCellAuthorization()) {
+			if (isCellAuthorizationAvailable()) {
 				const authorizationToken = await postAuthorizationToken();
 
 				if (authorizationToken?.accessToken) {
@@ -130,7 +130,7 @@ export async function postChatMessage(
 		'Content-Type': 'application/json',
 	});
 
-	if (shouldUseCellAuthorization()) {
+	if (isCellAuthorizationAvailable()) {
 		const authorizationToken = await postAuthorizationToken();
 
 		if (authorizationToken) {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -12,9 +12,17 @@ const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 let aiHubURL = '';
 let liferayDXPURL = '';
 
+let cellAuthorizationAvailable: boolean | null = null;
+
 export function setURLs(aiHub: string, liferayDXP: string) {
 	aiHubURL = aiHub;
 	liferayDXPURL = liferayDXP;
+}
+
+function shouldUseCellAuthorization(): boolean {
+	return (
+		Boolean((window as any).Liferay) && cellAuthorizationAvailable !== false
+	);
 }
 
 async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
@@ -30,6 +38,12 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 				method: 'POST',
 			}
 		);
+
+		if (response.status === 404) {
+			cellAuthorizationAvailable = false;
+
+			return null;
+		}
 
 		if (!response.ok) {
 			throw new Error(
@@ -51,11 +65,11 @@ async function postAuthorizationToken(): Promise<AuthorizationToken | null> {
 			throw new Error('Unable to find service URL.');
 		}
 
+		cellAuthorizationAvailable = true;
+
 		return data as AuthorizationToken;
 	}
-	catch (error) {
-		console.warn(error instanceof Error ? error.message : String(error));
-
+	catch {
 		return null;
 	}
 }
@@ -86,7 +100,7 @@ export async function createEventSource(): Promise<EventSource | null> {
 		fetch: async (input, init) => {
 			const headers = new Headers({Accept: 'text/event-stream'});
 
-			if ((window as any).Liferay) {
+			if (shouldUseCellAuthorization()) {
 				const authorizationToken = await postAuthorizationToken();
 
 				if (authorizationToken?.accessToken) {
@@ -116,23 +130,19 @@ export async function postChatMessage(
 		'Content-Type': 'application/json',
 	});
 
-	if ((window as any).Liferay) {
+	if (shouldUseCellAuthorization()) {
 		const authorizationToken = await postAuthorizationToken();
 
-		if (!authorizationToken) {
-			throw new Error(
-				'Unable to obtain authorization token for chat message.'
+		if (authorizationToken) {
+			headers.set(
+				'Authorization',
+				`Bearer ${authorizationToken.accessToken}`
+			);
+			headers.set(
+				'Liferay-AI-Hub-Cell-On-Behalf-Of',
+				authorizationToken.userToken
 			);
 		}
-
-		headers.set(
-			'Authorization',
-			`Bearer ${authorizationToken.accessToken}`
-		);
-		headers.set(
-			'Liferay-AI-Hub-Cell-On-Behalf-Of',
-			authorizationToken.userToken
-		);
 	}
 
 	return fetch(

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/api.ts
@@ -82,27 +82,26 @@ export async function getChatbotConfiguration(
 }
 
 export async function createEventSource(): Promise<EventSource | null> {
-	const headers = new Headers({Accept: 'text/event-stream'});
-
-	if ((window as any).Liferay) {
-		const authorizationToken = await postAuthorizationToken();
-
-		if (!authorizationToken) {
-			return null;
-		}
-
-		headers.set(
-			'Authorization',
-			`Bearer ${authorizationToken.accessToken}`
-		);
-	}
-
 	return new EventSource(`${aiHubURL}${AI_HUB_ENDPOINT}/chats/subscribe`, {
-		fetch: (input, init) =>
-			fetch(input as RequestInfo, {
+		fetch: async (input, init) => {
+			const headers = new Headers({Accept: 'text/event-stream'});
+
+			if ((window as any).Liferay) {
+				const authorizationToken = await postAuthorizationToken();
+
+				if (authorizationToken?.accessToken) {
+					headers.set(
+						'Authorization',
+						`Bearer ${authorizationToken.accessToken}`
+					);
+				}
+			}
+
+			return fetch(input as RequestInfo, {
 				...init,
 				headers,
-			}),
+			});
+		},
 		withCredentials: true,
 	});
 }

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/src/components/ChatbotWidget.tsx
@@ -120,14 +120,26 @@ export default function ChatbotWidget({
 				});
 
 				eventSource.addEventListener('error', () => {
-					console.error('EventSource connection error');
-
 					setSubscribed(false);
-					setMessages((prev) => [
-						...prev,
-						{sender: 'error', text: ''},
-					]);
-					setLoading(false);
+
+					if (loadingTimeoutRef.current) {
+						clearTimeout(loadingTimeoutRef.current);
+						loadingTimeoutRef.current = null;
+
+						setMessages((prev) => [
+							...prev,
+							{sender: 'error', text: ''},
+						]);
+						setLoading(false);
+					}
+					else if (eventSource.readyState === EventSource.CLOSED) {
+						console.error('EventSource connection closed');
+
+						setMessages((prev) => [
+							...prev,
+							{sender: 'error', text: ''},
+						]);
+					}
 				});
 			})
 			.catch((error) => {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/vite.config.ts
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-custom-element/vite.config.ts
@@ -8,10 +8,17 @@ import {defineConfig} from 'vite';
 
 export default defineConfig({
 	build: {
+		cssCodeSplit: false,
 		outDir: 'build/vite',
 		rollupOptions: {
 			output: {
-				assetFileNames: '[name][extname]',
+				assetFileNames: (assetInfo) => {
+					const name = assetInfo.names?.[0] ?? '';
+
+					return name.endsWith('.css')
+						? 'index.css'
+						: '[name][extname]';
+				},
 				banner:
 					'/*!\n' +
 					' * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com\n' +
@@ -19,6 +26,9 @@ export default defineConfig({
 					' */',
 				chunkFileNames: '[name]-[hash].js',
 				entryFileNames: 'index.js',
+				format: 'iife',
+				inlineDynamicImports: true,
+				name: 'liferayAIHubChatbot',
 			},
 		},
 	},

--- a/workspaces/liferay-aihub-workspace/package.json
+++ b/workspaces/liferay-aihub-workspace/package.json
@@ -13,22 +13,7 @@
 	"private": true,
 	"workspaces": {
 		"packages": [
-			"client-extensions/liferay-sample-commerce-checkout-step",
-			"client-extensions/liferay-sample-custom-element-2",
-			"client-extensions/liferay-sample-custom-element-3",
-			"client-extensions/liferay-sample-custom-element-4",
-			"client-extensions/liferay-sample-custom-element-5",
-			"client-extensions/liferay-sample-editor-config-contributor",
-			"client-extensions/liferay-sample-etc-node",
-			"client-extensions/liferay-sample-fds-cell-renderer",
-			"client-extensions/liferay-sample-fds-filter",
-			"client-extensions/liferay-sample-theme-css-1",
-			"client-extensions/liferay-sample-theme-css-2",
-			"client-extensions/liferay-sample-theme-spritemap-2",
-			"client-extensions/liferay-sample-custom-element-6",
-			"client-extensions/liferay-sample-etc-frontend",
-			"client-extensions/liferay-sample-js-import-maps-entry",
-			"client-extensions/liferay-sample-theme-css-3"
+			"client-extensions/liferay-aihub-custom-element"
 		]
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93676

## What Is Being Fixed

The AI Hub chatbot custom element had several robustness gaps in how it
authenticates against the AI Hub cell and keeps its SSE connection alive.
The authorization token was not renewed when the SSE stream reconnected,
so a long-lived widget eventually failed with an expired token. The cell
could also hand out an already-expired access token from its cache.
Transient SSE drops surfaced to the user as errors instead of being
retried silently. The widget assumed the AI Hub cell backend is always
present, breaking on DXPs where it is absent (older versions, or Click to
Chat's AI Hub not enabled). Finally, the bundled widget leaked internal
declarations onto the host page's global scope.

## How It Is Being Fixed

On the cell side, the access token is now cached with expiry awareness so
an expired token is never served, and the widget renews its authorization
token on each SSE reconnection; transient SSE drops are kept silent
(LPD-93676), with unit tests added for AIHubCellAccessTokenWebCacheItem.
The client now probes the cell once and falls back to a DXP-agnostic mode
when it is absent, gated behind a tri-state isCellAuthorizationAvailable
cache (LPD-93696). The widget bundle is emitted as an IIFE exposing a
single named global, so it no longer leaks declarations onto the page
(LPD-93870).

## PR Check

**pr-check: PASS** — tested on `f4f6a31e3e19e117323d42445a0efdd7f7478833`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Workspace Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f4f6a31e3e19e117323d42445a0efdd7f7478833"} -->
