### PR TITLE
LPD-94271 When accessing to workflow from AI Hub Home, it goes to a different workflow

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
@@ -15,6 +15,7 @@ interface Entry {
 	description?: string;
 	externalReferenceCode: string;
 	title: string;
+	workflowDefinitionName?: string;
 }
 
 interface HomeDashboardProps {
@@ -34,9 +35,14 @@ function appendBackURL(url: string, backURL: string) {
 function appendEntryParams(
 	url: string,
 	externalReferenceCode: string,
-	backURL: string
+	backURL: string,
+	workflowDefinitionName?: string
 ) {
 	const params = new URLSearchParams({backURL, externalReferenceCode});
+
+	if (workflowDefinitionName) {
+		params.set('workflowDefinitionName', workflowDefinitionName);
+	}
 
 	return `${url}?${params.toString()}`;
 }
@@ -123,7 +129,8 @@ export default function HomeDashboard({
 						detailURL={appendEntryParams(
 							agentURL,
 							item.externalReferenceCode,
-							backURL
+							backURL,
+							item.workflowDefinitionName
 						)}
 						key={item.externalReferenceCode}
 						title={item.title}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {cleanup, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import HomeDashboard from '../../../src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard';
+
+const mockGetAgentDefinitions = jest.fn();
+const mockGetChatbots = jest.fn();
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService',
+	() => ({
+		getAgentDefinitions: (...args: any[]) =>
+			mockGetAgentDefinitions(...args),
+	})
+);
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService',
+	() => ({
+		getChatbots: (...args: any[]) => mockGetChatbots(...args),
+	})
+);
+
+(global as any).Liferay = {
+	Icons: {spritemap: 'icons.svg'},
+	Language: {
+		get: (key: string) => key,
+	},
+};
+
+const defaultProps = {
+	agentBuilderURL: 'http://localhost:8080/web/ai-hub/agent-builder',
+	agentURL: 'http://localhost:8080/web/ai-hub/agent',
+	backURL: 'http://localhost:8080/web/ai-hub',
+	chatbotURL: 'http://localhost:8080/web/ai-hub/chatbot',
+	chatbotsURL: 'http://localhost:8080/web/ai-hub/chatbots',
+};
+
+function getCardHref(title: string): string {
+	const link = screen.getByText(title).closest('a');
+
+	return link?.getAttribute('href') ?? '';
+}
+
+describe('HomeDashboard', () => {
+	afterEach(() => {
+		cleanup();
+
+		jest.clearAllMocks();
+	});
+
+	it('passes the workflow definition name in the agent link', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({
+			items: [
+				{
+					active: true,
+					externalReferenceCode: 'L_IMPROVE_WRITING',
+					title: 'Improve Writing',
+					workflowDefinitionName: 'Improve Writing',
+				},
+			],
+		});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => screen.getByText('Improve Writing'));
+
+		const href = getCardHref('Improve Writing');
+
+		expect(href).toContain('externalReferenceCode=L_IMPROVE_WRITING');
+		expect(href).toContain('workflowDefinitionName=Improve+Writing');
+	});
+
+	it('omits the workflow definition name when the agent has none', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({
+			items: [
+				{
+					active: true,
+					externalReferenceCode: 'L_NO_WORKFLOW',
+					title: 'No Workflow Agent',
+				},
+			],
+		});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => screen.getByText('No Workflow Agent'));
+
+		const href = getCardHref('No Workflow Agent');
+
+		expect(href).toContain('externalReferenceCode=L_NO_WORKFLOW');
+		expect(href).not.toContain('workflowDefinitionName');
+	});
+
+	it('never adds the workflow definition name to chatbot links', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({items: []});
+		mockGetChatbots.mockResolvedValue({
+			items: [
+				{
+					active: true,
+					externalReferenceCode: 'L_SUPPORT_BOT',
+					title: 'Support Bot',
+				},
+			],
+		});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => screen.getByText('Support Bot'));
+
+		const href = getCardHref('Support Bot');
+
+		expect(href).toContain('externalReferenceCode=L_SUPPORT_BOT');
+		expect(href).not.toContain('workflowDefinitionName');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94271

## What Is Being Fixed

When opening a workflow agent from the AI Hub Home page, the Kaleo Designer opened a different, blank workflow and the LLM node was not shown. Opening the same agent from the Agents page worked correctly. The Home page link omitted the workflow definition name, so the agent page could not tell the designer which definition to load.

## How It Is Being Fixed

The agent page builds the Kaleo Designer URL and only adds the name parameter when the request carries a workflowDefinitionName. The Agents page sent that parameter, but the Home dashboard built the agent link with only backURL and externalReferenceCode. This change forwards the agent's workflowDefinitionName, which is already present in the agent definition REST response, through the Home dashboard link, so the designer receives the definition name and loads the correct workflow. The parameter is appended only when present, so chatbot links and agents without a workflow are unaffected.

## PR Check

**pr-check: PASS** — tested on `5711e1bfc5f593b826e5e041fdaec2907f4fe1ab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5711e1bfc5f593b826e5e041fdaec2907f4fe1ab"} -->
