### PR TITLE
LPD-92338 Add agent issue report object definition and REST endpoint

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 124.0.1
+Bundle-Version: 125.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -198,6 +198,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"AIHubMCPServer", "/ai-hub/mcp-servers"
 		).put(
+			"AIHubReport", "/ai-hub/reports"
+		).put(
 			"APIApplication", "/headless-builder/applications"
 		).put(
 			"APIEndpoint", "/headless-builder/endpoints"

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 35.3.0
+version 35.4.0

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -38,6 +38,9 @@ import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.scope.AgentInvocation;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.agentic.supervisor.SupervisorContextStrategy;
 import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
@@ -244,8 +247,24 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 				SupervisorResponseStrategy.SCORED
 			).build();
 
-		String data = supervisorAgent.invoke(
-			MapUtil.getString(agentContext.getInput(), "message"));
+		ResultWithAgenticScope<String> resultWithAgenticScope =
+			supervisorAgent.invokeWithAgenticScope(
+				MapUtil.getString(agentContext.getInput(), "message"));
+
+		AgenticScope agenticScope = resultWithAgenticScope.agenticScope();
+
+		String[] agentDefinitionExternalReferenceCodes = null;
+
+		if ((agenticScope != null) &&
+			(agenticScope.agentInvocations() != null)) {
+
+			agentDefinitionExternalReferenceCodes = ArrayUtil.distinct(
+				TransformUtil.transformToArray(
+					agenticScope.agentInvocations(), AgentInvocation::agentName,
+					String.class));
+		}
+
+		String data = resultWithAgenticScope.result();
 
 		if (Validator.isBlank(data)) {
 			DTOConverterContext dtoConverterContext =
@@ -257,7 +276,8 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 		}
 
 		SseUtil.send(
-			data, "Chat Message Sent", null, agentContext.getSseEventSinkKey());
+			agentDefinitionExternalReferenceCodes, data, "Chat Message Sent",
+			null, agentContext.getSseEventSinkKey());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -230,6 +230,8 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 		_quotaManager.checkTokensUsage(
 			agentContext.getCompanyId(), agentContext.getUserId());
 
+		String[] agentDefinitionExternalReferenceCodes = null;
+
 		dev.langchain4j.agentic.supervisor.SupervisorAgent supervisorAgent =
 			AgenticServices.supervisorBuilder(
 			).chatMemoryProvider(
@@ -252,8 +254,6 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 				MapUtil.getString(agentContext.getInput(), "message"));
 
 		AgenticScope agenticScope = resultWithAgenticScope.agenticScope();
