### PR TITLE
LPD-94149 Calling provisioning endpoint twice for the same account ERC raise error

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
@@ -25,6 +25,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
@@ -121,6 +122,15 @@ public class ProvisioningRequestManagerImpl
 				companyId, "AIHubConfiguration");
 
 		if (objectDefinition == null) {
+			return;
+		}
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.fetchObjectEntry(
+				accountEntry.getAccountEntryId() + "-ai-hub-configuration", 0,
+				objectDefinition.getObjectDefinitionId());
+
+		if (serviceBuilderObjectEntry != null) {
 			return;
 		}
 
@@ -382,6 +392,9 @@ public class ProvisioningRequestManagerImpl
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference(target = "(object.entry.manager.storage.type=default)")
 	private ObjectEntryManager _objectEntryManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ProvisioningRequestResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ProvisioningRequestResourceTest.java
@@ -117,19 +117,19 @@ public class ProvisioningRequestResourceTest
 			}
 		};
 
-		ProvisioningRequest provisioningRequest = randomProvisioningRequest(
+		ProvisioningRequest provisioningRequest1 = randomProvisioningRequest(
 			userAccounts);
 
 		ProvisioningRequest postProvisioningRequest =
-			provisioningRequestResource.postProvisioning(provisioningRequest);
+			provisioningRequestResource.postProvisioning(provisioningRequest1);
 
-		assertEquals(provisioningRequest, postProvisioningRequest);
+		assertEquals(provisioningRequest1, postProvisioningRequest);
 
 		AccountEntry customerAccountEntry =
 			_accountEntryLocalService.getAccountEntry(
 				postProvisioningRequest.getAccountEntryId());
 
-		_assertAccountEntry(customerAccountEntry, provisioningRequest);
+		_assertAccountEntry(customerAccountEntry, provisioningRequest1);
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
@@ -148,12 +148,27 @@ public class ProvisioningRequestResourceTest
 
 		_assertServiceAccountUsers(aiHubAccountEntry, customerAccountEntry);
 
-		_assertOAuth2Application(customerAccountEntry, provisioningRequest);
+		_assertOAuth2Application(customerAccountEntry, provisioningRequest1);
 
 		_assertUserAccounts(
 			aiHubAccountEntry, customerAccountEntry,
-			provisioningRequest.getUserAccounts(),
+			provisioningRequest1.getUserAccounts(),
 			postProvisioningRequest.getUserAccounts());
+
+		ProvisioningRequest provisioningRequest2 =
+			provisioningRequestResource.postProvisioning(provisioningRequest1);
+
+		assertEquals(provisioningRequest1, provisioningRequest2);
+
+		Assert.assertEquals(
+			Long.valueOf(customerAccountEntry.getAccountEntryId()),
+			provisioningRequest2.getAccountEntryId());
+
+		Assert.assertNotNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				customerAccountEntry.getAccountEntryId() +
+					"-ai-hub-configuration",
+				0, objectDefinition.getObjectDefinitionId()));
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94149

## What Is Being Fixed

The provisioning request endpoint was not idempotent with respect to the AI Hub configuration object entry. When a provisioning request was sent for an account that already had its configuration object entry, the manager attempted to create it again. Because an object entry with that external reference code already exists, the repeated request failed instead of completing cleanly.

## How It Is Being Fixed

Before creating the configuration object entry, the manager now fetches it by its external reference code (`<accountEntryId>-ai-hub-configuration`) through ObjectEntryLocalService. When the entry already exists, the method returns early and leaves the existing configuration untouched. The integration test now posts the same provisioning request twice and asserts that the second call succeeds, returns the same account entry, and that the configuration object entry is present.

## PR Check

**pr-check: PASS** — tested on `81bc1f8498cd42019a4826cd922460d2fcdcff60`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "81bc1f8498cd42019a4826cd922460d2fcdcff60"} -->