### PR TITLE
LPD-93985 Enforce the concurrent agent execution limit on async runs

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
@@ -7,21 +7,21 @@ package com.liferay.ai.hub.quota;
 
 import com.liferay.portal.kernel.exception.PortalException;
 
-import java.io.Closeable;
-
 /**
  * @author Carolina Barbosa
  */
 public interface QuotaManager {
 
-	public void addQuotas(long accountEntryId, long companyId, long userId)
+	public String acquireAgentInstancePermit(long userId)
 		throws PortalException;
 
-	public Closeable checkConcurrentRequests(long userId)
+	public void addQuotas(long accountEntryId, long companyId, long userId)
 		throws PortalException;
 
 	public void checkTokensUsage(long companyId, long userId)
 		throws PortalException;
+
+	public void releaseAgentInstancePermit(String permit);
 
 	public void updateUsage(long companyId, Usage usage, long userId)
 		throws PortalException;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
@@ -31,7 +31,6 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 
-import java.io.Closeable;
 import java.io.Serializable;
 
 import java.lang.reflect.InvocationHandler;
@@ -83,8 +82,12 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 	}
 
 	public Object invoke(Map<String, ?> inputObjects) {
-		try (Closeable closeable = _quotaManager.checkConcurrentRequests(
-				_agentContext.getUserId())) {
+		boolean invoked = false;
+		String permit = null;
+
+		try {
+			permit = _quotaManager.acquireAgentInstancePermit(
+				_agentContext.getUserId());
 
 			Company company = CompanyLocalServiceUtil.getCompany(
 				_agentContext.getCompanyId());
@@ -95,6 +98,8 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 					_agentContext.getServiceContext()
 				).put(
 					"agentDefinitionExternalReferenceCode", _name
+				).put(
+					"agentInstancePermit", permit
 				).put(
 					"instructionDefinitionScope",
 					_agentContext.getInstructionDefinitionScope()
@@ -156,6 +161,8 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 			MessageBusUtil.sendMessage(
 				AIHubDestinationNames.AI_HUB_AGENT_INSTANCE, message);
 
+			invoked = true;
+
 			if (async()) {
 				return workflowInstance.getWorkflowInstanceId();
 			}
@@ -167,6 +174,11 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
+		}
+		finally {
+			if (!invoked && (permit != null)) {
+				_quotaManager.releaseAgentInstancePermit(permit);
+			}
 		}
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/AIHubAgentInstanceMessageListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/AIHubAgentInstanceMessageListener.java
@@ -6,7 +6,9 @@
 package com.liferay.ai.hub.internal.messaging;
 
 import com.liferay.ai.hub.internal.audit.AuditRouterUtil;
+import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
 import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
@@ -16,8 +18,10 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 
 import java.util.Date;
+import java.util.Objects;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -25,6 +29,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Feliphe Marinho
@@ -61,11 +66,35 @@ public class AIHubAgentInstanceMessageListener extends BaseMessageListener {
 			(Date)message.get("createDate"), message.getString("eventType"),
 			(JSONObject)message.get("additionalInformation"),
 			message.getLong("userId"));
+
+		if (Objects.equals(
+				AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE,
+				message.getString("eventType")) ||
+			Objects.equals(
+				AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE_EXCEPTIONALLY,
+				message.getString("eventType"))) {
+
+			WorkflowInstance workflowInstance =
+				_workflowInstanceManager.getWorkflowInstance(
+					message.getLong("companyId"),
+					message.getLong("workflowInstanceId"));
+
+			_quotaManager.releaseAgentInstancePermit(
+				MapUtil.getString(
+					workflowInstance.getWorkflowContext(),
+					"agentInstancePermit"));
+		}
 	}
 
 	@Reference
 	private DestinationFactory _destinationFactory;
 
 	private ServiceRegistration<Destination> _destinationServiceRegistration;
+
+	@Reference(policyOption = ReferencePolicyOption.GREEDY)
+	private QuotaManager _quotaManager;
+
+	@Reference
+	private WorkflowInstanceManager _workflowInstanceManager;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManager.java
@@ -9,8 +9,6 @@ import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.ai.hub.quota.Usage;
 import com.liferay.portal.kernel.exception.PortalException;
 
-import java.io.Closeable;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -22,19 +20,22 @@ import org.osgi.service.component.annotations.Component;
 public class DummyQuotaManager implements QuotaManager {
 
 	@Override
+	public String acquireAgentInstancePermit(long userId)
+		throws PortalException {
+
+		return null;
+	}
+
+	@Override
 	public void addQuotas(long accountEntryId, long companyId, long userId) {
 	}
 
 	@Override
-	public Closeable checkConcurrentRequests(long userId)
-		throws PortalException {
-
-		return () -> {
-		};
+	public void checkTokensUsage(long companyId, long userId) {
 	}
 
 	@Override
-	public void checkTokensUsage(long companyId, long userId) {
+	public void releaseAgentInstancePermit(String permit) {
 	}
 
 	@Override

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManager.java
@@ -19,7 +19,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = "service.ranking:Integer=-1", service = QuotaManager.class
 )
-public class DummyQuotaManagerImpl implements QuotaManager {
+public class DummyQuotaManager implements QuotaManager {
 
 	@Override
 	public void addQuotas(long accountEntryId, long companyId, long userId) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93985

## What Is Being Fixed

The concurrent agent execution limit was only enforced for synchronous
agent executions. It relied on `QuotaManager.checkConcurrentRequests`,
which returned a `Closeable` released when the synchronous invocation
returned. Asynchronous agent executions run through the workflow and
messaging pipeline and complete later, so the permit could not span their
lifetime and the limit went unenforced for them.

## How It Is Being Fixed

The `Closeable`-based `checkConcurrentRequests` is replaced with an
explicit permit lifecycle on `QuotaManager`: `acquireAgentInstancePermit`
returns a permit at the start of an invocation and
`releaseAgentInstancePermit` releases it. `InternalAgentImpl` acquires the
permit and stores it in the workflow context under `agentInstancePermit`
so it travels with the asynchronous execution.
`AIHubAgentInstanceMessageListener` releases the permit when it observes
the agent instance complete or complete-exceptionally events, reading the
permit back from the workflow instance context. The dummy implementation
is updated to the new interface and renamed from `DummyQuotaManagerImpl`
to `DummyQuotaManager`.

## Why Are There No Tests?

The permit lifecycle spans the asynchronous workflow and messaging
pipeline — acquired in `InternalAgentImpl` and released in the
agent-instance message listener — which is difficult to exercise reliably
at the unit or integration level given the cross-component, asynchronous
flow. The behavior will be covered by a follow-up once a harness for the
async agent pipeline is in place.

## PR Check

**pr-check: PASS** — tested on `10fa21bcca2987af1091776c028cedd504fa1367`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "10fa21bcca2987af1091776c028cedd504fa1367"} -->