-
-		String[] agentDefinitionExternalReferenceCodes = null;
 
 		if ((agenticScope != null) &&
 			(agenticScope.agentInvocations() != null)) {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/Report.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/Report.java
@@ -1,0 +1,782 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Report")
+@io.swagger.v3.oas.annotations.media.Schema(
+	requiredProperties = {
+		"agentDefinitionExternalReferenceCodes", "feedback", "surface"
+	}
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Report")
+public class Report implements Serializable {
+
+	public static Report toDTO(String json) {
+		return ObjectMapperUtil.readValue(Report.class, json);
+	}
+
+	public static Report unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Report.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String[] getAgentDefinitionExternalReferenceCodes() {
+		if (_agentDefinitionExternalReferenceCodesSupplier != null) {
+			agentDefinitionExternalReferenceCodes =
+				_agentDefinitionExternalReferenceCodesSupplier.get();
+
+			_agentDefinitionExternalReferenceCodesSupplier = null;
+		}
+
+		return agentDefinitionExternalReferenceCodes;
+	}
+
+	public void setAgentDefinitionExternalReferenceCodes(
+		String[] agentDefinitionExternalReferenceCodes) {
+
+		this.agentDefinitionExternalReferenceCodes =
+			agentDefinitionExternalReferenceCodes;
+
+		_agentDefinitionExternalReferenceCodesSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAgentDefinitionExternalReferenceCodes(
+		UnsafeSupplier<String[], Exception>
+			agentDefinitionExternalReferenceCodesUnsafeSupplier) {
+
+		_agentDefinitionExternalReferenceCodesSupplier = () -> {
+			try {
+				return agentDefinitionExternalReferenceCodesUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
+	protected String[] agentDefinitionExternalReferenceCodes;
+
+	@JsonIgnore
+	private Supplier<String[]> _agentDefinitionExternalReferenceCodesSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getChatbotExternalReferenceCode() {
+		if (_chatbotExternalReferenceCodeSupplier != null) {
+			chatbotExternalReferenceCode =
+				_chatbotExternalReferenceCodeSupplier.get();
+
+			_chatbotExternalReferenceCodeSupplier = null;
+		}
+
+		return chatbotExternalReferenceCode;
+	}
+
+	public void setChatbotExternalReferenceCode(
+		String chatbotExternalReferenceCode) {
+
+		this.chatbotExternalReferenceCode = chatbotExternalReferenceCode;
+
+		_chatbotExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setChatbotExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			chatbotExternalReferenceCodeUnsafeSupplier) {
+
+		_chatbotExternalReferenceCodeSupplier = () -> {
+			try {
+				return chatbotExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String chatbotExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _chatbotExternalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateCreated() {
+		if (_dateCreatedSupplier != null) {
+			dateCreated = _dateCreatedSupplier.get();
+
+			_dateCreatedSupplier = null;
+		}
+
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+
+		_dateCreatedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		_dateCreatedSupplier = () -> {
+			try {
+				return dateCreatedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateCreated;
+
+	@JsonIgnore
+	private Supplier<Date> _dateCreatedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getFeedback() {
+		if (_feedbackSupplier != null) {
+			feedback = _feedbackSupplier.get();
+
+			_feedbackSupplier = null;
+		}
+
+		return feedback;
+	}
+
+	public void setFeedback(String feedback) {
+		this.feedback = feedback;
+
+		_feedbackSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFeedback(
+		UnsafeSupplier<String, Exception> feedbackUnsafeSupplier) {
+
+		_feedbackSupplier = () -> {
+			try {
+				return feedbackUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotEmpty
+	protected String feedback;
+
+	@JsonIgnore
+	private Supplier<String> _feedbackSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getLevel() {
+		if (_levelSupplier != null) {
+			level = _levelSupplier.get();
+
+			_levelSupplier = null;
+		}
+
+		return level;
+	}
+
+	public void setLevel(String level) {
+		this.level = level;
+
+		_levelSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLevel(
+		UnsafeSupplier<String, Exception> levelUnsafeSupplier) {
+
+		_levelSupplier = () -> {
+			try {
+				return levelUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String level;
+
+	@JsonIgnore
+	private Supplier<String> _levelSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getReason() {
+		if (_reasonSupplier != null) {
+			reason = _reasonSupplier.get();
+
+			_reasonSupplier = null;
+		}
+
+		return reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+
+		_reasonSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setReason(
+		UnsafeSupplier<String, Exception> reasonUnsafeSupplier) {
+
+		_reasonSupplier = () -> {
+			try {
+				return reasonUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String reason;
+
+	@JsonIgnore
+	private Supplier<String> _reasonSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getSurface() {
+		if (_surfaceSupplier != null) {
+			surface = _surfaceSupplier.get();
+
+			_surfaceSupplier = null;
+		}
+
+		return surface;
+	}
+
+	public void setSurface(String surface) {
+		this.surface = surface;
+
+		_surfaceSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSurface(
+		UnsafeSupplier<String, Exception> surfaceUnsafeSupplier) {
+
+		_surfaceSupplier = () -> {
+			try {
+				return surfaceUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotEmpty
+	protected String surface;
+
+	@JsonIgnore
+	private Supplier<String> _surfaceSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getUserMessage() {
+		if (_userMessageSupplier != null) {
+			userMessage = _userMessageSupplier.get();
+
+			_userMessageSupplier = null;
+		}
+
+		return userMessage;
+	}
+
+	public void setUserMessage(String userMessage) {
+		this.userMessage = userMessage;
+
+		_userMessageSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUserMessage(
+		UnsafeSupplier<String, Exception> userMessageUnsafeSupplier) {
+
+		_userMessageSupplier = () -> {
+			try {
+				return userMessageUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String userMessage;
+
+	@JsonIgnore
+	private Supplier<String> _userMessageSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Report)) {
+			return false;
+		}
+
+		Report report = (Report)object;
+
+		return Objects.equals(toString(), report.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String[] agentDefinitionExternalReferenceCodes =
+			getAgentDefinitionExternalReferenceCodes();
+
+		if (agentDefinitionExternalReferenceCodes != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"agentDefinitionExternalReferenceCodes\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < agentDefinitionExternalReferenceCodes.length;
+				 i++) {
+
+				sb.append("\"");
+
+				sb.append(_escape(agentDefinitionExternalReferenceCodes[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < agentDefinitionExternalReferenceCodes.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		String chatbotExternalReferenceCode = getChatbotExternalReferenceCode();
+
+		if (chatbotExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"chatbotExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(chatbotExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		Date dateCreated = getDateCreated();
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String feedback = getFeedback();
+
+		if (feedback != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"feedback\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(feedback));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String level = getLevel();
+
+		if (level != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"level\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(level));
+
+			sb.append("\"");
+		}
+
+		String reason = getReason();
+
+		if (reason != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"reason\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(reason));
+
+			sb.append("\"");
+		}
+
+		String surface = getSurface();
+
+		if (surface != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"surface\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(surface));
+
+			sb.append("\"");
+		}
+
+		String userMessage = getUserMessage();
+
+		if (userMessage != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"userMessage\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(userMessage));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.ai.hub.rest.dto.v1_0.Report",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:208239394

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/ReportManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/ReportManager.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.manager.v1_0;
+
+import com.liferay.ai.hub.rest.dto.v1_0.Report;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+/**
+ * @author Fábio Alves
+ */
+public interface ReportManager {
+
+	public Report postReport(
+			Company company, DTOConverterContext dtoConverterContext,
+			Report report)
+		throws Exception;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/ReportResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/ReportResource.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.resource.v1_0;
+
+import com.liferay.ai.hub.rest.dto.v1_0.Report;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/ai-hub/v1.0
+ *
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface ReportResource {
+
+	public Report postReport(Report report) throws Exception;
+
+	public Response postReportBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public ReportResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1451276799

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/util/SseUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/util/SseUtil.java
@@ -59,6 +59,13 @@ public class SseUtil {
 	public static void send(
 		String data, String name, String nodeName, String sseEventSinkKey) {
 
+		send(null, data, name, nodeName, sseEventSinkKey);
+	}
+
+	public static void send(
+		String[] agentDefinitionExternalReferenceCodes, String data,
+		String name, String nodeName, String sseEventSinkKey) {
+
 		if (Validator.isBlank(sseEventSinkKey)) {
 			return;
 		}
@@ -71,6 +78,16 @@ public class SseUtil {
 			).data(
 				String.class,
 				JSONUtil.put(
+					"agentDefinitionExternalReferenceCodes",
+					() -> {
+						if (agentDefinitionExternalReferenceCodes == null) {
+							return null;
+						}
+
+						return JSONUtil.putAll(
+							agentDefinitionExternalReferenceCodes);
+					}
+				).put(
 					"data", data
 				).put(
 					"nodeName", nodeName

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/resources/com/liferay/ai/hub/rest/resource/v1_0/util/packageinfo
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/resources/com/liferay/ai/hub/rest/resource/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/Report.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/Report.java
@@ -1,0 +1,278 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.client.dto.v1_0;
+
+import com.liferay.ai.hub.rest.client.function.UnsafeSupplier;
+import com.liferay.ai.hub.rest.client.serdes.v1_0.ReportSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+public class Report implements Cloneable, Serializable {
+
+	public static Report toDTO(String json) {
+		return ReportSerDes.toDTO(json);
+	}
+
+	public String[] getAgentDefinitionExternalReferenceCodes() {
+		return agentDefinitionExternalReferenceCodes;
+	}
+
+	public void setAgentDefinitionExternalReferenceCodes(
+		String[] agentDefinitionExternalReferenceCodes) {
+
+		this.agentDefinitionExternalReferenceCodes =
+			agentDefinitionExternalReferenceCodes;
+	}
+
+	public void setAgentDefinitionExternalReferenceCodes(
+		UnsafeSupplier<String[], Exception>
+			agentDefinitionExternalReferenceCodesUnsafeSupplier) {
+
+		try {
+			agentDefinitionExternalReferenceCodes =
+				agentDefinitionExternalReferenceCodesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] agentDefinitionExternalReferenceCodes;
+
+	public String getChatbotExternalReferenceCode() {
+		return chatbotExternalReferenceCode;
+	}
+
+	public void setChatbotExternalReferenceCode(
+		String chatbotExternalReferenceCode) {
+
+		this.chatbotExternalReferenceCode = chatbotExternalReferenceCode;
+	}
+
+	public void setChatbotExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			chatbotExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			chatbotExternalReferenceCode =
+				chatbotExternalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String chatbotExternalReferenceCode;
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public String getFeedback() {
+		return feedback;
+	}
+
+	public void setFeedback(String feedback) {
+		this.feedback = feedback;
+	}
+
+	public void setFeedback(
+		UnsafeSupplier<String, Exception> feedbackUnsafeSupplier) {
+
+		try {
+			feedback = feedbackUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String feedback;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getLevel() {
+		return level;
+	}
+
+	public void setLevel(String level) {
+		this.level = level;
+	}
+
+	public void setLevel(
+		UnsafeSupplier<String, Exception> levelUnsafeSupplier) {
+
+		try {
+			level = levelUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String level;
+
+	public String getReason() {
+		return reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	public void setReason(
+		UnsafeSupplier<String, Exception> reasonUnsafeSupplier) {
+
+		try {
+			reason = reasonUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String reason;
+
+	public String getSurface() {
+		return surface;
+	}
+
+	public void setSurface(String surface) {
+		this.surface = surface;
+	}
+
+	public void setSurface(
+		UnsafeSupplier<String, Exception> surfaceUnsafeSupplier) {
+
+		try {
+			surface = surfaceUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String surface;
+
+	public String getUserMessage() {
+		return userMessage;
+	}
+
+	public void setUserMessage(String userMessage) {
+		this.userMessage = userMessage;
+	}
+
+	public void setUserMessage(
+		UnsafeSupplier<String, Exception> userMessageUnsafeSupplier) {
+
+		try {
+			userMessage = userMessageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String userMessage;
+
+	@Override
+	public Report clone() throws CloneNotSupportedException {
+		return (Report)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Report)) {
+			return false;
+		}
+
+		Report report = (Report)object;
+
+		return Objects.equals(toString(), report.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ReportSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1586795596

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/ReportResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/ReportResource.java
@@ -1,0 +1,368 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.client.resource.v1_0;
+
+import com.liferay.ai.hub.rest.client.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.client.http.HttpInvoker;
+import com.liferay.ai.hub.rest.client.problem.Problem;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+public interface ReportResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Report postReport(Report report) throws Exception;
+
+	public HttpInvoker.HttpResponse postReportHttpResponse(Report report)
+		throws Exception;
+
+	public void postReportBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postReportBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public ReportResource build() {
+			return new ReportResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class ReportResourceImpl implements ReportResource {
+
+		public Report postReport(Report report) throws Exception {
+			HttpInvoker.HttpResponse httpResponse = postReportHttpResponse(
+				report);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return com.liferay.ai.hub.rest.client.serdes.v1_0.ReportSerDes.
+					toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postReportHttpResponse(Report report)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(report.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/reports");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postReportBatch(String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse = postReportBatchHttpResponse(
+				callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postReportBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/reports/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private ReportResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			ReportResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1765210240

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ReportSerDes.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ReportSerDes.java
@@ -1,0 +1,507 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.client.serdes.v1_0;
+
+import com.liferay.ai.hub.rest.client.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+public class ReportSerDes {
+
+	public static Report toDTO(String json) {
+		ReportJSONParser reportJSONParser = new ReportJSONParser();
+
+		return reportJSONParser.parseToDTO(json);
+	}
+
+	public static Report[] toDTOs(String json) {
+		ReportJSONParser reportJSONParser = new ReportJSONParser();
+
+		return reportJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Report report) {
+		if (report == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (report.getAgentDefinitionExternalReferenceCodes() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"agentDefinitionExternalReferenceCodes\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < report.getAgentDefinitionExternalReferenceCodes().length;
+				 i++) {
+
+				sb.append(
+					_toJSON(
+						report.getAgentDefinitionExternalReferenceCodes()[i]));
+
+				if ((i + 1) <
+						report.
+							getAgentDefinitionExternalReferenceCodes().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (report.getChatbotExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"chatbotExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getChatbotExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (report.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(report.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (report.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (report.getFeedback() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"feedback\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getFeedback()));
+
+			sb.append("\"");
+		}
+
+		if (report.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(report.getId());
+		}
+
+		if (report.getLevel() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"level\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getLevel()));
+
+			sb.append("\"");
+		}
+
+		if (report.getReason() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"reason\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getReason()));
+
+			sb.append("\"");
+		}
+
+		if (report.getSurface() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"surface\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getSurface()));
+
+			sb.append("\"");
+		}
+
+		if (report.getUserMessage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"userMessage\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(report.getUserMessage()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ReportJSONParser reportJSONParser = new ReportJSONParser();
+
+		return reportJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Report report) {
+		if (report == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (report.getAgentDefinitionExternalReferenceCodes() == null) {
+			map.put("agentDefinitionExternalReferenceCodes", null);
+		}
+		else {
+			map.put(
+				"agentDefinitionExternalReferenceCodes",
+				String.valueOf(
+					report.getAgentDefinitionExternalReferenceCodes()));
+		}
+
+		if (report.getChatbotExternalReferenceCode() == null) {
+			map.put("chatbotExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"chatbotExternalReferenceCode",
+				String.valueOf(report.getChatbotExternalReferenceCode()));
+		}
+
+		if (report.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(report.getDateCreated()));
+		}
+
+		if (report.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(report.getExternalReferenceCode()));
+		}
+
+		if (report.getFeedback() == null) {
+			map.put("feedback", null);
+		}
+		else {
+			map.put("feedback", String.valueOf(report.getFeedback()));
+		}
+
+		if (report.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(report.getId()));
+		}
+
+		if (report.getLevel() == null) {
+			map.put("level", null);
+		}
+		else {
+			map.put("level", String.valueOf(report.getLevel()));
+		}
+
+		if (report.getReason() == null) {
+			map.put("reason", null);
+		}
+		else {
+			map.put("reason", String.valueOf(report.getReason()));
+		}
+
+		if (report.getSurface() == null) {
+			map.put("surface", null);
+		}
+		else {
+			map.put("surface", String.valueOf(report.getSurface()));
+		}
+
+		if (report.getUserMessage() == null) {
+			map.put("userMessage", null);
+		}
+		else {
+			map.put("userMessage", String.valueOf(report.getUserMessage()));
+		}
+
+		return map;
+	}
+
+	public static class ReportJSONParser extends BaseJSONParser<Report> {
+
+		@Override
+		protected Report createDTO() {
+			return new Report();
+		}
+
+		@Override
+		protected Report[] createDTOArray(int size) {
+			return new Report[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(
+					jsonParserFieldName,
+					"agentDefinitionExternalReferenceCodes")) {
+
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "chatbotExternalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "feedback")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "level")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "reason")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "surface")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "userMessage")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Report report, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(
+					jsonParserFieldName,
+					"agentDefinitionExternalReferenceCodes")) {
+
+				if (jsonParserFieldValue != null) {
+					report.setAgentDefinitionExternalReferenceCodes(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "chatbotExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					report.setChatbotExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					report.setDateCreated(toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					report.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "feedback")) {
+				if (jsonParserFieldValue != null) {
+					report.setFeedback((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					report.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "level")) {
+				if (jsonParserFieldValue != null) {
+					report.setLevel((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "reason")) {
+				if (jsonParserFieldValue != null) {
+					report.setReason((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "surface")) {
+				if (jsonParserFieldValue != null) {
+					report.setSurface((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "userMessage")) {
+				if (jsonParserFieldValue != null) {
+					report.setUserMessage((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-310956924

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -221,6 +221,41 @@ components:
                 -   accountEntryName
                 -   userAccounts
             type: object
+        Report:
+            properties:
+                agentDefinitionExternalReferenceCodes:
+                    items:
+                        type: string
+                    type: array
+                chatbotExternalReferenceCode:
+                    type: string
+                dateCreated:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                externalReferenceCode:
+                    readOnly: true
+                    type: string
+                feedback:
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                level:
+                    readOnly: true
+                    type: string
+                reason:
+                    type: string
+                surface:
+                    type: string
+                userMessage:
+                    type: string
+            required:
+                -   agentDefinitionExternalReferenceCodes
+                -   feedback
+                -   surface
+            type: object
         Site:
             properties:
                 externalReferenceCode:
@@ -574,6 +609,27 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ProvisioningRequest"
             tags: ["ProvisioningRequest"]
+    "/reports":
+        post:
+            operationId: postReport
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Report"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Report"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Report"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Report"
+            tags: ["Report"]
     "/sites/by-external-reference-code/{externalReferenceCode}/site-initializer":
         put:
             operationId: putSiteByExternalReferenceCodeSiteInitializer

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -9,7 +9,6 @@ import com.liferay.account.model.AccountEntry;
 import com.liferay.ai.hub.rest.dto.v1_0.Report;
 import com.liferay.ai.hub.rest.manager.v1_0.ReportManager;
 import com.liferay.ai.hub.util.AccountEntryUtil;
-import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -87,16 +86,10 @@ public class ReportManagerImpl implements ReportManager {
 			for (String agentDefinitionExternalReferenceCode :
 					report.getAgentDefinitionExternalReferenceCodes()) {
 
-				com.liferay.object.model.ObjectEntry
-					serviceBuilderObjectEntry =
-						_objectEntryLocalService.fetchObjectEntry(
-							agentDefinitionExternalReferenceCode, 0L,
-							objectDefinition.getObjectDefinitionId());
-
-				if (serviceBuilderObjectEntry == null) {
-					throw new NoSuchObjectEntryException(
-						agentDefinitionExternalReferenceCode);
-				}
+				com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+					_objectEntryLocalService.getObjectEntry(
+						agentDefinitionExternalReferenceCode, 0L,
+						objectDefinition.getObjectDefinitionId());
 
 				_objectRelationshipLocalService.
 					addObjectRelationshipMappingTableValues(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -88,12 +88,12 @@ public class ReportManagerImpl implements ReportManager {
 					report.getAgentDefinitionExternalReferenceCodes()) {
 
 				com.liferay.object.model.ObjectEntry
-					agentDefinitionObjectEntry =
+					serviceBuilderObjectEntry =
 						_objectEntryLocalService.fetchObjectEntry(
 							agentDefinitionExternalReferenceCode, 0L,
 							objectDefinition.getObjectDefinitionId());
 
-				if (agentDefinitionObjectEntry == null) {
+				if (serviceBuilderObjectEntry == null) {
 					throw new NoSuchObjectEntryException(
 						agentDefinitionExternalReferenceCode);
 				}
@@ -102,7 +102,7 @@ public class ReportManagerImpl implements ReportManager {
 					addObjectRelationshipMappingTableValues(
 						dtoConverterContext.getUserId(),
 						objectRelationship.getObjectRelationshipId(),
-						agentDefinitionObjectEntry.getObjectEntryId(),
+						serviceBuilderObjectEntry.getObjectEntryId(),
 						objectEntry.getId(), new ServiceContext());
 			}
 		}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -18,7 +18,6 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -71,33 +70,29 @@ public class ReportManagerImpl implements ReportManager {
 			},
 			null);
 
-		if (ArrayUtil.isNotEmpty(
-				report.getAgentDefinitionExternalReferenceCodes())) {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				company.getCompanyId(), "AIHubAgentDefinition");
 
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					company.getCompanyId(), "AIHubAgentDefinition");
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.getObjectRelationship(
+				objectDefinition.getObjectDefinitionId(),
+				"aiHubAgentDefinitionsToAIHubReports");
 
-			ObjectRelationship objectRelationship =
-				_objectRelationshipLocalService.getObjectRelationship(
-					objectDefinition.getObjectDefinitionId(),
-					"aiHubAgentDefinitionsToAIHubReports");
+		for (String agentDefinitionExternalReferenceCode :
+				report.getAgentDefinitionExternalReferenceCodes()) {
 
-			for (String agentDefinitionExternalReferenceCode :
-					report.getAgentDefinitionExternalReferenceCodes()) {
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+				_objectEntryLocalService.getObjectEntry(
+					agentDefinitionExternalReferenceCode, 0L,
+					objectDefinition.getObjectDefinitionId());
 
-				com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-					_objectEntryLocalService.getObjectEntry(
-						agentDefinitionExternalReferenceCode, 0L,
-						objectDefinition.getObjectDefinitionId());
-
-				_objectRelationshipLocalService.
-					addObjectRelationshipMappingTableValues(
-						dtoConverterContext.getUserId(),
-						objectRelationship.getObjectRelationshipId(),
-						serviceBuilderObjectEntry.getObjectEntryId(),
-						objectEntry.getId(), new ServiceContext());
-			}
+			_objectRelationshipLocalService.
+				addObjectRelationshipMappingTableValues(
+					dtoConverterContext.getUserId(),
+					objectRelationship.getObjectRelationshipId(),
+					serviceBuilderObjectEntry.getObjectEntryId(),
+					objectEntry.getId(), new ServiceContext());
 		}
 
 		return new Report() {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -118,9 +118,9 @@ public class ReportManagerImpl implements ReportManager {
 	).put(
 		"harmfulContent", "critical"
 	).put(
-		"incorrect", "high"
+		"inaccurateResponse", "high"
 	).put(
-		"piiExposure", "critical"
+		"personalDataExposure", "critical"
 	).build();
 
 	@Reference

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -85,8 +85,7 @@ public class ReportManagerImpl implements ReportManager {
 					"aiHubAgentDefinitionsToAIHubReports");
 
 			for (String agentDefinitionExternalReferenceCode :
-					ArrayUtil.distinct(
-						report.getAgentDefinitionExternalReferenceCodes())) {
+					report.getAgentDefinitionExternalReferenceCodes()) {
 
 				com.liferay.object.model.ObjectEntry
 					agentDefinitionObjectEntry =

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ReportManagerImpl.java
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.manager.v1_0;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.ai.hub.rest.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.manager.v1_0.ReportManager;
+import com.liferay.ai.hub.util.AccountEntryUtil;
+import com.liferay.object.exception.NoSuchObjectEntryException;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(service = ReportManager.class)
+public class ReportManagerImpl implements ReportManager {
+
+	@Override
+	public Report postReport(
+			Company company, DTOConverterContext dtoConverterContext,
+			Report report)
+		throws Exception {
+
+		AccountEntry accountEntry = AccountEntryUtil.getUserAccountEntry(
+			dtoConverterContext.getUserId());
+
+		ObjectEntry objectEntry = _objectEntryManager.addObjectEntry(
+			dtoConverterContext,
+			_objectDefinitionLocalService.getObjectDefinition(
+				company.getCompanyId(), "AIHubReport"),
+			new ObjectEntry() {
+				{
+					setProperties(
+						() -> HashMapBuilder.<String, Object>put(
+							"feedback",
+							GetterUtil.getString(report.getFeedback())
+						).put(
+							"level",
+							_levels.getOrDefault(report.getReason(), "low")
+						).put(
+							"r_accountToAIHubReports_accountEntryId",
+							accountEntry.getAccountEntryId()
+						).put(
+							"reason", GetterUtil.getString(report.getReason())
+						).put(
+							"surface", GetterUtil.getString(report.getSurface())
+						).put(
+							"userMessage",
+							GetterUtil.getString(report.getUserMessage())
+						).build());
+				}
+			},
+			null);
+
+		if (ArrayUtil.isNotEmpty(
+				report.getAgentDefinitionExternalReferenceCodes())) {
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					company.getCompanyId(), "AIHubAgentDefinition");
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					objectDefinition.getObjectDefinitionId(),
+					"aiHubAgentDefinitionsToAIHubReports");
+
+			for (String agentDefinitionExternalReferenceCode :
+					ArrayUtil.distinct(
+						report.getAgentDefinitionExternalReferenceCodes())) {
+
+				com.liferay.object.model.ObjectEntry
+					agentDefinitionObjectEntry =
+						_objectEntryLocalService.fetchObjectEntry(
+							agentDefinitionExternalReferenceCode, 0L,
+							objectDefinition.getObjectDefinitionId());
+
+				if (agentDefinitionObjectEntry == null) {
+					throw new NoSuchObjectEntryException(
+						agentDefinitionExternalReferenceCode);
+				}
+
+				_objectRelationshipLocalService.
+					addObjectRelationshipMappingTableValues(
+						dtoConverterContext.getUserId(),
+						objectRelationship.getObjectRelationshipId(),
+						agentDefinitionObjectEntry.getObjectEntryId(),
+						objectEntry.getId(), new ServiceContext());
+			}
+		}
+
+		return new Report() {
+			{
+				setAgentDefinitionExternalReferenceCodes(
+					report::getAgentDefinitionExternalReferenceCodes);
+				setChatbotExternalReferenceCode(
+					report::getChatbotExternalReferenceCode);
+				setDateCreated(objectEntry::getDateCreated);
+				setExternalReferenceCode(objectEntry::getExternalReferenceCode);
+				setFeedback(report::getFeedback);
+				setId(objectEntry::getId);
+				setLevel(() -> _levels.getOrDefault(report.getReason(), "low"));
+				setReason(report::getReason);
+				setSurface(report::getSurface);
+				setUserMessage(report::getUserMessage);
+			}
+		};
+	}
+
+	private static final Map<String, String> _levels = HashMapBuilder.put(
+		"agentError", "medium"
+	).put(
+		"harmfulContent", "critical"
+	).put(
+		"incorrect", "high"
+	).put(
+		"piiExposure", "critical"
+	).build();
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference(target = "(object.entry.manager.storage.type=default)")
+	private ObjectEntryManager _objectEntryManager;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseReportResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseReportResourceImpl.java
@@ -1,0 +1,812 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.resource.v1_0;
+
+import com.liferay.ai.hub.rest.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.resource.v1_0.ReportResource;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseReportResourceImpl
+	implements EntityModelResource, ReportResource,
+			   VulcanBatchEngineTaskItemDelegate<Report> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/reports' -d $'{"agentDefinitionExternalReferenceCodes": ___, "chatbotExternalReferenceCode": ___, "feedback": ___, "reason": ___, "surface": ___, "userMessage": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Report")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/reports")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Report postReport(Report report) throws Exception {
+		return new Report();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/reports/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Report")}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/reports/batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postReportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				Report.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<Report> reports, Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeFunction<Report, Report, Exception> reportUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
+			reportUnsafeFunction = report -> postReport(report);
+		}
+
+		if (reportUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for Report");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(reports, reportUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				reports, reportUnsafeFunction::apply);
+		}
+		else {
+			for (Report report : reports) {
+				reportUnsafeFunction.apply(report);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			Collection<Report> reports, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	public String getResourceName() {
+		return "Report";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<Report> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<Report> reports, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<Report>, UnsafeFunction<Report, Report, Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<Report>, UnsafeConsumer<Report, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "ai-hub";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<Report>, UnsafeFunction<Report, Report, Exception>,
+		 Exception> contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<Report>, UnsafeConsumer<Report, Exception>, Exception>
+			contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseReportResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:707286093

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -5,24 +5,16 @@
 
 package com.liferay.ai.hub.rest.internal.resource.v1_0;
 
-import com.liferay.account.model.AccountEntryUserRel;
-import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.agent.SupervisorAgent;
 import com.liferay.ai.hub.rest.dto.v1_0.Message;
+import com.liferay.ai.hub.rest.internal.util.ContextUserUtil;
 import com.liferay.ai.hub.rest.internal.util.OAuth2ApplicationIdResolverUtil;
 import com.liferay.ai.hub.rest.resource.v1_0.MessageResource;
 import com.liferay.ai.hub.util.AccountEntryUtil;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
@@ -52,7 +44,7 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		User user = _initContextUser(
+		User user = ContextUserUtil.initContextUser(
 			message.getChatbotExternalReferenceCode(),
 			contextCompany.getCompanyId(), contextUser);
 
@@ -91,56 +83,8 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		return message;
 	}
 
-	private User _initContextUser(
-			String chatbotExternalReferenceCode, long companyId, User user)
-		throws Exception {
-
-		if (!user.isGuestUser() ||
-			Validator.isNull(chatbotExternalReferenceCode)) {
-
-			return user;
-		}
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_AI_HUB_CHATBOT", companyId);
-
-		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-			chatbotExternalReferenceCode, 0L,
-			objectDefinition.getObjectDefinitionId());
-
-		for (AccountEntryUserRel accountEntryUserRel :
-				_accountEntryUserRelLocalService.
-					getAccountEntryUserRelsByAccountEntryId(
-						MapUtil.getLong(
-							objectEntry.getValues(),
-							"r_accountToAIHubChatbots_accountEntryId"))) {
-
-			User accountEntryUserRelUser = accountEntryUserRel.getUser();
-
-			if (accountEntryUserRelUser.isServiceAccountUser()) {
-				AccessControlUtil.initContextUser(
-					accountEntryUserRelUser.getUserId());
-
-				return accountEntryUserRelUser;
-			}
-		}
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Reference
-	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
-
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private SupervisorAgent _supervisorAgent;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -101,6 +101,8 @@ public class OpenAPIResourceImpl {
 
 			add(ProvisioningRequestResourceImpl.class);
 
+			add(ReportResourceImpl.class);
+
 			add(SiteResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);
@@ -108,4 +110,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-621016047
+// LIFERAY-REST-BUILDER-HASH:9810069

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ReportResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ReportResourceImpl.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.resource.v1_0;
+
+import com.liferay.ai.hub.rest.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.internal.util.ContextUserUtil;
+import com.liferay.ai.hub.rest.manager.v1_0.ReportManager;
+import com.liferay.ai.hub.rest.resource.v1_0.ReportResource;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/report.properties",
+	scope = ServiceScope.PROTOTYPE, service = ReportResource.class
+)
+public class ReportResourceImpl extends BaseReportResourceImpl {
+
+	@Override
+	public Report postReport(Report report) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		return _reportManager.postReport(
+			contextCompany,
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), null,
+				_dtoConverterRegistry, contextHttpServletRequest, null,
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				ContextUserUtil.initContextUser(
+					report.getChatbotExternalReferenceCode(),
+					contextCompany.getCompanyId(), contextUser)),
+			report);
+	}
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private ReportManager _reportManager;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/factory/ReportResourceFactoryImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/factory/ReportResourceFactoryImpl.java
@@ -1,0 +1,327 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.resource.v1_0.factory;
+
+import com.liferay.ai.hub.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.ai.hub.rest.resource.v1_0.ReportResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/ai-hub/v1.0/Report",
+	service = ReportResource.Factory.class
+)
+@Generated("")
+public class ReportResourceFactoryImpl implements ReportResource.Factory {
+
+	@Override
+	public ReportResource.Builder create() {
+		return new ReportResource.Builder() {
+
+			@Override
+			public ReportResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, ReportResource>
+					reportResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_reportResourceProxyProviderFunction;
+
+				return reportResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public ReportResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public ReportResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public ReportResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public ReportResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public ReportResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public ReportResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, ReportResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			ReportResource.class.getClassLoader(), ReportResource.class);
+
+		try {
+			Constructor<ReportResource> constructor =
+				(Constructor<ReportResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		ReportResource reportResource = _componentServiceObjects.getService();
+
+		reportResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		reportResource.setContextCompany(company);
+
+		reportResource.setContextHttpServletRequest(httpServletRequest);
+		reportResource.setContextHttpServletResponse(httpServletResponse);
+		reportResource.setContextUriInfo(uriInfo);
+		reportResource.setContextUser(user);
+		reportResource.setExpressionConvert(_expressionConvert);
+		reportResource.setFilterParserProvider(_filterParserProvider);
+		reportResource.setGroupLocalService(_groupLocalService);
+		reportResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		reportResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		reportResource.setRoleLocalService(_roleLocalService);
+		reportResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(reportResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(reportResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<ReportResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, ReportResource>
+			_reportResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-919075031

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/util/ContextUserUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/util/ContextUserUtil.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.util;
+
+import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.service.AccountEntryUserRelLocalServiceUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Fábio Alves
+ */
+public class ContextUserUtil {
+
+	public static User initContextUser(
+			String chatbotExternalReferenceCode, long companyId, User user)
+		throws Exception {
+
+		if (!user.isGuestUser() ||
+			Validator.isNull(chatbotExternalReferenceCode)) {
+
+			return user;
+		}
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_AI_HUB_CHATBOT", companyId);
+
+		ObjectEntry objectEntry = ObjectEntryLocalServiceUtil.getObjectEntry(
+			chatbotExternalReferenceCode, 0L,
+			objectDefinition.getObjectDefinitionId());
+
+		for (AccountEntryUserRel accountEntryUserRel :
+				AccountEntryUserRelLocalServiceUtil.
+					getAccountEntryUserRelsByAccountEntryId(
+						MapUtil.getLong(
+							objectEntry.getValues(),
+							"r_accountToAIHubChatbots_accountEntryId"))) {
+
+			User accountEntryUserRelUser = accountEntryUserRel.getUser();
+
+			if (!accountEntryUserRelUser.isServiceAccountUser()) {
+				continue;
+			}
+
+			AccessControlUtil.initContextUser(
+				accountEntryUserRelUser.getUserId());
+
+			return accountEntryUserRelUser;
+		}
+
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/report.properties
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/report.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.ai.hub.rest.dto.v1_0.Report
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=false
+batch.planner.import.enabled=true
+entity.class.name=com.liferay.ai.hub.rest.dto.v1_0.Report
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.AI.Hub.REST)
+osgi.jaxrs.resource=true

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseReportResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseReportResourceTestCase.java
@@ -1,0 +1,1339 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.ai.hub.rest.client.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.client.http.HttpInvoker;
+import com.liferay.ai.hub.rest.client.pagination.Page;
+import com.liferay.ai.hub.rest.client.resource.v1_0.ReportResource;
+import com.liferay.ai.hub.rest.client.serdes.v1_0.ReportSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Feliphe Marinho
+ * @generated
+ */
+@Generated("")
+public abstract class BaseReportResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_reportResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		reportResource = ReportResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Report report1 = randomReport();
+
+		String json = objectMapper.writeValueAsString(report1);
+
+		Report report2 = ReportSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(report1, report2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Report report = randomReport();
+
+		String json1 = objectMapper.writeValueAsString(report);
+		String json2 = ReportSerDes.toJSON(report);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Report report = randomReport();
+
+		report.setChatbotExternalReferenceCode(regex);
+		report.setExternalReferenceCode(regex);
+		report.setFeedback(regex);
+		report.setLevel(regex);
+		report.setReason(regex);
+		report.setSurface(regex);
+		report.setUserMessage(regex);
+
+		String json = ReportSerDes.toJSON(report);
+
+		Assert.assertFalse(json.contains(regex));
+
+		report = ReportSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, report.getChatbotExternalReferenceCode());
+		Assert.assertEquals(regex, report.getExternalReferenceCode());
+		Assert.assertEquals(regex, report.getFeedback());
+		Assert.assertEquals(regex, report.getLevel());
+		Assert.assertEquals(regex, report.getReason());
+		Assert.assertEquals(regex, report.getSurface());
+		Assert.assertEquals(regex, report.getUserMessage());
+	}
+
+	@Test
+	public void testPostReport() throws Exception {
+		Report randomReport = randomReport();
+
+		Report postReport = testPostReport_addReport(randomReport);
+
+		assertEquals(randomReport, postReport);
+		assertValid(postReport);
+	}
+
+	protected Report testPostReport_addReport(Report report) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	protected void assertContains(Report report, List<Report> reports) {
+		boolean contains = false;
+
+		for (Report item : reports) {
+			if (equals(report, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(reports + " does not contain " + report, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(Report report1, Report report2) {
+		Assert.assertTrue(
+			report1 + " does not equal " + report2, equals(report1, report2));
+	}
+
+	protected void assertEquals(List<Report> reports1, List<Report> reports2) {
+		Assert.assertEquals(reports1.size(), reports2.size());
+
+		for (int i = 0; i < reports1.size(); i++) {
+			Report report1 = reports1.get(i);
+			Report report2 = reports2.get(i);
+
+			assertEquals(report1, report2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Report> reports1, List<Report> reports2) {
+
+		Assert.assertEquals(reports1.size(), reports2.size());
+
+		for (Report report1 : reports1) {
+			boolean contains = false;
+
+			for (Report report2 : reports2) {
+				if (equals(report1, report2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				reports2 + " does not contain " + report1, contains);
+		}
+	}
+
+	protected void assertValid(Report report) throws Exception {
+		boolean valid = true;
+
+		if (report.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (report.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"agentDefinitionExternalReferenceCodes",
+					additionalAssertFieldName)) {
+
+				if (report.getAgentDefinitionExternalReferenceCodes() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"chatbotExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (report.getChatbotExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (report.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("feedback", additionalAssertFieldName)) {
+				if (report.getFeedback() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("level", additionalAssertFieldName)) {
+				if (report.getLevel() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("reason", additionalAssertFieldName)) {
+				if (report.getReason() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("surface", additionalAssertFieldName)) {
+				if (report.getSurface() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("userMessage", additionalAssertFieldName)) {
+				if (report.getUserMessage() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Report> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<Report> page, Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<Report> reports = page.getItems();
+
+		int size = reports.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.ai.hub.rest.dto.v1_0.Report.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Report report1, Report report2) {
+		if (report1 == report2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"agentDefinitionExternalReferenceCodes",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						report1.getAgentDefinitionExternalReferenceCodes(),
+						report2.getAgentDefinitionExternalReferenceCodes())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"chatbotExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						report1.getChatbotExternalReferenceCode(),
+						report2.getChatbotExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getDateCreated(), report2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						report1.getExternalReferenceCode(),
+						report2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("feedback", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getFeedback(), report2.getFeedback())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(report1.getId(), report2.getId())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("level", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getLevel(), report2.getLevel())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("reason", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getReason(), report2.getReason())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("surface", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getSurface(), report2.getSurface())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("userMessage", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						report1.getUserMessage(), report2.getUserMessage())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_reportResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_reportResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Report report) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("agentDefinitionExternalReferenceCodes")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("chatbotExternalReferenceCode")) {
+			Object object = report.getChatbotExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				Date date = report.getDateCreated();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(report.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = report.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("feedback")) {
+			Object object = report.getFeedback();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("level")) {
+			Object object = report.getLevel();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("reason")) {
+			Object object = report.getReason();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("surface")) {
+			Object object = report.getSurface();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("userMessage")) {
+			Object object = report.getUserMessage();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected Report randomReport() throws Exception {
+		return new Report() {
+			{
+				chatbotExternalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				dateCreated = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				feedback = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
+				level = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				reason = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				surface = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				userMessage = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected Report randomIrrelevantReport() throws Exception {
+		Report randomIrrelevantReport = randomReport();
+
+		return randomIrrelevantReport;
+	}
+
+	protected Report randomPatchReport() throws Exception {
+		return randomReport();
+	}
+
+	protected ReportResource reportResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseReportResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.ai.hub.rest.resource.v1_0.ReportResource
+		_reportResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-477900950

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
@@ -5,15 +5,277 @@
 
 package com.liferay.ai.hub.rest.resource.v1_0.test;
 
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.ai.hub.rest.client.dto.v1_0.Report;
+import com.liferay.ai.hub.rest.client.resource.v1_0.ReportResource;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
 
-import org.junit.Ignore;
+import java.util.Calendar;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Feliphe Marinho
+ * @author Fábio Alves
  */
-@Ignore
+@FeatureFlag("LPD-62272")
 @RunWith(Arquillian.class)
 public class ReportResourceTest extends BaseReportResourceTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_accountEntry = _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString() + "@liferay.com", null,
+			RandomTestUtil.randomString(),
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			_accountEntry.getAccountEntryId(), TestPropsValues.getUserId());
+
+		_defaultObjectEntryManager =
+			(DefaultObjectEntryManager)_objectEntryManager;
+
+		_dtoConverterContext = new DefaultDTOConverterContext(
+			false, Map.of(), _dtoConverterRegistry, null,
+			LocaleUtil.getDefault(), null, TestPropsValues.getUser());
+
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		_originalName = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.ai.hub.site.initializer");
+
+		siteInitializer.initialize(TestPropsValues.getGroupId());
+
+		AccountEntry aiHubAccountEntry =
+			_accountEntryLocalService.getAccountEntryByExternalReferenceCode(
+				"L_AI_HUB", TestPropsValues.getCompanyId());
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			aiHubAccountEntry.getAccountEntryId(), TestPropsValues.getUserId());
+
+		User user = _userLocalService.addUser(
+			UserConstants.USER_ID_DEFAULT, TestPropsValues.getCompanyId(), true,
+			null, null, false,
+			_accountEntry.getAccountEntryId() + "-guest-service-account",
+			RandomTestUtil.randomString() + "@liferay.com",
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			StringPool.BLANK, RandomTestUtil.randomString(), 0, 0, true,
+			Calendar.JANUARY, 1, 1970, StringPool.BLANK,
+			UserConstants.TYPE_SERVICE_ACCOUNT, null, null, null, null, false,
+			ServiceContextTestUtil.getServiceContext());
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			aiHubAccountEntry.getAccountEntryId(), user.getUserId());
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			_accountEntry.getAccountEntryId(), user.getUserId());
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+
+		PrincipalThreadLocal.setName(_originalName);
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Override
+	@Test
+	public void testPostReport() throws Exception {
+		super.testPostReport();
+
+		_testPostReport(null, reportResource);
+
+		String chatbotExternalReferenceCode = RandomTestUtil.randomString();
+
+		_defaultObjectEntryManager.addObjectEntry(
+			_dtoConverterContext,
+			_objectDefinitionLocalService.getObjectDefinition(
+				testCompany.getCompanyId(), "AIHubChatbot"),
+			new ObjectEntry() {
+				{
+					setProperties(
+						() -> HashMapBuilder.<String, Object>put(
+							"active", true
+						).put(
+							"externalReferenceCode",
+							chatbotExternalReferenceCode
+						).put(
+							"r_accountToAIHubChatbots_accountEntryId",
+							_accountEntry.getAccountEntryId()
+						).put(
+							"title", RandomTestUtil.randomString()
+						).build());
+				}
+			},
+			null);
+
+		_testPostReport(
+			chatbotExternalReferenceCode,
+			ReportResource.builder(
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build());
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"agentDefinitionExternalReferenceCodes",
+			"chatbotExternalReferenceCode", "feedback", "reason", "surface",
+			"userMessage"
+		};
+	}
+
+	@Override
+	protected Report randomReport() throws Exception {
+		Report report = super.randomReport();
+
+		report.setAgentDefinitionExternalReferenceCodes(
+			new String[] {"L_FIX_SPELLING_AND_GRAMMAR", "L_MAKE_SHORTER"});
+		report.setChatbotExternalReferenceCode(RandomTestUtil.randomString());
+		report.setFeedback("negative");
+		report.setReason("piiExposure");
+		report.setSurface("aiAssistant");
+
+		return report;
+	}
+
+	@Override
+	protected Report testPostReport_addReport(Report report) throws Exception {
+		return reportResource.postReport(report);
+	}
+
+	private void _testPostReport(
+			String chatbotExternalReferenceCode, ReportResource reportResource)
+		throws Exception {
+
+		Report randomReport = randomReport();
+
+		randomReport.setChatbotExternalReferenceCode(
+			chatbotExternalReferenceCode);
+
+		Report postReport = reportResource.postReport(randomReport);
+
+		assertEquals(randomReport, postReport);
+
+		Assert.assertEquals("critical", postReport.getLevel());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_AI_HUB_REPORT", TestPropsValues.getCompanyId());
+
+		Page<ObjectEntry> objectEntriesPage =
+			_defaultObjectEntryManager.getRelatedObjectEntries(
+				null, _dtoConverterContext,
+				postReport.getExternalReferenceCode(), null,
+				_objectRelationshipLocalService.
+					fetchObjectRelationshipByObjectDefinitionId1(
+						objectDefinition.getObjectDefinitionId(),
+						"aiHubAgentDefinitionsToAIHubReports"),
+				null, null, null, null);
+
+		Assert.assertArrayEquals(
+			randomReport.getAgentDefinitionExternalReferenceCodes(),
+			TransformUtil.transformToArray(
+				objectEntriesPage.getItems(),
+				ObjectEntry::getExternalReferenceCode, String.class));
+	}
+
+	private static AccountEntry _accountEntry;
+
+	@Inject
+	private static AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private static AccountEntryUserRelLocalService
+		_accountEntryUserRelLocalService;
+
+	private static DefaultObjectEntryManager _defaultObjectEntryManager;
+	private static DTOConverterContext _dtoConverterContext;
+
+	@Inject
+	private static DTOConverterRegistry _dtoConverterRegistry;
+
+	@Inject(
+		filter = "object.entry.manager.storage.type=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private static ObjectEntryManager _objectEntryManager;
+
+	private static String _originalName;
+	private static PermissionChecker _originalPermissionChecker;
+
+	@Inject
+	private static SiteInitializerRegistry _siteInitializerRegistry;
+
+	@Inject
+	private static UserLocalService _userLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class ReportResourceTest extends BaseReportResourceTestCase {
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ReportResourceTest.java
@@ -195,7 +195,7 @@ public class ReportResourceTest extends BaseReportResourceTestCase {
 			new String[] {"L_FIX_SPELLING_AND_GRAMMAR", "L_MAKE_SHORTER"});
 		report.setChatbotExternalReferenceCode(RandomTestUtil.randomString());
 		report.setFeedback("negative");
-		report.setReason("piiExposure");
+		report.setReason("personalDataExposure");
 		report.setSurface("aiAssistant");
 
 		return report;

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-feedbacks-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-feedbacks-list-type-definition.json
@@ -1,0 +1,19 @@
+{
+	"externalReferenceCode": "L_AI_HUB_REPORT_FEEDBACKS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "NEGATIVE",
+			"key": "negative",
+			"name": "Negative",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "POSITIVE",
+			"key": "positive",
+			"name": "Positive",
+			"system": true
+		}
+	],
+	"name": "AI Hub Report Feedbacks",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-levels-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-levels-list-type-definition.json
@@ -1,0 +1,37 @@
+{
+	"externalReferenceCode": "L_AI_HUB_REPORT_LEVELS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "CRITICAL",
+			"key": "critical",
+			"name": "Critical",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "HIGH",
+			"key": "high",
+			"name": "High",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "LOW",
+			"key": "low",
+			"name": "Low",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "MEDIUM",
+			"key": "medium",
+			"name": "Medium",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "OTHER",
+			"key": "other",
+			"name": "Other",
+			"system": true
+		}
+	],
+	"name": "AI Hub Report Levels",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-reasons-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-reasons-list-type-definition.json
@@ -1,0 +1,37 @@
+{
+	"externalReferenceCode": "L_AI_HUB_REPORT_REASONS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "AGENT_ERROR",
+			"key": "agentError",
+			"name": "Agent Error or Malfunction",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "HARMFUL_CONTENT",
+			"key": "harmfulContent",
+			"name": "Inappropriate or Harmful Content",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "INCORRECT",
+			"key": "incorrect",
+			"name": "Incorrect or Inaccurate Response",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "OTHER",
+			"key": "other",
+			"name": "Other",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "PII_EXPOSURE",
+			"key": "piiExposure",
+			"name": "Exposure of Personal / Sensitive Data (PII)",
+			"system": true
+		}
+	],
+	"name": "AI Hub Report Reasons",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-reasons-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-reasons-list-type-definition.json
@@ -4,19 +4,19 @@
 		{
 			"externalReferenceCode": "AGENT_ERROR",
 			"key": "agentError",
-			"name": "Agent Error or Malfunction",
+			"name": "Agent Error",
 			"system": true
 		},
 		{
 			"externalReferenceCode": "HARMFUL_CONTENT",
 			"key": "harmfulContent",
-			"name": "Inappropriate or Harmful Content",
+			"name": "Harmful Content",
 			"system": true
 		},
 		{
-			"externalReferenceCode": "INCORRECT",
-			"key": "incorrect",
-			"name": "Incorrect or Inaccurate Response",
+			"externalReferenceCode": "INACCURATE_RESPONSE",
+			"key": "inaccurateResponse",
+			"name": "Inaccurate Response",
 			"system": true
 		},
 		{
@@ -26,9 +26,9 @@
 			"system": true
 		},
 		{
-			"externalReferenceCode": "PII_EXPOSURE",
-			"key": "piiExposure",
-			"name": "Exposure of Personal / Sensitive Data (PII)",
+			"externalReferenceCode": "PERSONAL_DATA_EXPOSURE",
+			"key": "personalDataExposure",
+			"name": "Personal Data Exposure",
 			"system": true
 		}
 	],

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-surfaces-list-type-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/list-type-definitions/report-surfaces-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_AI_HUB_REPORT_SURFACES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "AI_ASSISTANT",
+			"key": "aiAssistant",
+			"name": "AI Assistant",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "CLICK_TO_CHAT",
+			"key": "clickToChat",
+			"name": "Click to Chat",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "WRITING_ASSISTANT",
+			"key": "writingAssistant",
+			"name": "Writing Assistant",
+			"system": true
+		}
+	],
+	"name": "AI Hub Report Surfaces",
+	"system": true
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/report-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/report-object-definition.json
@@ -1,0 +1,139 @@
+{
+	"accountEntryRestricted": true,
+	"accountEntryRestrictedObjectFieldName": "r_accountToAIHubReports_accountEntryId",
+	"className": "com.liferay.object.model.ObjectDefinition#I9R7",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"enableObjectEntryHistory": true,
+	"externalReferenceCode": "L_AI_HUB_REPORT",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "AI Hub Report"
+	},
+	"modifiable": true,
+	"name": "AIHubReport",
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "null",
+			"externalReferenceCode": "FEEDBACK",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Feedback"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_REPORT_FEEDBACKS",
+			"name": "feedback",
+			"readOnly": false,
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "null",
+			"externalReferenceCode": "LEVEL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Level"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_REPORT_LEVELS",
+			"name": "level",
+			"readOnly": false,
+			"required": false,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "null",
+			"externalReferenceCode": "REASON",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reason"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_REPORT_REASONS",
+			"name": "reason",
+			"readOnly": false,
+			"required": false,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "null",
+			"externalReferenceCode": "SURFACE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Surface"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_AI_HUB_REPORT_SURFACES",
+			"name": "surface",
+			"readOnly": false,
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"defaultValue": "null",
+			"externalReferenceCode": "USER_MESSAGE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "User Message"
+			},
+			"name": "userMessage",
+			"readOnly": false,
+			"readOnlyConditionExpression": "",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"defaultValue": "null",
+			"externalReferenceCode": "ACCOUNT_TO_AI_HUB_REPORTS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Account to AI Hub Reports"
+			},
+			"name": "r_accountToAIHubReports_accountEntryId",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "AccountEntry"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_accountToAIHubReports_accountEntryERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_ACCOUNT_TO_L_AI_HUB_REPORTS",
+			"readOnly": false,
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "AI Hub Reports"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "externalReferenceCode"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/report-object-relationship-1.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/report-object-relationship-1.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_ACCOUNT_TO_L_AI_HUB_REPORTS",
+	"label": {
+		"en_US": "Account to AI Hub Reports"
+	},
+	"name": "accountToAIHubReports",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AccountEntry$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:AIHubReport$]",
+	"objectDefinitionName2": "AIHubReport",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/report-object-relationship-2.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-relationships/report-object-relationship-2.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "disassociate",
+	"externalReferenceCode": "L_AI_HUB_AGENT_DEFINITIONS_TO_L_AI_HUB_REPORTS",
+	"label": {
+		"en_US": "AI Hub Agent Definitions to AI Hub Reports"
+	},
+	"name": "aiHubAgentDefinitionsToAIHubReports",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AIHubAgentDefinition$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:AIHubReport$]",
+	"objectDefinitionName2": "AIHubReport",
+	"system": true,
+	"type": "manyToMany"
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
@@ -231,6 +231,15 @@
 	},
 	{
 		"actionIds": [
+			"ADD_OBJECT_ENTRY"
+		],
+		"primKey": "0",
+		"resourceName": "com.liferay.object#[$OBJECT_DEFINITION_ID:AIHubReport$]",
+		"roleName": "Guest",
+		"scope": "3"
+	},
+	{
+		"actionIds": [
 			"VIEW"
 		],
 		"primKey": "0",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/sap-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/sap-entries.json
@@ -2,7 +2,8 @@
 	{
 		"allowedServiceSignatures": [
 			"com.liferay.ai.hub.rest.internal.resource.v1_0.ChatResourceImpl#getChatSubscribe",
-			"com.liferay.ai.hub.rest.internal.resource.v1_0.MessageResourceImpl#postChatByExternalReferenceCodeMessage"
+			"com.liferay.ai.hub.rest.internal.resource.v1_0.MessageResourceImpl#postChatByExternalReferenceCodeMessage",
+			"com.liferay.ai.hub.rest.internal.resource.v1_0.ReportResourceImpl#postReport"
 		],
 		"defaultSAPEntry": true,
 		"enabled": true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92338

## What Is Being Fixed

AI Hub had no way to capture an end user's report about an agent response. There was no object to persist a report, no REST endpoint to submit one, and the chat SSE response did not expose which agent definitions produced a message — so a report could not be associated with the agents responsible for the response.

## How It Is Being Fixed

The site initializer now provisions an AIHubReport object definition with picklist fields (feedback, level, reason, surface) backed by new report-feedbacks, report-levels, report-reasons, and report-surfaces list type definitions, a user message field, and relationships to Account and AI Hub Agent Definitions. Matching object relationships and a guest ADD_OBJECT_ENTRY resource permission are added so an unauthenticated visitor can submit a report.

A POST /reports endpoint is added to the REST application (Report schema in rest-openapi.yaml, ReportResource). ReportManagerImpl creates the AIHubReport object entry, derives a severity level from the reason, and links the report to the agent definitions that produced the response. The endpoint is guarded by the LPD-62272 feature flag.

The guest context user resolution is extracted out of MessageResourceImpl into a shared ContextUserUtil reused by ReportResourceImpl. The SSE "Chat Message Sent" event now carries agentDefinitionExternalReferenceCodes, sourced from the supervisor agent's invocation scope, so the client can report against the correct agents. Report reason names are standardized per technical writer guidance.

## PR Check

**pr-check: PASS** — tested on `2ec6ae0d68f6b7eaf37daf93369965a9c748f93b`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "2ec6ae0d68f6b7eaf37daf93369965a9c748f93b"} -->