### PR TITLE
LPD-95098 Support embedding the AI Assistant Chat in a page

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -94,7 +94,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	useEffect(() => {
 		getContextRef.current = getContext;
 		instructionDefinitionScopeRef.current = instructionDefinitionScope;
-	});
+	}, [getContext, instructionDefinitionScope]);
 
 	const sendMessage = useCallback((text: string) => {
 		if (!text.trim()) {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -10,7 +10,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {EventSource} from 'eventsource';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import ReportFeedbackModal from '../ReportFeedback/ReportFeedbackModal';
 import submitPositiveReportFeedback from '../ReportFeedback/submitPositiveReportFeedback';
@@ -38,13 +38,19 @@ interface ReportContext {
 }
 
 interface AIAssistantChatProps {
+	embedded?: boolean;
 	getContext: () => ChatContext;
+	initialMessage?: string;
 	instructionDefinitionScope: string;
+	quickActions?: string[];
 }
 
 const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
+	embedded = false,
 	getContext,
+	initialMessage,
 	instructionDefinitionScope,
+	quickActions,
 }) => {
 	const [active, setActive] = useState<boolean>(false);
 	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
@@ -75,13 +81,23 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	};
 	const eventSourceRef = useRef<EventSource | null>(null);
 	const eventSourceReference = useRef<string | null>(null);
+	const getContextRef = useRef<() => ChatContext>(getContext);
+	const initialMessageRef = useRef<string | undefined>(initialMessage);
+	const initialMessageSentRef = useRef<boolean>(false);
+	const instructionDefinitionScopeRef = useRef<string>(
+		instructionDefinitionScope
+	);
 	const messagesEndRef = useRef<HTMLDivElement | null>(null);
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
-	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-		if (!message.trim()) {
+	useEffect(() => {
+		getContextRef.current = getContext;
+		instructionDefinitionScopeRef.current = instructionDefinitionScope;
+	});
+
+	const sendMessage = useCallback((text: string) => {
+		if (!text.trim()) {
 			return;
 		}
 
@@ -90,7 +106,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 				messagesEndRef.current?.scrollIntoView({behavior: 'smooth'});
 			}, 0);
 
-			return [...previousMessages, {sender: 'user', text: message}];
+			return [...previousMessages, {sender: 'user', text}];
 		});
 
 		setMessage('');
@@ -98,13 +114,22 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		if (eventSourceReference.current) {
 			setIsGenerating(true);
 
+			const getCurrentContext = getContextRef.current;
+
 			postChatByExternalReferenceCodeMessage({
-				chatContext: getContext(),
+				chatContext: getCurrentContext(),
 				eventSourceReference: eventSourceReference.current,
-				instructionDefinitionScope,
-				message,
+				instructionDefinitionScope:
+					instructionDefinitionScopeRef.current,
+				message: text,
 			}).catch(() => setIsGenerating(false));
 		}
+	}, []);
+
+	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		sendMessage(message);
 	}
 
 	function adjustTextAreaHeight(element: HTMLTextAreaElement) {
@@ -163,7 +188,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		}
 	}
 
-	function openAIAssistantChatConnection() {
+	const openAIAssistantChatConnection = useCallback(() => {
 		createEventSource().then((eventSource) => {
 			if (!eventSource) {
 				return;
@@ -212,6 +237,15 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 
 			eventSourceRef.current.addEventListener('Subscribe', (event) => {
 				eventSourceReference.current = event.data;
+
+				if (
+					initialMessageRef.current &&
+					!initialMessageSentRef.current
+				) {
+					initialMessageSentRef.current = true;
+
+					sendMessage(initialMessageRef.current);
+				}
 			});
 
 			eventSourceRef.current.addEventListener(
@@ -247,13 +281,13 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 				}
 			);
 		});
-	}
+	}, [sendMessage]);
 
