### PR TITLE
LPD-94314 Page builder agent shows up in the list of agents to add to the chatbot

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -46,7 +46,7 @@ async function getAgentDefinition(externalReferenceCode: string) {
 }
 
 async function getAgentDefinitions() {
-	const response = await fetch(AGENT_DEFINITION_BASE_URI, {
+	const response = await fetch('/o/ai-hub/v1.0/agent-definitions', {
 		method: 'GET',
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94314

## What Is Being Fixed

The Page Builder agent — still in development — appears in the chatbot's "Assigned agents" multiselect (and the home dashboard agent list). LPD-92072 added a server-side filter to hide it, but that filter only applies on the REST Builder endpoint, so the agent kept leaking through.

## How It Is Being Fixed

The frontend's getAgentDefinitions() fetched the list from the object headless API at /o/ai-hub/agent-definitions, which has no Page Builder filter. The REST Builder resource that does apply the filter is the versioned path /o/ai-hub/v1.0/agent-definitions. Pointing the list call at the versioned endpoint makes the existing filter take effect, so Page Builder no longer appears in the chatbot multiselect or the dashboard. The other service methods (get by external reference code, relationships, create) legitimately rely on the object API and are left untouched.

## PR Check

**pr-check: PASS** — tested on `5db36cabcbf0da9b37e178097d40469510cd91b1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5db36cabcbf0da9b37e178097d40469510cd91b1"} -->
