### PR TITLE
LPD-94494 Add the Image Descriptor accessibility agent

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.ai.hub.internal.assistant.handler;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.invocation.InvocationParameters;
@@ -40,6 +41,7 @@ public class AssistantHandlerContext {
 		_tools = builder._tools;
 		_toolProvider = builder._toolProvider;
 		_userMessage = builder._userMessage;
+		_userMessageImageContents = builder._userMessageImageContents;
 		_vertexAiGeminiStreamingChatModel =
 			builder._vertexAiGeminiStreamingChatModel;
 	}
@@ -90,6 +92,10 @@ public class AssistantHandlerContext {
 
 	public String getUserMessage() {
 		return _userMessage;
+	}
+
+	public List<ImageContent> getUserMessageImageContents() {
+		return _userMessageImageContents;
 	}
 
 	public VertexAiGeminiStreamingChatModel
@@ -190,6 +196,14 @@ public class AssistantHandlerContext {
 			return this;
 		}
 
+		public Builder userMessageImageContents(
+			List<ImageContent> userMessageImageContents) {
+
+			_userMessageImageContents = userMessageImageContents;
+
+			return this;
+		}
+
 		public Builder vertexAiGeminiStreamingChatModel(
 			VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
 
@@ -211,6 +225,7 @@ public class AssistantHandlerContext {
 		private ToolProvider _toolProvider;
 		private Object[] _tools = new Object[0];
 		private String _userMessage;
+		private List<ImageContent> _userMessageImageContents = List.of();
 		private VertexAiGeminiStreamingChatModel
 			_vertexAiGeminiStreamingChatModel;
 
@@ -228,6 +243,7 @@ public class AssistantHandlerContext {
 	private final ToolProvider _toolProvider;
 	private final Object[] _tools;
 	private final String _userMessage;
+	private final List<ImageContent> _userMessageImageContents;
 	private final VertexAiGeminiStreamingChatModel
 		_vertexAiGeminiStreamingChatModel;
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerUtil.java
@@ -6,14 +6,19 @@
 package com.liferay.ai.hub.internal.assistant.handler;
 
 import com.liferay.ai.hub.internal.memory.ChatMemoryProviderUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
+
+import java.util.List;
 
 /**
  * @author Feliphe Marinho
@@ -56,18 +61,36 @@ public class AssistantHandlerUtil {
 			assistantHandlerContext.getTools()
 		).build();
 
+		List<ImageContent> userMessageImageContents =
+			assistantHandlerContext.getUserMessageImageContents();
+
 		if (assistant instanceof
 				ChatMemoryAccessAssistant chatMemoryAccessAssistant) {
 
-			tokenStream = chatMemoryAccessAssistant.invoke(
+			if (ListUtil.isEmpty(userMessageImageContents)) {
+				tokenStream = chatMemoryAccessAssistant.invoke(
+					assistantHandlerContext.getInvocationParameters(),
+					assistantHandlerContext.getMemoryId(),
+					assistantHandlerContext.getUserMessage());
+			}
+			else {
+				tokenStream = chatMemoryAccessAssistant.invoke(
+					assistantHandlerContext.getInvocationParameters(),
+					assistantHandlerContext.getMemoryId(),
+					_getUserMessage(assistantHandlerContext),
+					userMessageImageContents);
+			}
+		}
+		else if (ListUtil.isEmpty(userMessageImageContents)) {
+			tokenStream = assistant.invoke(
 				assistantHandlerContext.getInvocationParameters(),
-				assistantHandlerContext.getMemoryId(),
 				assistantHandlerContext.getUserMessage());
 		}
 		else {
 			tokenStream = assistant.invoke(
 				assistantHandlerContext.getInvocationParameters(),
-				assistantHandlerContext.getUserMessage());
+				_getUserMessage(assistantHandlerContext),
+				userMessageImageContents);
 		}
 
 		tokenStream.onCompleteResponse(
@@ -83,6 +106,11 @@ public class AssistantHandlerUtil {
 			InvocationParameters invocationParameters,
 			@UserMessage String userMessage);
 
+		public TokenStream invoke(
+			InvocationParameters invocationParameters,
+			@UserMessage String userMessage,
+			@UserMessage List<ImageContent> imageContents);
+
 	}
 
 	public interface ChatMemoryAccessAssistant
@@ -92,6 +120,23 @@ public class AssistantHandlerUtil {
 			InvocationParameters invocationParameters,
 			@MemoryId String memoryId, @UserMessage String userMessage);
 
+		public TokenStream invoke(
+			InvocationParameters invocationParameters,
+			@MemoryId String memoryId, @UserMessage String userMessage,
+			@UserMessage List<ImageContent> imageContents);
+
+	}
+
+	private static String _getUserMessage(
+		AssistantHandlerContext assistantHandlerContext) {
+
+		String userMessage = assistantHandlerContext.getUserMessage();
+
+		if (Validator.isNull(userMessage)) {
+			return StringPool.PERIOD;
+		}
+
+		return userMessage;
 	}
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -251,6 +251,9 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 					serviceContext.getUserId(), workflowContext)
 			).userMessage(
 				userMessage
+			).userMessageImageContents(
+				VariablesUtil.getImageContents(
+					executionContext, kaleoNodeSettingValues)
 			).vertexAiGeminiStreamingChatModel(
 				vertexAiGeminiStreamingChatModel
 			).build());

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -214,6 +214,9 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 					serviceContext.getUserId(), workflowContext)
 			).userMessage(
 				userMessage
+			).userMessageImageContents(
+				VariablesUtil.getImageContents(
+					executionContext, kaleoNodeSettingValues)
 			).vertexAiGeminiStreamingChatModel(
 				vertexAiGeminiStreamingChatModel
 			).build());

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/VariablesUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/VariablesUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -13,13 +14,19 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+
+import dev.langchain4j.data.message.ImageContent;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author João Victor Alves
@@ -41,6 +48,47 @@ public class VariablesUtil {
 		}
 
 		return value;
+	}
+
+	public static List<ImageContent> getImageContents(
+		ExecutionContext executionContext,
+		Map<String, String> kaleoNodeSettingValues) {
+
+		JSONArray jsonArray = getVariablesJSONArray(
+			"inputVariables", kaleoNodeSettingValues);
+
+		if (jsonArray == null) {
+			return List.of();
+		}
+
+		List<ImageContent> imageContents = new ArrayList<>();
+
+		Map<String, Serializable> workflowContext =
+			executionContext.getWorkflowContext();
+
+		Iterator<JSONObject> iterator = jsonArray.iterator();
+
+		iterator.forEachRemaining(
+			jsonObject -> {
+				if (!Objects.equals(jsonObject.getString("type"), "image")) {
+					return;
+				}
+
+				String value = GetterUtil.getString(
+					workflowContext.get(jsonObject.getString("name")));
+
+				if (Validator.isNull(value)) {
+					return;
+				}
+
+				ImageContent imageContent = _createImageContent(value.trim());
+
+				if (imageContent != null) {
+					imageContents.add(imageContent);
+				}
+			});
+
+		return imageContents;
 	}
 
 	public static JSONArray getVariablesJSONArray(
@@ -65,6 +113,46 @@ public class VariablesUtil {
 		}
 	}
 
+	private static ImageContent _createImageContent(String value) {
+		if (!StringUtil.startsWith(value, "data:")) {
+			if (value.matches("\\S+")) {
+				return ImageContent.from(value);
+			}
+
+			_log.error(
+				"Unable to create an image content from a URL that contains " +
+					"whitespace");
+
+			return null;
+		}
+
+		int index = value.indexOf(";base64,");
+
+		if (index == -1) {
+			return ImageContent.from(value);
+		}
+
+		String mimeType = value.substring(5, index);
+
+		int semicolonIndex = mimeType.indexOf(CharPool.SEMICOLON);
+
+		if (semicolonIndex != -1) {
+			mimeType = mimeType.substring(0, semicolonIndex);
+		}
+
+		if (Validator.isNull(mimeType)) {
+			_log.error(
+				"Unable to create an image content from a data URI that has " +
+					"no MIME type");
+
+			return null;
+		}
+
+		String base64Data = value.substring(index + 8);
+
+		return ImageContent.from(base64Data.replaceAll("\\s", ""), mimeType);
+	}
+
 	private static Map<String, String> _getInputVariables(
 		Map<String, String> kaleoNodeSettingValues,
 		Map<String, Serializable> workflowContext) {
@@ -82,6 +170,10 @@ public class VariablesUtil {
 
 		iterator.forEachRemaining(
 			jsonObject -> {
+				if (Objects.equals(jsonObject.getString("type"), "image")) {
+					return;
+				}
+
 				String name = jsonObject.getString("name");
 
 				inputVariables.put(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/assistant/handler/AssistantHandlerUtilTest.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.assistant.handler;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationParameters;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Marcos Castro
+ */
+public class AssistantHandlerUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		Mockito.when(
+			_vertexAiGeminiStreamingChatModel.defaultRequestParameters()
+		).thenReturn(
+			DefaultChatRequestParameters.builder().build()
+		);
+
+		Mockito.doAnswer(
+			invocation -> {
+				_chatRequestAtomicReference.set(invocation.getArgument(0));
+
+				StreamingChatResponseHandler streamingChatResponseHandler =
+					invocation.getArgument(1);
+
+				streamingChatResponseHandler.onCompleteResponse(
+					ChatResponse.builder(
+					).aiMessage(
+						AiMessage.from("an alternative text")
+					).build());
+
+				return null;
+			}
+		).when(
+			_vertexAiGeminiStreamingChatModel
+		).chat(
+			Mockito.any(ChatRequest.class),
+			Mockito.any(StreamingChatResponseHandler.class)
+		);
+	}
+
+	@Test
+	public void testHandle() throws Exception {
+		_handle(List.of());
+
+		UserMessage userMessage = _getUserMessage();
+
+		Assert.assertEquals(
+			"Propose the alternative text for the attached image.",
+			userMessage.singleText());
+	}
+
+	@Test
+	public void testHandleWithUserMessageImageContents() throws Exception {
+		_handle(List.of(ImageContent.from("iVBORw0KGgo=", "image/png")));
+
+		UserMessage userMessage = _getUserMessage();
+
+		List<Content> contents = userMessage.contents();
+
+		Assert.assertEquals(contents.toString(), 2, contents.size());
+
+		TextContent textContent = (TextContent)contents.get(0);
+
+		Assert.assertEquals(
+			"Propose the alternative text for the attached image.",
+			textContent.text());
+
+		ImageContent imageContent = (ImageContent)contents.get(1);
+
+		Assert.assertEquals(
+			ImageContent.from("iVBORw0KGgo=", "image/png"), imageContent);
+	}
+
+	private UserMessage _getUserMessage() {
+		ChatRequest chatRequest = _chatRequestAtomicReference.get();
+
+		Assert.assertNotNull(chatRequest);
+
+		List<ChatMessage> chatMessages = chatRequest.messages();
+
+		ChatMessage chatMessage = chatMessages.get(chatMessages.size() - 1);
+
+		return (UserMessage)chatMessage;
+	}
+
+	private void _handle(List<ImageContent> userMessageImageContents)
+		throws Exception {
+
+		AtomicReference<Throwable> throwableAtomicReference =
+			new AtomicReference<>();
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		AssistantHandlerUtil.handle(
+			AssistantHandlerContext.builder(
+			).aiServiceListeners(
+				List.of()
+			).inputGuardrails(
+				List.of()
+			).invocationParameters(
+				InvocationParameters.from(Map.of())
+			).onCompleteResponseConsumer(
+				chatResponse -> countDownLatch.countDown()
+			).onErrorConsumer(
+				throwable -> {
+					throwableAtomicReference.set(throwable);
+
+					countDownLatch.countDown();
+				}
+			).outputGuardrails(
+				List.of()
+			).systemMessageProviderFunction(
+				memoryId -> "You are a web accessibility specialist."
+			).userMessage(
+				"Propose the alternative text for the attached image."
+			).userMessageImageContents(
+				userMessageImageContents
+			).vertexAiGeminiStreamingChatModel(
+				_vertexAiGeminiStreamingChatModel
+			).build());
+
+		Assert.assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+
+		Throwable throwable = throwableAtomicReference.get();
+
+		Assert.assertNull(String.valueOf(throwable), throwable);
+	}
+
+	private final AtomicReference<ChatRequest> _chatRequestAtomicReference =
+		new AtomicReference<>();
+	private final VertexAiGeminiStreamingChatModel
+		_vertexAiGeminiStreamingChatModel = Mockito.mock(
+			VertexAiGeminiStreamingChatModel.class);
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/VariablesUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/VariablesUtilTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.ImageContent;
+
+import java.io.Serializable;
+
+import java.net.URI;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marcos Castro
+ */
+public class VariablesUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testApplyInputVariablesExcludesImageVariables() {
+		String value = VariablesUtil.applyInputVariables(
+			_getExecutionContext(
+				HashMapBuilder.<String, Serializable>put(
+					"context", "a product page"
+				).put(
+					"image", "data:image/png;base64,iVBORw0KGgo="
+				).build()),
+			"userMessage",
+			HashMapBuilder.put(
+				"inputVariables", _INPUT_VARIABLES
+			).put(
+				"userMessage", "Image: {{image}}, context: {{context}}"
+			).build());
+
+		Assert.assertEquals(
+			"Image: {{image}}, context: a product page", value);
+	}
+
+	@Test
+	public void testGetImageContents() {
+		List<ImageContent> imageContents = _getImageContents(
+			"data:image/png;base64,iVBORw0KGgo=");
+
+		Assert.assertEquals(
+			imageContents.toString(), 1, imageContents.size());
+
+		ImageContent imageContent = imageContents.get(0);
+
+		Image image = imageContent.image();
+
+		Assert.assertEquals("iVBORw0KGgo=", image.base64Data());
+		Assert.assertEquals("image/png", image.mimeType());
+	}
+
+	@Test
+	public void testGetImageContentsWithDataURIParameters() {
+		List<ImageContent> imageContents = _getImageContents(
+			"data:image/png;charset=US-ASCII;base64,iVBORw0KGgo=");
+
+		Assert.assertEquals(
+			imageContents.toString(), 1, imageContents.size());
+
+		ImageContent imageContent = imageContents.get(0);
+
+		Image image = imageContent.image();
+
+		Assert.assertEquals("image/png", image.mimeType());
+	}
+
+	@Test
+	public void testGetImageContentsWithInvalidValues() {
+		Assert.assertTrue(
+			_getImageContents("data:;base64,iVBORw0KGgo=").isEmpty());
+		Assert.assertTrue(
+			_getImageContents("https://example.com/an image.png").isEmpty());
+	}
+
+	@Test
+	public void testGetImageContentsWithMultilineBase64() {
+		List<ImageContent> imageContents = _getImageContents(
+			"data:image/png;base64,iVBO\nRw0K\r\nGgo=");
+
+		Assert.assertEquals(
+			imageContents.toString(), 1, imageContents.size());
+
+		ImageContent imageContent = imageContents.get(0);
+
+		Image image = imageContent.image();
+
+		Assert.assertEquals("iVBORw0KGgo=", image.base64Data());
+	}
+
+	@Test
+	public void testGetImageContentsWithStringVariable() {
+		List<ImageContent> imageContents = VariablesUtil.getImageContents(
+			_getExecutionContext(
+				HashMapBuilder.<String, Serializable>put(
+					"context", "data:image/png;base64,iVBORw0KGgo="
+				).build()),
+			HashMapBuilder.put(
+				"inputVariables", _INPUT_VARIABLES
+			).build());
+
+		Assert.assertTrue(imageContents.toString(), imageContents.isEmpty());
+	}
+
+	@Test
+	public void testGetImageContentsWithURL() {
+		List<ImageContent> imageContents = _getImageContents(
+			"https://example.com/image.png");
+
+		Assert.assertEquals(
+			imageContents.toString(), 1, imageContents.size());
+
+		ImageContent imageContent = imageContents.get(0);
+
+		Image image = imageContent.image();
+
+		Assert.assertEquals(
+			URI.create("https://example.com/image.png"), image.url());
+	}
+
+	private ExecutionContext _getExecutionContext(
+		Map<String, Serializable> workflowContext) {
+
+		return new ExecutionContext(
+			null, workflowContext, new ServiceContext());
+	}
+
+	private List<ImageContent> _getImageContents(String value) {
+		return VariablesUtil.getImageContents(
+			_getExecutionContext(
+				HashMapBuilder.<String, Serializable>put(
+					"image", value
+				).build()),
+			HashMapBuilder.put(
+				"inputVariables", _INPUT_VARIABLES
+			).build());
+	}
+
+	private static final String _INPUT_VARIABLES = StringBundler.concat(
+		"[{\"name\": \"image\", \"type\": \"image\"}, {\"name\": \"context\", ",
+		"\"type\": \"string\"}]");
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -28,6 +28,19 @@
 		},
 		{
 			"active": true,
+			"description": "This accessibility agent looks at an image and proposes an alternative text aligned with WCAG 2.2 Success Criterion 1.1.1. When the image is decorative, it resolves that there is no relevant information and returns an empty value, so the consumer can render alt=\"\".",
+			"externalReferenceCode": "L_IMAGE_DESCRIPTOR",
+			"inputVariables": "image,context",
+			"outputVariable": "altText",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Image Descriptor"
+			},
+			"workflowDefinitionName": "Image Descriptor"
+		},
+		{
+			"active": true,
 			"description": "This writing agent improves text eliminating wordiness and passive voice to deliver a clear, direct message.",
 			"externalReferenceCode": "L_IMPROVE_WRITING",
 			"inputVariables": "text",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/image-descriptor-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/image-descriptor-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_IMAGE_DESCRIPTOR",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Image Descriptor",
+	"scope": "ai",
+	"title": "Image Descriptor",
+	"title_i18n": {
+		"en_US": "Image Descriptor"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/image-descriptor-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/image-descriptor-workflow-definition/workflow-definition.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Image Descriptor</name>
+	<version>1</version>
+	<llm>
+		<name>imageDescriptor</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Image Descriptor
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+[
+	{
+		"name": "image",
+		"type": "image"
+	},
+	{
+		"name": "context",
+		"type": "string"
+	}
+]
+]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+[
+	{
+		"name": "altText",
+		"type": "string"
+	}
+]
+]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[You are a web accessibility specialist applying WCAG 2.2 Success Criterion 1.1.1 (Non-text Content). Your sole task is to propose the alternative text for the image provided by the user. Describe the function and the relevant information the image conveys in its context, not its visual appearance. Use the surrounding page context when provided. Be concise: at most 125 characters. Never start with phrases like "image of", "picture of", or "photo of". Only output the alternative text. Do not include any explanation, introduction, quotation marks, or conversation. If the image is purely decorative — it conveys no information relevant to the content, such as spacers, ornaments, background textures, or stock imagery used only for visual styling — output nothing at all: return a completely empty response with zero characters, so the consumer can render alt="".]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Propose the alternative text for the attached image. Surrounding page context (may be empty): {{context}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Image Descriptor
+					</label>
+				</labels>
+				<name>imageDescriptor</name>
+				<target>imageDescriptor</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
## Concept for Final User Usage:

<img width="400"  alt="concept" src="https://github.com/user-attachments/assets/d0c985ec-4d34-4e18-9bac-845f0ce7bddf" />


https://liferay.atlassian.net/browse/LPD-94494

## What Is Being Proposed

AI Hub agents are text-only today: workflow input variables can only carry strings, even though the underlying model (Vertex AI Gemini) is natively multimodal. This PR unlocks **image inputs for the agent pipeline** and ships the first agent built on it: the **Image Descriptor**, an accessibility agent born from partner feedback (accessibility review with Vertigo, whose clients repeatedly ask for autogenerated image descriptions).

### The Image Descriptor Agent

- Input: an `image` (URL or base64 data URI) plus an optional `context` string (surrounding page content).
- Output: `altText` — a WCAG 2.2 SC 1.1.1 oriented alternative text (function-first, ≤125 characters, no "image of…" prefix).
- **Decorative images**: when the image conveys no relevant information, the agent resolves that explicitly by returning an empty value, so consumers can render `alt=""` as WCAG prescribes.

## How It Works

The multimodal support is generic and reusable by any future vision agent:

- `VariablesUtil.getImageContents` collects input variables typed `"image"` from the workflow context and converts them to langchain4j `ImageContent` (handling data URIs with parameters, multiline base64, and skipping unusable values without failing the workflow node).
- `AssistantHandlerContext`/`AssistantHandlerUtil` attach those contents to the user message through the AiServices-supported idiom (`@UserMessage String` + `@UserMessage List<ImageContent>`), verified against the langchain4j 1.10.0 bytecode — a raw `UserMessage` parameter is not supported by `AiServiceValidation` and fails at runtime.
- Image-typed variables are excluded from the text-substitution map, so a `{{image}}` reference in a prompt template can no longer inline megabytes of base64 as text.
- Both `LLMNodeExecutor` and `AIDecisionNodeExecutor` are wired, so decision nodes can also see images.
- The agent itself is fully declarative: a Kaleo workflow definition plus an `AgentDefinition` object entry seeded by `ai-hub-site-initializer`, following the existing pattern of the eight system agents.

## How It Can Be Used

- **Individually, per image**: `POST /o/ai-hub/v1.0/agent-instances` with `{"agentDefinitionExternalReferenceCode": "L_IMAGE_DESCRIPTOR", "context": {"image": "data:image/png;base64,…", "context": "…"}}` — or, as a product integration, a "Generate alt text" action next to any alt field (Documents and Media, page editor image fragments, content editors). An empty result maps naturally to a "decorative image" checkbox that renders `alt=""`.
- **In batch**: the bulk image upload flows (e.g. the CMS multiple file uploader) can request a proposed alt text per file and present an accept/edit column, which is where "generate alt text for every image of the site" becomes tangible for customers. A design proposal for both surfaces will be attached to this PR.
<img width="150" height="auto" alt="concept" src="https://github.com/user-attachments/assets/d0c985ec-4d34-4e18-9bac-845f0ce7bddf" />

## Tests

Nine unit tests cover the new code:

- `AssistantHandlerUtilTest` builds the real AiServices proxy against a mocked Gemini streaming model and asserts that the multimodal signature passes validation and that the model receives the user message with both `TextContent` and `ImageContent` — pinning the langchain4j idiom against regressions.
- `VariablesUtilTest` covers data URI parsing (plain, with parameters, no MIME type, multiline base64), URL handling, type filtering, and the exclusion of image variables from text substitution.

## Known Limitations / Follow-Ups

- **Image transport**: base64 data URIs travel inside the Kaleo `workflowContext`, which is persisted in `KaleoInstance` — large images inflate that table. Clients should downscale before sending; a Document Library/GCS-based transport is the natural evolution (note that Vertex can only fetch `gs://` URIs and public URLs, so private DXP URLs must go inline).
- **Chat memory**: with a `memoryId`, the image message is retained in chat memory and resent on every turn of the conversation.
- **REST/UI typing**: `AgentDefinitionManagerImpl` exposes every input variable as `string`, so API consumers and the supervisor agent cannot discover that `image` expects an image; the visual workflow editor does not offer an `image` variable type yet.
- **Decorative contract**: the "empty response means decorative" contract lives in the prompt; consumers should trim the output, and a structured output could make it verifiable.

## PR Check

**pr-check: PASS** — tested on `e4da5f13fc9c6` (validations exercised by this diff)

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS (9/9) |

<!-- pr-check {"result": "success", "sha": "e4da5f13fc9c6"} -->

More Context (sorry for the Spanish, I've added subtitles):

https://github.com/user-attachments/assets/317889d9-3564-4db8-832c-4e26b3eae5a7

