### PR TITLE
LPD-94084 Prevent NPE when no AI Hub account is provisioned

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditConfigurationDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditConfigurationDisplayContext.java
@@ -51,6 +51,10 @@ public class EditConfigurationDisplayContext {
 		).put(
 			"clientId",
 			() -> {
+				if (accountEntry == null) {
+					return null;
+				}
+
 				OAuth2Application oAuth2Application =
 					_oAuth2ApplicationLocalService.
 						fetchOAuth2ApplicationByExternalReferenceCode(

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditConfigurationDisplayContextTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditConfigurationDisplayContextTest.java
@@ -100,6 +100,25 @@ public class EditConfigurationDisplayContextTest {
 				"1-ai-hub-configuration",
 				reactData.get("externalReferenceCode"));
 		}
+
+		try (MockedStatic<AccountEntryUtil> accountEntryUtilMockedStatic =
+				Mockito.mockStatic(AccountEntryUtil.class)) {
+
+			accountEntryUtilMockedStatic.when(
+				() -> AccountEntryUtil.getUserAccountEntry(Mockito.anyLong())
+			).thenReturn(
+				null
+			);
+
+			Map<String, Object> reactData =
+				_editConfigurationDisplayContext.getReactData();
+
+			Assert.assertNull(reactData.get("accountEntryId"));
+			Assert.assertEquals(
+				"http://localhost:8080/web/test", reactData.get("backURL"));
+			Assert.assertNull(reactData.get("clientId"));
+			Assert.assertNull(reactData.get("externalReferenceCode"));
+		}
 	}
 
 	private EditConfigurationDisplayContext _editConfigurationDisplayContext;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94084

## What Is Being Fixed

When a super admin (or any user without a provisioned customer environment) opens the AI Hub Configuration screen, the screen fails to load. The user has no AI Hub account yet, so AccountEntryUtil.getUserAccountEntry returns null, and the "clientId" entry of the screen's React data dereferenced that null account to build the OAuth2 application external reference code, throwing a NullPointerException.

## How It Is Being Fixed

The "clientId" supplier in EditConfigurationDisplayContext.getReactData now guards against a null account entry and returns null, mirroring the null checks already present in the "accountEntryId" and "externalReferenceCode" suppliers. A regression test reproduces the original NullPointerException when the account entry is null and verifies the screen data resolves with null credentials instead.

## PR Check

**pr-check: PASS** — tested on `ab49839936589adbfd71afd5f1b1fefc7ea0792d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

_Per-Module Deploy matched but was skipped at the developer's request (would redeploy into a running bundle)._

<!-- pr-check {"result": "success", "sha": "ab49839936589adbfd71afd5f1b1fefc7ea0792d"} -->
