### PR TITLE
LPD-94146 Remove Notification Email from AI Hub configuration UI

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/AccountConfigurationPanel.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/AccountConfigurationPanel.tsx
@@ -41,21 +41,6 @@ export default function AccountConfigurationPanel({
 					value={values.environmentURLs}
 				/>
 			</FieldBase>
-
-			<FieldBase
-				id="recipientEmailAddress"
-				label={Liferay.Language.get('notification-email')}
-			>
-				<ClayInput
-					id="recipientEmailAddress"
-					name="recipientEmailAddress"
-					onChange={(event) =>
-						setField('recipientEmailAddress', event.target.value)
-					}
-					type="email"
-					value={values.recipientEmailAddress}
-				/>
-			</FieldBase>
 		</>
 	);
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/hooks/useConfigurationForm.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/hooks/useConfigurationForm.ts
@@ -29,7 +29,6 @@ export function useConfigurationForm({
 			initialValues: {
 				environmentURLs: '',
 				externalReferenceCode,
-				recipientEmailAddress: '',
 			},
 			onSubmit: async (formValues) => {
 				try {
@@ -82,8 +81,6 @@ export function useConfigurationForm({
 				setValues({
 					environmentURLs: configuration.environmentURLs || '',
 					externalReferenceCode,
-					recipientEmailAddress:
-						configuration.recipientEmailAddress || '',
 				});
 			})
 			.catch(() => {

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/types/Configuration.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/configuration_form/types/Configuration.ts
@@ -7,7 +7,6 @@ export type Configuration = {
 	environmentURLs: string;
 	externalReferenceCode: string;
 	r_accountToAIHubConfigurations_accountEntryId?: number;
-	recipientEmailAddress: string;
 };
 
 export type Credential = {

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/AccountConfigurationPanel.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/AccountConfigurationPanel.test.tsx
@@ -36,7 +36,6 @@ const defaultProps = {
 	values: {
 		environmentURLs: '',
 		externalReferenceCode: '',
-		recipientEmailAddress: '',
 	},
 };
 
@@ -62,26 +61,9 @@ describe('AccountConfigurationPanel', () => {
 		);
 	});
 
-	it('calls setField when the Notification Email changes', () => {
-		render(<AccountConfigurationPanel {...defaultProps} />);
-
-		fireEvent.change(screen.getByLabelText(/^notification-email/), {
-			target: {value: 'test@example.com'},
-		});
-
-		expect(mockSetField).toHaveBeenCalledWith(
-			'recipientEmailAddress',
-			'test@example.com'
-		);
-	});
-
-	it('renders the Environment URL and Notification Email fields', () => {
+	it('renders the Environment URL field', () => {
 		render(<AccountConfigurationPanel {...defaultProps} />);
 
 		expect(screen.getByLabelText(/^environment-url/)).toBeInTheDocument();
-
-		expect(
-			screen.getByLabelText(/^notification-email/)
-		).toBeInTheDocument();
 	});
 });

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/ConfigurationForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/ConfigurationForm.test.tsx
@@ -119,7 +119,6 @@ describe('ConfigurationForm', () => {
 		mockGetConfiguration.mockResolvedValueOnce({
 			environmentURLs: 'https://test.example.com',
 			externalReferenceCode: 'CONFIG_X',
-			recipientEmailAddress: 'test@example.com',
 		});
 
 		render(
@@ -134,10 +133,6 @@ describe('ConfigurationForm', () => {
 				screen.getByDisplayValue('https://test.example.com')
 			).toBeInTheDocument();
 		});
-
-		expect(
-			screen.getByDisplayValue('test@example.com')
-		).toBeInTheDocument();
 	});
 
 	it('renders the credentials panel when a clientId is provided', () => {
@@ -152,7 +147,6 @@ describe('ConfigurationForm', () => {
 		mockGetConfiguration.mockResolvedValueOnce({
 			environmentURLs: '',
 			externalReferenceCode: 'CONFIG_X',
-			recipientEmailAddress: '',
 		});
 
 		mockPutConfiguration.mockResolvedValueOnce({});
@@ -174,10 +168,6 @@ describe('ConfigurationForm', () => {
 			target: {value: 'https://www.example.com'},
 		});
 
-		fireEvent.change(screen.getByLabelText(/^notification-email/), {
-			target: {value: 'test@example.com'},
-		});
-
 		fireEvent.click(screen.getByRole('button', {name: 'save'}));
 
 		await waitFor(() => {
@@ -186,7 +176,6 @@ describe('ConfigurationForm', () => {
 				expect.objectContaining({
 					environmentURLs: 'https://www.example.com',
 					r_accountToAIHubConfigurations_accountEntryId: 12345,
-					recipientEmailAddress: 'test@example.com',
 				})
 			);
 		});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/hooks/useConfigurationForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/configuration_form/hooks/useConfigurationForm.test.tsx
@@ -45,7 +45,6 @@ function renderConfigurationHook({
 
 function fillFields(result: any) {
 	result.current.setField('environmentURLs', 'https://www.example.com');
-	result.current.setField('recipientEmailAddress', 'admin@example.com');
 }
 
 describe('fetch lifecycle', () => {
@@ -58,7 +57,6 @@ describe('fetch lifecycle', () => {
 		mockGetConfiguration.mockResolvedValueOnce({
 			environmentURLs: 'https://loaded.example.com',
 			externalReferenceCode: 'CONFIG_X',
-			recipientEmailAddress: 'loaded@example.com',
 		});
 
 		const {result} = renderConfigurationHook({
@@ -70,10 +68,6 @@ describe('fetch lifecycle', () => {
 				'https://loaded.example.com'
 			);
 		});
-
-		expect(result.current.values.recipientEmailAddress).toBe(
-			'loaded@example.com'
-		);
 
 		expect(result.current.values.externalReferenceCode).toBe('CONFIG_X');
 
@@ -121,8 +115,6 @@ describe('useConfigurationForm', () => {
 
 			expect(result.current.values.environmentURLs).toBe('');
 
-			expect(result.current.values.recipientEmailAddress).toBe('');
-
 			expect(result.current.values.externalReferenceCode).toBe('');
 		});
 	});
@@ -151,7 +143,7 @@ describe('useConfigurationForm', () => {
 			});
 		});
 
-		it('saves even when both fields are left empty', async () => {
+		it('saves even when the field is left empty', async () => {
 			mockPutConfiguration.mockResolvedValueOnce({});
 
 			const {result} = renderConfigurationHook({
@@ -167,7 +159,6 @@ describe('useConfigurationForm', () => {
 					'',
 					expect.objectContaining({
 						environmentURLs: '',
-						recipientEmailAddress: '',
 					})
 				);
 			});
@@ -195,7 +186,6 @@ describe('useConfigurationForm', () => {
 						environmentURLs: 'https://www.example.com',
 						r_accountToAIHubConfigurations_accountEntryId:
 							ACCOUNT_ENTRY_ID,
-						recipientEmailAddress: 'admin@example.com',
 					})
 				);
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94146

## What Is Being Fixed

The AI Hub account configuration form exposed a "Notification Email"
field (`recipientEmailAddress`) that should no longer be part of the
configuration UI.

## How It Is Being Fixed

Removed the Notification Email field from `AccountConfigurationPanel`. To
avoid leaving the property as dead state, `recipientEmailAddress` was also
dropped from the `Configuration` type and from the `useConfigurationForm`
hook — its initial value, the post-fetch hydration, and therefore the
submit payload — so the field is fully removed from the form's data
contract rather than just hidden. The `configuration_form` tests were
updated to drop the assertions tied to the removed field while keeping the
remaining behavior covered.

## PR Check

**pr-check: PASS** — tested on `ace4cf032781cab0bc9e315c13dadabb6220fe14`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ace4cf032781cab0bc9e315c13dadabb6220fe14"} -->

## Demo

<img width="1834" height="823" alt="image" src="https://github.com/user-attachments/assets/11d30a6d-44b6-4efb-a026-56992a47d50d" />
