### PR TITLE
LPD-93999 Fix missing citation URL in Elasticsearch content retriever

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
@@ -57,7 +57,8 @@ public class ElasticsearchContentRetriever extends BaseContentRetriever {
 
 		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
 
-		searchSearchRequest.setFetchSource(false);
+		searchSearchRequest.setFetchSource(true);
+		searchSearchRequest.setFetchSourceIncludes(new String[] {"url"});
 		searchSearchRequest.setHighlight(
 			_highlightBuilderFactory.builder(
 			).addFieldConfig(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
@@ -5,16 +5,12 @@
 
 package com.liferay.ai.hub.internal.langchain4j.rag.content.retriever;
 
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
-import com.liferay.portal.search.highlight.FieldConfig;
 import com.liferay.portal.search.highlight.FieldConfigBuilder;
 import com.liferay.portal.search.highlight.FieldConfigBuilderFactory;
-import com.liferay.portal.search.highlight.Highlight;
 import com.liferay.portal.search.highlight.HighlightBuilder;
 import com.liferay.portal.search.highlight.HighlightBuilderFactory;
 import com.liferay.portal.search.highlight.HighlightField;
@@ -36,7 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -51,65 +46,35 @@ public class ElasticsearchContentRetrieverTest {
 
 	@Before
 	public void setUp() {
-		_searchEngineAdapter = Mockito.mock(SearchEngineAdapter.class);
-
-		_elasticsearchContentRetriever = new ElasticsearchContentRetriever(
-			_mockFieldConfigBuilderFactory(), _mockHighlightBuilderFactory(),
-			new String[] {RandomTestUtil.randomString()}, _searchEngineAdapter,
-			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
+		_setUpFieldConfigBuilderFactory();
+		_setUpHighlightBuilderFactory();
+		_setUpSearchEngineAdapter();
 	}
 
 	@Test
-	public void testSearchFetchesURLSourceField() {
-		try (MockedStatic<JSONUtil> jsonUtilMockedStatic = Mockito.mockStatic(
-				JSONUtil.class)) {
+	public void testSearch() {
+		ElasticsearchContentRetriever elasticsearchContentRetriever =
+			new ElasticsearchContentRetriever(
+				_fieldConfigBuilderFactory, _highlightBuilderFactory,
+				new String[] {RandomTestUtil.randomString()},
+				_searchEngineAdapter, RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLong());
 
-			JSONObject jsonObject = Mockito.mock(JSONObject.class);
+		List<Content> contents = elasticsearchContentRetriever.search(
+			Mockito.mock(Query.class));
 
-			Mockito.when(
-				jsonObject.toString()
-			).thenReturn(
-				"{}"
-			);
+		Assert.assertEquals(contents.toString(), 1, contents.size());
 
-			jsonUtilMockedStatic.when(
-				() -> JSONUtil.put(Mockito.anyString(), (Object)Mockito.any())
-			).thenReturn(
-				jsonObject
-			);
+		Content content = contents.get(0);
 
-			Content content = _retrieveSingleContent(
-				"https://learn.liferay.com/w/dxp/low-code/objects",
-				"Liferay Objects let you build no-code applications.");
+		Assert.assertEquals(
+			_URL,
+			content.textSegment(
+			).metadata(
+			).getString(
+				"url"
+			));
 
-			// The retrieved URL must reach the chunk metadata so the content
-			// injector can append it at the end of the text segment for the
-			// model to cite (LPD-93999).
-
-			Assert.assertEquals(
-				"https://learn.liferay.com/w/dxp/low-code/objects",
-				content.textSegment(
-				).metadata(
-				).getString(
-					"url"
-				));
-
-			// The request must enable source fetching and restrict it to the
-			// "url" field. Reading "url" from the sources map while source
-			// fetching is disabled silently drops the URL.
-
-			SearchSearchRequest searchSearchRequest =
-				_captureSearchSearchRequest();
-
-			Assert.assertEquals(
-				Boolean.TRUE, searchSearchRequest.getFetchSource());
-			Assert.assertEquals(
-				Arrays.toString(new String[] {"url"}),
-				Arrays.toString(searchSearchRequest.getFetchSourceIncludes()));
-		}
-	}
-
-	private SearchSearchRequest _captureSearchSearchRequest() {
 		ArgumentCaptor<SearchSearchRequest> argumentCaptor =
 			ArgumentCaptor.forClass(SearchSearchRequest.class);
 
@@ -119,40 +84,28 @@ public class ElasticsearchContentRetrieverTest {
 			argumentCaptor.capture()
 		);
 
-		return argumentCaptor.getValue();
+		SearchSearchRequest searchSearchRequest = argumentCaptor.getValue();
+
+		Assert.assertEquals(Boolean.TRUE, searchSearchRequest.getFetchSource());
+		Assert.assertEquals(
+			Arrays.toString(new String[] {"url"}),
+			Arrays.toString(searchSearchRequest.getFetchSourceIncludes()));
 	}
 
-	private FieldConfigBuilderFactory _mockFieldConfigBuilderFactory() {
-		FieldConfigBuilderFactory fieldConfigBuilderFactory = Mockito.mock(
-			FieldConfigBuilderFactory.class);
-
-		FieldConfigBuilder fieldConfigBuilder = Mockito.mock(
-			FieldConfigBuilder.class);
-
+	private void _setUpFieldConfigBuilderFactory() {
 		Mockito.when(
-			fieldConfigBuilderFactory.builder(Mockito.anyString())
+			_fieldConfigBuilderFactory.builder(Mockito.anyString())
 		).thenReturn(
-			fieldConfigBuilder
+			Mockito.mock(FieldConfigBuilder.class)
 		);
-
-		Mockito.when(
-			fieldConfigBuilder.build()
-		).thenReturn(
-			Mockito.mock(FieldConfig.class)
-		);
-
-		return fieldConfigBuilderFactory;
 	}
 
-	private HighlightBuilderFactory _mockHighlightBuilderFactory() {
-		HighlightBuilderFactory highlightBuilderFactory = Mockito.mock(
-			HighlightBuilderFactory.class);
-
+	private void _setUpHighlightBuilderFactory() {
 		HighlightBuilder highlightBuilder = Mockito.mock(
 			HighlightBuilder.class);
 
 		Mockito.when(
-			highlightBuilderFactory.builder()
+			_highlightBuilderFactory.builder()
 		).thenReturn(
 			highlightBuilder
 		);
@@ -162,23 +115,15 @@ public class ElasticsearchContentRetrieverTest {
 		).thenReturn(
 			highlightBuilder
 		);
-
-		Mockito.when(
-			highlightBuilder.build()
-		).thenReturn(
-			Mockito.mock(Highlight.class)
-		);
-
-		return highlightBuilderFactory;
 	}
 
-	private Content _retrieveSingleContent(String url, String fragment) {
+	private void _setUpSearchEngineAdapter() {
 		HighlightField highlightField = Mockito.mock(HighlightField.class);
 
 		Mockito.when(
 			highlightField.getFragments()
 		).thenReturn(
-			List.of(fragment)
+			List.of(RandomTestUtil.randomString())
 		);
 
 		SearchHit searchHit = Mockito.mock(SearchHit.class);
@@ -192,7 +137,7 @@ public class ElasticsearchContentRetrieverTest {
 		Mockito.when(
 			searchHit.getSourcesMap()
 		).thenReturn(
-			Map.of("url", url)
+			Map.of("url", _URL)
 		);
 
 		SearchHits searchHits = Mockito.mock(SearchHits.class);
@@ -219,23 +164,15 @@ public class ElasticsearchContentRetrieverTest {
 		).execute(
 			Mockito.any(SearchSearchRequest.class)
 		);
-
-		Query query = Mockito.mock(Query.class);
-
-		Mockito.when(
-			query.text()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		List<Content> contents = _elasticsearchContentRetriever.search(query);
-
-		Assert.assertEquals(contents.toString(), 1, contents.size());
-
-		return contents.get(0);
 	}
 
-	private ElasticsearchContentRetriever _elasticsearchContentRetriever;
-	private SearchEngineAdapter _searchEngineAdapter;
+	private static final String _URL = RandomTestUtil.randomString();
+
+	private final FieldConfigBuilderFactory _fieldConfigBuilderFactory =
+		Mockito.mock(FieldConfigBuilderFactory.class);
+	private final HighlightBuilderFactory _highlightBuilderFactory =
+		Mockito.mock(HighlightBuilderFactory.class);
+	private final SearchEngineAdapter _searchEngineAdapter = Mockito.mock(
+		SearchEngineAdapter.class);
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.langchain4j.rag.content.retriever;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
+import com.liferay.portal.search.highlight.FieldConfig;
+import com.liferay.portal.search.highlight.FieldConfigBuilder;
+import com.liferay.portal.search.highlight.FieldConfigBuilderFactory;
+import com.liferay.portal.search.highlight.Highlight;
+import com.liferay.portal.search.highlight.HighlightBuilder;
+import com.liferay.portal.search.highlight.HighlightBuilderFactory;
+import com.liferay.portal.search.highlight.HighlightField;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Iliyan Peychev
+ */
+public class ElasticsearchContentRetrieverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_searchEngineAdapter = Mockito.mock(SearchEngineAdapter.class);
+
+		_elasticsearchContentRetriever = new ElasticsearchContentRetriever(
+			_mockFieldConfigBuilderFactory(), _mockHighlightBuilderFactory(),
+			new String[] {RandomTestUtil.randomString()}, _searchEngineAdapter,
+			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testSearchFetchesURLSourceField() {
+		try (MockedStatic<JSONUtil> jsonUtilMockedStatic = Mockito.mockStatic(
+				JSONUtil.class)) {
+
+			JSONObject jsonObject = Mockito.mock(JSONObject.class);
+
+			Mockito.when(
+				jsonObject.toString()
+			).thenReturn(
+				"{}"
+			);
+
+			jsonUtilMockedStatic.when(
+				() -> JSONUtil.put(Mockito.anyString(), (Object)Mockito.any())
+			).thenReturn(
+				jsonObject
+			);
+
+			Content content = _retrieveSingleContent(
+				"https://learn.liferay.com/w/dxp/low-code/objects",
+				"Liferay Objects let you build no-code applications.");
+
+			// The retrieved URL must reach the chunk metadata so the content
+			// injector can append it at the end of the text segment for the
+			// model to cite (LPD-93999).
+
+			Assert.assertEquals(
+				"https://learn.liferay.com/w/dxp/low-code/objects",
+				content.textSegment(
+				).metadata(
+				).getString(
+					"url"
+				));
+
+			// The request must enable source fetching and restrict it to the
+			// "url" field. Reading "url" from the sources map while source
+			// fetching is disabled silently drops the URL.
+
+			SearchSearchRequest searchSearchRequest =
+				_captureSearchSearchRequest();
+
+			Assert.assertEquals(
+				Boolean.TRUE, searchSearchRequest.getFetchSource());
+			Assert.assertEquals(
+				Arrays.toString(new String[] {"url"}),
+				Arrays.toString(searchSearchRequest.getFetchSourceIncludes()));
+		}
+	}
+
+	private SearchSearchRequest _captureSearchSearchRequest() {
+		ArgumentCaptor<SearchSearchRequest> argumentCaptor =
+			ArgumentCaptor.forClass(SearchSearchRequest.class);
+
+		Mockito.verify(
+			_searchEngineAdapter
+		).execute(
+			argumentCaptor.capture()
+		);
+
+		return argumentCaptor.getValue();
+	}
+
+	private FieldConfigBuilderFactory _mockFieldConfigBuilderFactory() {
+		FieldConfigBuilderFactory fieldConfigBuilderFactory = Mockito.mock(
+			FieldConfigBuilderFactory.class);
+
+		FieldConfigBuilder fieldConfigBuilder = Mockito.mock(
+			FieldConfigBuilder.class);
+
+		Mockito.when(
+			fieldConfigBuilderFactory.builder(Mockito.anyString())
+		).thenReturn(
+			fieldConfigBuilder
+		);
+
+		Mockito.when(
+			fieldConfigBuilder.build()
+		).thenReturn(
+			Mockito.mock(FieldConfig.class)
+		);
+
+		return fieldConfigBuilderFactory;
+	}
+
+	private HighlightBuilderFactory _mockHighlightBuilderFactory() {
+		HighlightBuilderFactory highlightBuilderFactory = Mockito.mock(
+			HighlightBuilderFactory.class);
+
+		HighlightBuilder highlightBuilder = Mockito.mock(
+			HighlightBuilder.class);
+
+		Mockito.when(
+			highlightBuilderFactory.builder()
+		).thenReturn(
+			highlightBuilder
+		);
+
+		Mockito.when(
+			highlightBuilder.addFieldConfig(Mockito.any())
+		).thenReturn(
+			highlightBuilder
+		);
+
+		Mockito.when(
+			highlightBuilder.build()
+		).thenReturn(
+			Mockito.mock(Highlight.class)
+		);
+
+		return highlightBuilderFactory;
+	}
+
+	private Content _retrieveSingleContent(String url, String fragment) {
+		HighlightField highlightField = Mockito.mock(HighlightField.class);
+
+		Mockito.when(
+			highlightField.getFragments()
+		).thenReturn(
+			List.of(fragment)
+		);
+
+		SearchHit searchHit = Mockito.mock(SearchHit.class);
+
+		Mockito.when(
+			searchHit.getHighlightFieldsMap()
+		).thenReturn(
+			Map.of("text_embedding", highlightField)
+		);
+
+		Mockito.when(
+			searchHit.getSourcesMap()
+		).thenReturn(
+			Map.of("url", url)
+		);
+
+		SearchHits searchHits = Mockito.mock(SearchHits.class);
+
+		Mockito.when(
+			searchHits.getSearchHits()
+		).thenReturn(
+			List.of(searchHit)
+		);
+
+		SearchSearchResponse searchSearchResponse = Mockito.mock(
+			SearchSearchResponse.class);
+
+		Mockito.when(
+			searchSearchResponse.getSearchHits()
+		).thenReturn(
+			searchHits
+		);
+
+		Mockito.doReturn(
+			searchSearchResponse
+		).when(
+			_searchEngineAdapter
+		).execute(
+			Mockito.any(SearchSearchRequest.class)
+		);
+
+		Query query = Mockito.mock(Query.class);
+
+		Mockito.when(
+			query.text()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		List<Content> contents = _elasticsearchContentRetriever.search(query);
+
+		Assert.assertEquals(contents.toString(), 1, contents.size());
+
+		return contents.get(0);
+	}
+
+	private ElasticsearchContentRetriever _elasticsearchContentRetriever;
+	private SearchEngineAdapter _searchEngineAdapter;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93999

## What Is Being Fixed

The AI Hub chatbot (e.g. learn-uat) hallucinates documentation URLs — citing plausible but nonexistent paths like /w/dxp/platform/objects. The root cause is in the RAG layer, not the crawler: ElasticsearchContentRetriever disabled source fetching on the search request yet read the "url" field from the result's source map, so the URL was always empty. With no real link in the retrieved chunks, the model has nothing to cite and invents one.

## How It Is Being Fixed

Source fetching is enabled on the search request and restricted to the "url" field via setFetchSourceIncludes, so the crawler-stored URL is returned without pulling the large text embedding vector into the response. The URL then flows into the chunk metadata, which the content injector (metadataKeysToInclude "url") appends to the end of each text segment for the model to cite. A new ElasticsearchContentRetrieverTest asserts the request fetches only the "url" source field and that the retrieved URL reaches the chunk metadata.

## PR Check

**pr-check: PASS** — tested on `048e37977144eae66b43e838f44f80d47d8080b1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "048e37977144eae66b43e838f44f80d47d8080b1"} -->