-	function closeAIAssistantChatConnection() {
+	const closeAIAssistantChatConnection = useCallback(() => {
 		eventSourceRef.current?.close();
 
 		eventSourceRef.current = null;
-	}
+	}, []);
 
 	useEffect(() => {
 		openAIAssistantChatConnection();
@@ -261,7 +295,144 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		return () => {
 			closeAIAssistantChatConnection();
 		};
-	}, []);
+	}, [closeAIAssistantChatConnection, openAIAssistantChatConnection]);
+
+	const chatSurface = (
+		<>
+			<div className="ai-assistant-chat__messages-container flex-grow-1 overflow-auto px-3">
+				{!initialMessage && (
+					<AIAssistantMessageBalloon
+						error={false}
+						message="Hi! I can help you generate content, titles, tags, or
+						translate your work. What would you like to do?"
+					/>
+				)}
+
+				{messages.map((item, index) =>
+					item.sender === 'user' ? (
+						<UserMessageBalloon key={index} message={item.text} />
+					) : (
+						<AIAssistantMessageBalloon
+							error={item.error ?? false}
+							feedbackGiven={Boolean(feedbackGiven[index])}
+							key={index}
+							message={item.text}
+							onReport={
+								!item.error
+									? () =>
+											setReportContext({
+												agentDefinitionExternalReferenceCodes:
+													item.agentDefinitionExternalReferenceCodes ??
+													[],
+												index,
+											})
+									: undefined
+							}
+							onThumbsUp={
+								!item.error
+									? () => handleThumbsUp(index, item)
+									: undefined
+							}
+						/>
+					)
+				)}
+
+				{isGenerating && (
+					<div className="ai-assistant-chat-balloon d-flex flex-row mb-2 rounded">
+						<div className="align-items-center d-flex ml-2">
+							<ClayLoadingIndicator />
+						</div>
+
+						<span className="ai-assistant-chat__generating-loading-text font-weight-semi-bold m-2 tex">
+							{Liferay.Language.get('generating')}
+						</span>
+					</div>
+				)}
+
+				<div ref={messagesEndRef} />
+			</div>
+
+			{!!quickActions?.length && (
+				<div className="ai-assistant-chat__quick-actions flex-shrink-0 px-3">
+					<span className="ai-assistant-chat__quick-actions-title small text-secondary">
+						{Liferay.Language.get('quick-actions')}
+					</span>
+
+					<div className="d-flex flex-wrap">
+						{quickActions.map((quickAction) => (
+							<ClayButton
+								className="mb-1 mr-1"
+								disabled={isGenerating}
+								displayType="secondary"
+								key={quickAction}
+								onClick={() => sendMessage(quickAction)}
+								size="xs"
+							>
+								<ClayIcon
+									className="mr-1"
+									height={12}
+									spritemap={Liferay.Icons.spritemap}
+									symbol="stars"
+									width={12}
+								/>
+
+								{quickAction}
+							</ClayButton>
+						))}
+					</div>
+				</div>
+			)}
+
+			<ClayForm
+				className="flex-shrink-0 pt-3 px-3"
+				onSubmit={(event) => onSubmit(event)}
+			>
+				<div className="align-items-end d-flex flex-row">
+					<textarea
+						className="ai-assistant-chat__input form-control mr-2"
+						disabled={isGenerating}
+						id="assistant-user-input"
+						onChange={(event) => {
+							setMessage(event.target.value);
+							adjustTextAreaHeight(event.target);
+						}}
+						onKeyDown={(
+							event: React.KeyboardEvent<HTMLTextAreaElement>
+						) => {
+							handleTextAreaKeyDown(event);
+						}}
+						placeholder="Ask me anything..."
+						ref={textAreaRef}
+						rows={1}
+						value={message}
+					/>
+
+					<ClayButton
+						disabled={!message.trim()}
+						displayType="primary"
+						type="submit"
+					>
+						<ClayIcon
+							height={12}
+							spritemap={Liferay.Icons.spritemap}
+							symbol={isGenerating ? 'square' : 'order-arrow-up'}
+							width={12}
+						/>
+					</ClayButton>
+				</div>
+			</ClayForm>
+
+			<AIAssistantFooterDisclaimer />
+		</>
+	);
+
+	if (embedded) {
+		return (
+			<div className="ai-assistant-chat__embedded d-flex flex-column pt-3">
+				{chatSurface}
+			</div>
+		);
+	}
 
 	return (
 		<ClayDropDown
@@ -323,102 +494,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 					</ClayLayout.ContentRow>
 				</div>
 
-				<div className="ai-assistant-chat__messages-container flex-grow-1 overflow-auto px-3">
-					<AIAssistantMessageBalloon
-						error={false}
-						message="Hi! I can help you generate content, titles, tags, or
-						translate your work. What would you like to do?"
-					/>
-
-					{messages.map((item, index) =>
-						item.sender === 'user' ? (
-							<UserMessageBalloon
-								key={index}
-								message={item.text}
-							/>
-						) : (
-							<AIAssistantMessageBalloon
-								error={item.error ?? false}
-								feedbackGiven={Boolean(feedbackGiven[index])}
-								key={index}
-								message={item.text}
-								onReport={
-									!item.error
-										? () =>
-												setReportContext({
-													agentDefinitionExternalReferenceCodes:
-														item.agentDefinitionExternalReferenceCodes ??
-														[],
-													index,
-												})
-										: undefined
-								}
-								onThumbsUp={
-									!item.error
-										? () => handleThumbsUp(index, item)
-										: undefined
-								}
-							/>
-						)
-					)}
-
-					{isGenerating && (
-						<div className="ai-assistant-chat-balloon d-flex flex-row mb-2 rounded">
-							<div className="align-items-center d-flex ml-2">
-								<ClayLoadingIndicator />
-							</div>
-
-							<span className="ai-assistant-chat__generating-loading-text font-weight-semi-bold m-2 tex">
-								{Liferay.Language.get('generating')}
-							</span>
-						</div>
-					)}
-
-					<div ref={messagesEndRef} />
-				</div>
-
-				<ClayForm
-					className="flex-shrink-0 pt-3 px-3"
-					onSubmit={(event) => onSubmit(event)}
-				>
-					<div className="align-items-end d-flex flex-row">
-						<textarea
-							className="ai-assistant-chat__input form-control mr-2"
-							disabled={isGenerating}
-							id="assistant-user-input"
-							onChange={(event) => {
-								setMessage(event.target.value);
-								adjustTextAreaHeight(event.target);
-							}}
-							onKeyDown={(
-								event: React.KeyboardEvent<HTMLTextAreaElement>
-							) => {
-								handleTextAreaKeyDown(event);
-							}}
-							placeholder="Ask me anything..."
-							ref={textAreaRef}
-							rows={1}
-							value={message}
-						/>
-
-						<ClayButton
-							disabled={!message.trim()}
-							displayType="primary"
-							type="submit"
-						>
-							<ClayIcon
-								height={12}
-								spritemap={Liferay.Icons.spritemap}
-								symbol={
-									isGenerating ? 'square' : 'order-arrow-up'
-								}
-								width={12}
-							/>
-						</ClayButton>
-					</div>
-				</ClayForm>
-
-				<AIAssistantFooterDisclaimer />
+				{chatSurface}
 			</div>
 
 			{reportContext !== null && (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -1,6 +1,20 @@
 @import 'atlas-variables';
 
-.ai-assistant-chat__dropdown-container {
+.ai-assistant-chat__embedded {
+	height: 100%;
+
+	.ai-assistant-chat__messages-container {
+		min-height: 200px;
+	}
+
+	.ai-assistant-chat__quick-actions-title {
+		display: block;
+		margin-bottom: 0.5rem;
+	}
+}
+
+.ai-assistant-chat__dropdown-container,
+.ai-assistant-chat__embedded {
 	height: 100%;
 	width: 100%;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95098

## What Is Being Fixed

Part of splitting the multi-feature PR #529 into focused, independently reviewable PRs. Adds support for embedding the AI Assistant Chat inside a page (e.g. the Content Site Generator wizard), so it can render in an in-page embedded layout rather than only as the floating widget.

## How It Is Being Fixed

Adds an `embedded` prop to `AIAssistantChat` and the corresponding `chat.scss` layout that switches the component to an embedded rendering. Rebased onto current master, preserving the existing report-feedback flow.

## Why Are There No Tests?

This commit does not add a new test, but the component is covered by the module's existing `AIAssistantChat.test.tsx` suite (12 tests, passing with this change), and the embedded mode is further exercised by the Content Site Generator wizard tests shipping in a later piece of the split.

## PR Check

**pr-check: PASS** — tested on `a6e276d71cd5a2a5f8ee76f6e00f184dbb457473`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a6e276d71cd5a2a5f8ee76f6e00f184dbb457473"} -->