### PR TITLE
LPD-89134 Add a page editor resource command for layout data

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
@@ -1,0 +1,300 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class GetLayoutDataMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_serviceContext = new ServiceContext();
+
+		_serviceContext.setScopeGroupId(_group.getGroupId());
+		_serviceContext.setUserId(TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetLayoutData() throws Exception {
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		JSONObject jsonObject = _serveResource(segmentsExperienceId);
+
+		Assert.assertTrue(jsonObject.has("fragmentEntryLinks"));
+		Assert.assertTrue(jsonObject.has("layoutData"));
+
+		JSONObject layoutDataJSONObject = jsonObject.getJSONObject(
+			"layoutData");
+
+		Assert.assertTrue(layoutDataJSONObject.has("items"));
+		Assert.assertTrue(layoutDataJSONObject.has("rootItems"));
+
+		JSONObject rootItemsJSONObject = layoutDataJSONObject.getJSONObject(
+			"rootItems");
+
+		String mainItemId = rootItemsJSONObject.getString("main");
+
+		Assert.assertNotNull(mainItemId);
+
+		JSONObject itemsJSONObject = layoutDataJSONObject.getJSONObject(
+			"items");
+
+		Assert.assertTrue(itemsJSONObject.has(mainItemId));
+	}
+
+	@Test
+	public void testGetLayoutDataWithFragmentEntryLink() throws Exception {
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout, segmentsExperienceId);
+
+		JSONObject jsonObject = _serveResource(segmentsExperienceId);
+
+		JSONObject layoutDataJSONObject = jsonObject.getJSONObject(
+			"layoutData");
+
+		JSONObject itemsJSONObject = layoutDataJSONObject.getJSONObject(
+			"items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(fragmentEntryLink, itemsJSONObject));
+
+		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertTrue(
+			fragmentEntryLinksJSONObject.has(
+				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId())));
+	}
+
+	@Test
+	public void testGetLayoutDataWithSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getExternalReferenceCode(), null,
+				_layout.getPlid(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				true, new UnicodeProperties(true), _serviceContext);
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout, segmentsExperienceId);
+
+		FragmentEntryLink experienceFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout,
+				segmentsExperience.getSegmentsExperienceId());
+
+		JSONObject jsonObject = _serveResource(segmentsExperienceId);
+
+		JSONObject layoutDataJSONObject = jsonObject.getJSONObject(
+			"layoutData");
+
+		JSONObject itemsJSONObject = layoutDataJSONObject.getJSONObject(
+			"items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(fragmentEntryLink, itemsJSONObject));
+		Assert.assertFalse(
+			_hasFragmentEntryLink(
+				experienceFragmentEntryLink, itemsJSONObject));
+
+		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertTrue(
+			fragmentEntryLinksJSONObject.has(
+				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId())));
+		Assert.assertFalse(
+			fragmentEntryLinksJSONObject.has(
+				String.valueOf(
+					experienceFragmentEntryLink.getFragmentEntryLinkId())));
+
+		JSONObject experienceJSONObject = _serveResource(
+			segmentsExperience.getSegmentsExperienceId());
+
+		layoutDataJSONObject = experienceJSONObject.getJSONObject("layoutData");
+
+		itemsJSONObject = layoutDataJSONObject.getJSONObject("items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(
+				experienceFragmentEntryLink, itemsJSONObject));
+		Assert.assertFalse(
+			_hasFragmentEntryLink(fragmentEntryLink, itemsJSONObject));
+
+		fragmentEntryLinksJSONObject = experienceJSONObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertTrue(
+			fragmentEntryLinksJSONObject.has(
+				String.valueOf(
+					experienceFragmentEntryLink.getFragmentEntryLinkId())));
+		Assert.assertFalse(
+			fragmentEntryLinksJSONObject.has(
+				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId())));
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
+			long segmentsExperienceId)
+		throws Exception {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(
+				_companyLocalService.fetchCompany(_group.getCompanyId()),
+				_group, _layout));
+
+		mockLiferayResourceRequest.setParameter(
+			"segmentsExperienceId", String.valueOf(segmentsExperienceId));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private boolean _hasFragmentEntryLink(
+		FragmentEntryLink fragmentEntryLink, JSONObject itemsJSONObject) {
+
+		String fragmentEntryLinkId = String.valueOf(
+			fragmentEntryLink.getFragmentEntryLinkId());
+
+		for (String itemId : itemsJSONObject.keySet()) {
+			JSONObject itemJSONObject = itemsJSONObject.getJSONObject(itemId);
+
+			JSONObject configJSONObject = itemJSONObject.getJSONObject(
+				"config");
+
+			if (configJSONObject == null) {
+				continue;
+			}
+
+			if (fragmentEntryLinkId.equals(
+					configJSONObject.getString("fragmentEntryLinkId"))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private JSONObject _serveResource(long segmentsExperienceId)
+		throws Exception {
+
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(segmentsExperienceId),
+			mockLiferayResourceResponse);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			(ByteArrayOutputStream)
+				mockLiferayResourceResponse.getPortletOutputStream();
+
+		return JSONFactoryUtil.createJSONObject(
+			byteArrayOutputStream.toString());
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/get_layout_data"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
@@ -101,8 +101,6 @@ public class GetLayoutDataMVCResourceCommandTest {
 
 		String mainItemId = rootItemsJSONObject.getString("main");
 
-		Assert.assertNotNull(mainItemId);
-
 		JSONObject itemsJSONObject = layoutDataJSONObject.getJSONObject(
 			"items");
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -563,6 +563,9 @@ public class ContentPageEditorDisplayContext {
 					"/layout_content_page_editor" +
 						"/get_info_item_one_to_many_relationships")
 			).put(
+				"getLayoutDataURL",
+				_getResourceURL("/layout_content_page_editor/get_layout_data")
+			).put(
 				"getLayoutFriendlyURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_layout_friendly_url")
@@ -616,6 +619,14 @@ public class ContentPageEditorDisplayContext {
 				"layoutConversionWarningMessages",
 				MultiSessionMessages.get(
 					portletRequest, "layoutConversionWarningMessages")
+			).put(
+				"layoutExternalReferenceCode",
+				() -> {
+					Layout layout = themeDisplay.getLayout();
+
+					return GetterUtil.getString(
+						layout.getExternalReferenceCode());
+				}
 			).put(
 				"layoutItemSelectorURL", _getLayoutItemSelectorURL()
 			).put(
@@ -721,6 +732,14 @@ public class ContentPageEditorDisplayContext {
 				_getSegmentsCompanyConfigurationURL()
 			).put(
 				"sidebarPanels", getSidebarPanels()
+			).put(
+				"siteExternalReferenceCode",
+				() -> {
+					Group group = themeDisplay.getScopeGroup();
+
+					return GetterUtil.getString(
+						group.getExternalReferenceCode());
+				}
 			).put(
 				"siteNavigationMenuItemSelectorURL",
 				_getSiteNavigationMenuItemSelectorURL()

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
@@ -26,9 +26,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import jakarta.portlet.ResourceRequest;
 import jakarta.portlet.ResourceResponse;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -54,26 +51,19 @@ public class GetLayoutDataMVCResourceCommand extends BaseMVCResourceCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		long segmentsExperienceId = ParamUtil.getLong(
-			resourceRequest, "segmentsExperienceId");
-
 		LayoutStructure layoutStructure =
 			LayoutStructureUtil.getLayoutStructure(
 				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
-				segmentsExperienceId);
+				ParamUtil.getLong(resourceRequest, "segmentsExperienceId"));
 
 		JSONObject fragmentEntryLinksJSONObject =
 			_jsonFactory.createJSONObject();
 
-		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
-			resourceRequest);
-		HttpServletResponse httpServletResponse =
-			_portal.getHttpServletResponse(resourceResponse);
-
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.
 				getFragmentEntryLinksBySegmentsExperienceId(
-					themeDisplay.getScopeGroupId(), segmentsExperienceId,
+					themeDisplay.getScopeGroupId(),
+					ParamUtil.getLong(resourceRequest, "segmentsExperienceId"),
 					themeDisplay.getPlid());
 
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
@@ -81,7 +71,9 @@ public class GetLayoutDataMVCResourceCommand extends BaseMVCResourceCommand {
 				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId()),
 				_fragmentEntryLinkManager.getFragmentEntryLinkJSONObject(
 					new DefaultFragmentRendererContext(fragmentEntryLink),
-					fragmentEntryLink, httpServletRequest, httpServletResponse,
+					fragmentEntryLink,
+					_portal.getHttpServletRequest(resourceRequest),
+					_portal.getHttpServletResponse(resourceResponse),
 					layoutStructure));
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.renderer.DefaultFragmentRendererContext;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
+import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mario Gomes
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_layout_data"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetLayoutDataMVCResourceCommand extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			resourceRequest, "segmentsExperienceId");
+
+		LayoutStructure layoutStructure =
+			LayoutStructureUtil.getLayoutStructure(
+				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
+				segmentsExperienceId);
+
+		JSONObject fragmentEntryLinksJSONObject =
+			_jsonFactory.createJSONObject();
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			resourceRequest);
+		HttpServletResponse httpServletResponse =
+			_portal.getHttpServletResponse(resourceResponse);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					themeDisplay.getScopeGroupId(), segmentsExperienceId,
+					themeDisplay.getPlid());
+
+		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			fragmentEntryLinksJSONObject.put(
+				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId()),
+				_fragmentEntryLinkManager.getFragmentEntryLinkJSONObject(
+					new DefaultFragmentRendererContext(fragmentEntryLink),
+					fragmentEntryLink, httpServletRequest, httpServletResponse,
+					layoutStructure));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONUtil.put(
+				"fragmentEntryLinks", fragmentEntryLinksJSONObject
+			).put(
+				"layoutData", layoutStructure.toJSONObject()
+			));
+	}
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private FragmentEntryLinkManager _fragmentEntryLinkManager;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89134

## What Is Being Fixed

Part of splitting the multi-feature PR #529 into focused, independently reviewable PRs. Adds a Page Editor resource command that returns a page's layout data and fragment entry links, consumed by the Content Site Generator wizard. Supersedes #363 (same scope), consolidating this piece under the #529 split.

## How It Is Being Fixed

Adds `GetLayoutDataMVCResourceCommand` and the supporting `ContentPageEditorDisplayContext` accessor, returning the layout data structure and fragment entry links as JSON, with an integration test.

## PR Check

**pr-check: PASS** — tested on `50b081cad4e6ce86cac002af92ce2c1a5a84a4df`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS (this branch's files; pre-existing unrelated dynamic-data-mapping/google-places drift in the wider compile) |

<!-- pr-check {"result": "success", "sha": "50b081cad4e6ce86cac002af92ce2c1a5a84a4df"} -->