### PR TITLE
LPD-93905 Show the latest agents and chatbots on the AI Hub homepage

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -45,8 +45,14 @@ async function getAgentDefinition(externalReferenceCode: string) {
 	return response.json();
 }
 
-async function getAgentDefinitions() {
-	const response = await fetch('/o/ai-hub/v1.0/agent-definitions', {
+async function getAgentDefinitions(params?: Record<string, string>) {
+	const baseURL = '/o/ai-hub/v1.0/agent-definitions';
+
+	const queryString = params ? new URLSearchParams(params).toString() : '';
+
+	const url = queryString ? `${baseURL}?${queryString}` : baseURL;
+
+	const response = await fetch(url, {
 		method: 'GET',
 	});
 

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
@@ -21,10 +21,10 @@ import {getAgentDefinitions} from '../agent_definition_form/services/AgentDefini
 import Toolbar from '../components/ToolBar';
 import {
 	disassociateChatbotFromAgentDefinition,
-	getChatbot,
-	postChatbot,
-	putChatbot,
+	getChatbotDefinition,
+	postChatbotDefinition,
 	putChatbotAgentDefinitionRelationship,
+	putChatbotDefinition,
 } from './services/ChatbotService';
 import {Chatbot} from './types/Chatbot';
 
@@ -275,10 +275,13 @@ export default function ChatbotForm({
 				existingChatbotExternalReferenceCode;
 
 			if (existingChatbotExternalReferenceCode) {
-				await putChatbot(existingChatbotExternalReferenceCode, payload);
+				await putChatbotDefinition(
+					existingChatbotExternalReferenceCode,
+					payload
+				);
 			}
 			else {
-				const created = await postChatbot(payload);
+				const created = await postChatbotDefinition(payload);
 
 				chatbotExternalReferenceCode = created.externalReferenceCode;
 
@@ -367,32 +370,39 @@ export default function ChatbotForm({
 			}
 
 			try {
-				const chatbot = await getChatbot(externalReferenceCode);
+				const chatbotDefinition = await getChatbotDefinition(
+					externalReferenceCode
+				);
 
 				const avatarAttachment =
-					chatbot.avatar && typeof chatbot.avatar === 'object'
-						? chatbot.avatar
+					chatbotDefinition.avatar &&
+					typeof chatbotDefinition.avatar === 'object'
+						? chatbotDefinition.avatar
 						: null;
 
 				setFormData({
-					active: chatbot.active ?? false,
+					active: chatbotDefinition.active ?? false,
 					avatar: avatarAttachment
 						? avatarAttachment.id
-						: chatbot.avatar,
+						: chatbotDefinition.avatar,
 					avatarFileName: avatarAttachment?.name,
-					description: chatbot.description,
-					disclaimerMessage_i18n: chatbot.disclaimerMessage_i18n,
-					externalReferenceCode: chatbot.externalReferenceCode,
-					introMessage_i18n: chatbot.introMessage_i18n,
-					notificationMessage_i18n: chatbot.notificationMessage_i18n,
-					placeholderMessage_i18n: chatbot.placeholderMessage_i18n,
+					description: chatbotDefinition.description,
+					disclaimerMessage_i18n:
+						chatbotDefinition.disclaimerMessage_i18n,
+					externalReferenceCode:
+						chatbotDefinition.externalReferenceCode,
+					introMessage_i18n: chatbotDefinition.introMessage_i18n,
+					notificationMessage_i18n:
+						chatbotDefinition.notificationMessage_i18n,
+					placeholderMessage_i18n:
+						chatbotDefinition.placeholderMessage_i18n,
 					r_accountToAIHubChatbots_accountEntryERC:
-						chatbot.r_accountToAIHubChatbots_accountEntryERC,
-					title_i18n: chatbot.title_i18n,
+						chatbotDefinition.r_accountToAIHubChatbots_accountEntryERC,
+					title_i18n: chatbotDefinition.title_i18n,
 				});
 
 				const agentDefinitions = (
-					chatbot.agentDefinitionsToChatbots ?? []
+					chatbotDefinition.agentDefinitionsToChatbots ?? []
 				).map((a: {externalReferenceCode: string; title: string}) => ({
 					externalReferenceCode: a.externalReferenceCode,
 					title: a.title,

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
@@ -30,7 +30,7 @@ async function disassociateChatbotFromAgentDefinition(
 	);
 }
 
-async function getChatbots(params?: Record<string, string>) {
+async function getChatbotDefinitions(params?: Record<string, string>) {
 	const queryString = params ? new URLSearchParams(params).toString() : '';
 
 	const url = queryString
@@ -49,7 +49,7 @@ async function getChatbots(params?: Record<string, string>) {
 	return response.json();
 }
 
-async function getChatbot(externalReferenceCode: string) {
+async function getChatbotDefinition(externalReferenceCode: string) {
 	const response = await fetch(
 		`${CHATBOT_BY_ERC_URI}${externalReferenceCode}?nestedFields=agentDefinitionsToChatbots`,
 		{
@@ -65,7 +65,7 @@ async function getChatbot(externalReferenceCode: string) {
 	return response.json();
 }
 
-async function postChatbot(chatbot: Chatbot) {
+async function postChatbotDefinition(chatbot: Chatbot) {
 	const response = await fetch(CHATBOT_BASE_URI, {
 		body: JSON.stringify(chatbot),
 		headers: HEADERS,
@@ -81,7 +81,7 @@ async function postChatbot(chatbot: Chatbot) {
 	return response.json();
 }
 
-async function putChatbot(
+async function putChatbotDefinition(
 	existingExternalReferenceCode: string,
 	chatbot: Chatbot
 ) {
@@ -118,9 +118,9 @@ async function putChatbotAgentDefinitionRelationship(
 
 export {
 	disassociateChatbotFromAgentDefinition,
-	getChatbot,
-	getChatbots,
-	postChatbot,
-	putChatbot,
+	getChatbotDefinition,
+	getChatbotDefinitions,
+	postChatbotDefinition,
 	putChatbotAgentDefinitionRelationship,
+	putChatbotDefinition,
 };

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
@@ -30,8 +30,14 @@ async function disassociateChatbotFromAgentDefinition(
 	);
 }
 
-async function getChatbots() {
-	const response = await fetch(CHATBOT_BASE_URI, {
+async function getChatbots(params?: Record<string, string>) {
+	const queryString = params ? new URLSearchParams(params).toString() : '';
+
+	const url = queryString
+		? `${CHATBOT_BASE_URI}?${queryString}`
+		: CHATBOT_BASE_URI;
+
+	const response = await fetch(url, {
 		headers: HEADERS,
 		method: 'GET',
 	});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
@@ -6,7 +6,7 @@
 import React, {useEffect, useState} from 'react';
 
 import {getAgentDefinitions} from '../agent_definition_form/services/AgentDefinitionService';
-import {getChatbots} from '../chatbot_form/services/ChatbotService';
+import {getChatbotDefinitions} from '../chatbot_form/services/ChatbotService';
 import DashboardCard from './components/DashboardCard';
 import DashboardCardSkeleton from './components/DashboardCardSkeleton';
 
@@ -74,7 +74,7 @@ export default function HomeDashboard({
 				}
 			});
 
-		getChatbots({pageSize: '4', sort: 'dateModified:desc'})
+		getChatbotDefinitions({pageSize: '4', sort: 'dateModified:desc'})
 			.then((data) => {
 				if (isMounted) {
 					setChatbots(data?.items ?? []);

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
@@ -62,7 +62,7 @@ export default function HomeDashboard({
 	useEffect(() => {
 		let isMounted = true;
 
-		getAgentDefinitions()
+		getAgentDefinitions({pageSize: '4', sort: 'dateModified:desc'})
 			.then((data) => {
 				if (isMounted) {
 					setAgents(data?.items ?? []);
@@ -74,7 +74,7 @@ export default function HomeDashboard({
 				}
 			});
 
-		getChatbots()
+		getChatbots({pageSize: '4', sort: 'dateModified:desc'})
 			.then((data) => {
 				if (isMounted) {
 					setChatbots(data?.items ?? []);
@@ -163,7 +163,7 @@ export default function HomeDashboard({
 						title={item.title}
 					/>
 				)}
-				take={3}
+				take={4}
 				title={Liferay.Language.get('latest-chatbots')}
 			/>
 		</div>

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
@@ -19,15 +19,18 @@ describe('AgentDefinitionService', () => {
 	});
 
 	describe('getAgentDefinitions', () => {
-		it('targets the base endpoint when no params are given', async () => {
+		it('appends sort and page size params as a query string', async () => {
 			mockFetch.mockResolvedValueOnce({
 				json: () => Promise.resolve({items: []}),
 			});
 
-			await getAgentDefinitions();
+			await getAgentDefinitions({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				BASE_URI,
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
 				expect.objectContaining({method: 'GET'})
 			);
 		});
@@ -45,18 +48,15 @@ describe('AgentDefinitionService', () => {
 			);
 		});
 
-		it('appends sort and page size params as a query string', async () => {
+		it('targets the base endpoint when no params are given', async () => {
 			mockFetch.mockResolvedValueOnce({
 				json: () => Promise.resolve({items: []}),
 			});
 
-			await getAgentDefinitions({
-				pageSize: '4',
-				sort: 'dateModified:desc',
-			});
+			await getAgentDefinitions();
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				BASE_URI,
 				expect.objectContaining({method: 'GET'})
 			);
 		});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getAgentDefinitions} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService';
+
+const mockFetch = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	fetch: (...args: any[]) => mockFetch(...args),
+}));
+
+const BASE_URI = '/o/ai-hub/v1.0/agent-definitions';
+
+describe('AgentDefinitionService', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	describe('getAgentDefinitions', () => {
+		it('targets the base endpoint when no params are given', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			});
+
+			await getAgentDefinitions();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('does not append a trailing question mark for empty params', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			});
+
+			await getAgentDefinitions({});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('appends sort and page size params as a query string', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			});
+
+			await getAgentDefinitions({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/ChatbotForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/ChatbotForm.test.tsx
@@ -16,9 +16,9 @@ import '@testing-library/jest-dom';
 
 import ChatbotForm from '../../../src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm';
 
-const mockGetChatbot = jest.fn();
-const mockPostChatbot = jest.fn();
-const mockPutChatbot = jest.fn();
+const mockGetChatbotDefinition = jest.fn();
+const mockPostChatbotDefinition = jest.fn();
+const mockPutChatbotDefinition = jest.fn();
 const mockOpenToast = jest.fn();
 
 jest.mock(
@@ -32,10 +32,13 @@ jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService',
 	() => ({
 		disassociateChatbotFromAgentDefinition: jest.fn().mockResolvedValue({}),
-		getChatbot: (...args: any[]) => mockGetChatbot(...args),
-		postChatbot: (...args: any[]) => mockPostChatbot(...args),
-		putChatbot: (...args: any[]) => mockPutChatbot(...args),
+		getChatbotDefinition: (...args: any[]) =>
+			mockGetChatbotDefinition(...args),
+		postChatbotDefinition: (...args: any[]) =>
+			mockPostChatbotDefinition(...args),
 		putChatbotAgentDefinitionRelationship: jest.fn().mockResolvedValue({}),
+		putChatbotDefinition: (...args: any[]) =>
+			mockPutChatbotDefinition(...args),
 	})
 );
 
@@ -117,9 +120,9 @@ function makeFile(name: string, sizeInBytes: number, type = 'image/png'): File {
 describe('ChatbotForm company logo upload', () => {
 	beforeEach(() => {
 		mockOpenToast.mockClear();
-		mockGetChatbot.mockReset();
-		mockPostChatbot.mockReset();
-		mockPutChatbot.mockReset();
+		mockGetChatbotDefinition.mockReset();
+		mockPostChatbotDefinition.mockReset();
+		mockPutChatbotDefinition.mockReset();
 	});
 
 	afterEach(() => {
@@ -194,9 +197,9 @@ describe('ChatbotForm company logo upload', () => {
 describe('ChatbotForm disclaimer message', () => {
 	beforeEach(() => {
 		mockOpenToast.mockClear();
-		mockGetChatbot.mockReset();
-		mockPostChatbot.mockReset();
-		mockPutChatbot.mockReset();
+		mockGetChatbotDefinition.mockReset();
+		mockPostChatbotDefinition.mockReset();
+		mockPutChatbotDefinition.mockReset();
 	});
 
 	afterEach(() => {
@@ -204,7 +207,7 @@ describe('ChatbotForm disclaimer message', () => {
 	});
 
 	it('submits with an empty disclaimer when the admin never fills it', async () => {
-		mockPostChatbot.mockResolvedValue({
+		mockPostChatbotDefinition.mockResolvedValue({
 			externalReferenceCode: 'CHATBOT-ERC',
 		});
 
@@ -214,15 +217,17 @@ describe('ChatbotForm disclaimer message', () => {
 
 		fireEvent.click(screen.getByRole('button', {name: 'save'}));
 
-		await waitFor(() => expect(mockPostChatbot).toHaveBeenCalled());
-
-		expect(mockPostChatbot.mock.calls[0][0].disclaimerMessage_i18n).toEqual(
-			{}
+		await waitFor(() =>
+			expect(mockPostChatbotDefinition).toHaveBeenCalled()
 		);
+
+		expect(
+			mockPostChatbotDefinition.mock.calls[0][0].disclaimerMessage_i18n
+		).toEqual({});
 	});
 
 	it('sends the typed disclaimer through to the API payload', async () => {
-		mockPostChatbot.mockResolvedValue({
+		mockPostChatbotDefinition.mockResolvedValue({
 			externalReferenceCode: 'CHATBOT-ERC',
 		});
 
@@ -234,10 +239,12 @@ describe('ChatbotForm disclaimer message', () => {
 
 		fireEvent.click(screen.getByRole('button', {name: 'save'}));
 
-		await waitFor(() => expect(mockPostChatbot).toHaveBeenCalled());
-
-		expect(mockPostChatbot.mock.calls[0][0].disclaimerMessage_i18n).toEqual(
-			{en_US: 'Custom disclaimer'}
+		await waitFor(() =>
+			expect(mockPostChatbotDefinition).toHaveBeenCalled()
 		);
+
+		expect(
+			mockPostChatbotDefinition.mock.calls[0][0].disclaimerMessage_i18n
+		).toEqual({en_US: 'Custom disclaimer'});
 	});
 });

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getChatbots} from '../../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService';
+
+const mockFetch = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	fetch: (...args: any[]) => mockFetch(...args),
+}));
+
+(global as any).Liferay = {
+	ThemeDisplay: {
+		getBCP47LanguageId: () => 'en-US',
+	},
+};
+
+const BASE_URI = '/o/ai-hub/chatbots';
+
+describe('ChatbotService', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	describe('getChatbots', () => {
+		it('targets the base endpoint when no params are given', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+				ok: true,
+			});
+
+			await getChatbots();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('does not append a trailing question mark for empty params', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+				ok: true,
+			});
+
+			await getChatbots({});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('appends sort and page size params as a query string', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+				ok: true,
+			});
+
+			await getChatbots({pageSize: '4', sort: 'dateModified:desc'});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('throws when the response is not ok', async () => {
+			mockFetch.mockResolvedValueOnce({ok: false});
+
+			await expect(getChatbots()).rejects.toThrow();
+		});
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {getChatbots} from '../../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService';
+import {getChatbotDefinitions} from '../../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService';
 
 const mockFetch = jest.fn();
 
@@ -24,17 +24,20 @@ describe('ChatbotService', () => {
 		mockFetch.mockReset();
 	});
 
-	describe('getChatbots', () => {
-		it('targets the base endpoint when no params are given', async () => {
+	describe('getChatbotDefinitions', () => {
+		it('appends sort and page size params as a query string', async () => {
 			mockFetch.mockResolvedValueOnce({
 				json: () => Promise.resolve({items: []}),
 				ok: true,
 			});
 
-			await getChatbots();
+			await getChatbotDefinitions({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				BASE_URI,
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
 				expect.objectContaining({method: 'GET'})
 			);
 		});
@@ -45,7 +48,7 @@ describe('ChatbotService', () => {
 				ok: true,
 			});
 
-			await getChatbots({});
+			await getChatbotDefinitions({});
 
 			expect(mockFetch).toHaveBeenCalledWith(
 				BASE_URI,
@@ -53,16 +56,16 @@ describe('ChatbotService', () => {
 			);
 		});
 
-		it('appends sort and page size params as a query string', async () => {
+		it('targets the base endpoint when no params are given', async () => {
 			mockFetch.mockResolvedValueOnce({
 				json: () => Promise.resolve({items: []}),
 				ok: true,
 			});
 
-			await getChatbots({pageSize: '4', sort: 'dateModified:desc'});
+			await getChatbotDefinitions();
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				BASE_URI,
 				expect.objectContaining({method: 'GET'})
 			);
 		});
@@ -70,7 +73,7 @@ describe('ChatbotService', () => {
 		it('throws when the response is not ok', async () => {
 			mockFetch.mockResolvedValueOnce({ok: false});
 
-			await expect(getChatbots()).rejects.toThrow();
+			await expect(getChatbotDefinitions()).rejects.toThrow();
 		});
 	});
 });

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom';
 import HomeDashboard from '../../../src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard';
 
 const mockGetAgentDefinitions = jest.fn();
-const mockGetChatbots = jest.fn();
+const mockGetChatbotDefinitions = jest.fn();
 
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService',
@@ -24,7 +24,8 @@ jest.mock(
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService',
 	() => ({
-		getChatbots: (...args: any[]) => mockGetChatbots(...args),
+		getChatbotDefinitions: (...args: any[]) =>
+			mockGetChatbotDefinitions(...args),
 	})
 );
 
@@ -75,7 +76,7 @@ describe('HomeDashboard', () => {
 				},
 			],
 		});
-		mockGetChatbots.mockResolvedValue({items: []});
+		mockGetChatbotDefinitions.mockResolvedValue({items: []});
 
 		render(<HomeDashboard {...defaultProps} />);
 
@@ -97,7 +98,7 @@ describe('HomeDashboard', () => {
 				},
 			],
 		});
-		mockGetChatbots.mockResolvedValue({items: []});
+		mockGetChatbotDefinitions.mockResolvedValue({items: []});
 
 		render(<HomeDashboard {...defaultProps} />);
 
@@ -111,7 +112,7 @@ describe('HomeDashboard', () => {
 
 	it('never adds the workflow definition name to chatbot links', async () => {
 		mockGetAgentDefinitions.mockResolvedValue({items: []});
-		mockGetChatbots.mockResolvedValue({
+		mockGetChatbotDefinitions.mockResolvedValue({
 			items: [
 				{
 					active: true,
@@ -133,7 +134,7 @@ describe('HomeDashboard', () => {
 
 	it('requests the latest agents and chatbots sorted by modification date', async () => {
 		mockGetAgentDefinitions.mockResolvedValue({items: []});
-		mockGetChatbots.mockResolvedValue({items: []});
+		mockGetChatbotDefinitions.mockResolvedValue({items: []});
 
 		render(<HomeDashboard {...defaultProps} />);
 
@@ -144,7 +145,7 @@ describe('HomeDashboard', () => {
 			});
 		});
 
-		expect(mockGetChatbots).toHaveBeenCalledWith({
+		expect(mockGetChatbotDefinitions).toHaveBeenCalledWith({
 			pageSize: '4',
 			sort: 'dateModified:desc',
 		});
@@ -152,7 +153,9 @@ describe('HomeDashboard', () => {
 
 	it('renders up to four chatbots in the order returned by the server', async () => {
 		mockGetAgentDefinitions.mockResolvedValue({items: []});
-		mockGetChatbots.mockResolvedValue({items: buildItems('Chatbot', 5)});
+		mockGetChatbotDefinitions.mockResolvedValue({
+			items: buildItems('Chatbot', 5),
+		});
 
 		render(<HomeDashboard {...defaultProps} />);
 
@@ -170,7 +173,7 @@ describe('HomeDashboard', () => {
 		mockGetAgentDefinitions.mockResolvedValue({
 			items: buildItems('Agent', 5),
 		});
-		mockGetChatbots.mockResolvedValue({items: []});
+		mockGetChatbotDefinitions.mockResolvedValue({items: []});
 
 		render(<HomeDashboard {...defaultProps} />);
 

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
@@ -43,6 +43,14 @@ const defaultProps = {
 	chatbotsURL: 'http://localhost:8080/web/ai-hub/chatbots',
 };
 
+function buildItems(prefix: string, count: number) {
+	return Array.from({length: count}, (_, index) => ({
+		active: true,
+		externalReferenceCode: `${prefix}_${index}`,
+		title: `${prefix} ${index}`,
+	}));
+}
+
 function getCardHref(title: string): string {
 	const link = screen.getByText(title).closest('a');
 
@@ -121,5 +129,56 @@ describe('HomeDashboard', () => {
 
 		expect(href).toContain('externalReferenceCode=L_SUPPORT_BOT');
 		expect(href).not.toContain('workflowDefinitionName');
+	});
+
+	it('requests the latest agents and chatbots sorted by modification date', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({items: []});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(mockGetAgentDefinitions).toHaveBeenCalledWith({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
+		});
+
+		expect(mockGetChatbots).toHaveBeenCalledWith({
+			pageSize: '4',
+			sort: 'dateModified:desc',
+		});
+	});
+
+	it('renders up to four chatbots in the order returned by the server', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({items: []});
+		mockGetChatbots.mockResolvedValue({items: buildItems('Chatbot', 5)});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Chatbot 0')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('Chatbot 1')).toBeInTheDocument();
+		expect(screen.getByText('Chatbot 2')).toBeInTheDocument();
+		expect(screen.getByText('Chatbot 3')).toBeInTheDocument();
+		expect(screen.queryByText('Chatbot 4')).not.toBeInTheDocument();
+	});
+
+	it('renders up to four agents', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({
+			items: buildItems('Agent', 5),
+		});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Agent 0')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('Agent 3')).toBeInTheDocument();
+		expect(screen.queryByText('Agent 4')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93905

## What Is Being Fixed

On the AI Hub homepage, the "Latest Agents" and "Latest Chatbots" lists did not show the most recent entries. The agents list was never sorted by modification date, so newly created or duplicated agents never appeared and it always showed the same oldest four. The chatbots list had the same sorting problem (oldest to latest) and additionally capped its display at three items instead of four.

## How It Is Being Fixed

The homepage requested both lists from their REST endpoints without a sort or page size and then sliced the first few entries on the client, which returned them in creation order. The fix passes query parameters so the server returns the entries already sorted by modification date in descending order and limited to a page size of four. The `getAgentDefinitions` and `getChatbots` services now accept an optional params argument that is appended as a query string, leaving their existing callers unchanged. The chatbots section's display limit was also corrected from three to four to match the agents section.

## PR Check

**pr-check: PASS** — tested on `31839c68d75d24d0e66522a69edc91c38549b130`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "31839c68d75d24d0e66522a69edc91c38549b130"} -->