### PR TITLE
LPD-95305 Add endpoint to disassociate two specific related entries

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -79,6 +79,13 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 			String parentExternalReferenceCode, String scopeKey)
 		throws Exception;
 
+	public void disassociateRelatedModel(
+			DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			String relatedExternalReferenceCode, String scopeKey)
+		throws Exception;
+
 	public void disassociateRelatedModels(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 23.1.0
+version 23.2.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -514,6 +514,36 @@ public class DefaultObjectEntryManagerImpl
 	}
 
 	@Override
+	public void disassociateRelatedModel(
+			DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			String relatedExternalReferenceCode, String scopeKey)
+		throws Exception {
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryService.getObjectEntry(
+				externalReferenceCode, getGroupId(objectDefinition, scopeKey),
+				objectDefinition.getObjectDefinitionId());
+
+		ObjectDefinition relatedObjectDefinition =
+			ObjectRelationshipUtil.getRelatedObjectDefinition(
+				objectDefinition, objectRelationship);
+
+		com.liferay.object.model.ObjectEntry serviceBuilderRelatedObjectEntry =
+			_objectEntryService.getObjectEntry(
+				relatedExternalReferenceCode,
+				getGroupId(relatedObjectDefinition, scopeKey),
+				relatedObjectDefinition.getObjectDefinitionId());
+
+		_disassociateRelatedModels(
+			objectDefinition, objectRelationship,
+			serviceBuilderObjectEntry.getObjectEntryId(),
+			new long[] {serviceBuilderRelatedObjectEntry.getObjectEntryId()},
+			relatedObjectDefinition, dtoConverterContext.getUserId());
+	}
+
+	@Override
 	public void disassociateRelatedModels(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
@@ -459,6 +459,40 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl
 
 	@Consumes({"application/json", "application/xml"})
 	@Operation(
+		operationId = "postByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate"
+	)
+	@Parameters(
+		{
+			@Parameter(
+				in = ParameterIn.PATH, name = "currentExternalReferenceCode"
+			),
+			@Parameter(in = ParameterIn.PATH, name = "objectRelationshipName"),
+			@Parameter(
+				in = ParameterIn.PATH, name = "relatedExternalReferenceCode"
+			)
+		}
+	)
+	@Path(
+		"/by-external-reference-code/{currentExternalReferenceCode}/{objectRelationshipName}/{relatedExternalReferenceCode}/disassociate"
+	)
+	@POST
+	@Produces({"application/json", "application/xml"})
+	@Tags(@Tag(name = "ObjectEntry"))
+	public abstract void
+			postByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("currentExternalReferenceCode")
+				String currentExternalReferenceCode,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("objectRelationshipName")
+				String objectRelationshipName,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("relatedExternalReferenceCode")
+				String relatedExternalReferenceCode)
+		throws Exception;
+
+	@Consumes({"application/json", "application/xml"})
+	@Operation(
 		operationId = "postByExternalReferenceCodeObjectEntryObjectRelationshipName"
 	)
 	@Parameters(
@@ -506,6 +540,43 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl
 			@NotNull @Parameter(hidden = true)
 			@PathParam("objectRelationshipName")
 			String objectRelationshipName)
+		throws Exception;
+
+	@Consumes({"application/json", "application/xml"})
+	@Operation(
+		operationId = "postScopeScopeKeyByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate"
+	)
+	@Parameters(
+		{
+			@Parameter(in = ParameterIn.PATH, name = "scopeKey"),
+			@Parameter(
+				in = ParameterIn.PATH, name = "currentExternalReferenceCode"
+			),
+			@Parameter(in = ParameterIn.PATH, name = "objectRelationshipName"),
+			@Parameter(
+				in = ParameterIn.PATH, name = "relatedExternalReferenceCode"
+			)
+		}
+	)
+	@Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/{objectRelationshipName}/{relatedExternalReferenceCode}/disassociate"
+	)
+	@POST
+	@Produces({"application/json", "application/xml"})
+	@Tags(@Tag(name = "ObjectEntry"))
+	public abstract void
+			postScopeScopeKeyByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate(
+				@NotNull @Parameter(hidden = true) @PathParam("scopeKey") String
+					scopeKey,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("currentExternalReferenceCode")
+				String currentExternalReferenceCode,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("objectRelationshipName")
+				String objectRelationshipName,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("relatedExternalReferenceCode")
+				String relatedExternalReferenceCode)
 		throws Exception;
 
 	@Consumes({"application/json", "application/xml"})

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -354,6 +354,29 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	}
 
 	@Override
+	public void
+			postByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate(
+				String currentExternalReferenceCode,
+				String objectRelationshipName,
+				String relatedExternalReferenceCode)
+		throws Exception {
+
+		DefaultObjectEntryManager defaultObjectEntryManager =
+			DefaultObjectEntryManagerProvider.provide(
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					_objectDefinition.getCompanyId(),
+					_objectDefinition.getStorageType()));
+
+		defaultObjectEntryManager.disassociateRelatedModel(
+			_getDTOConverterContext(null), currentExternalReferenceCode,
+			_objectDefinition,
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectDefinition.getObjectDefinitionId(),
+				objectRelationshipName),
+			relatedExternalReferenceCode, null);
+	}
+
+	@Override
 	public Object postByExternalReferenceCodeObjectEntryObjectRelationshipName(
 			String currentExternalReferenceCode, ObjectEntry objectEntry,
 			String objectRelationshipName)
@@ -391,6 +414,29 @@ public class ObjectEntryRelatedObjectsResourceImpl
 			_objectRelationshipLocalService.getObjectRelationship(
 				_objectDefinition.getObjectDefinitionId(),
 				objectRelationshipName));
+	}
+
+	@Override
+	public void
+			postScopeScopeKeyByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate(
+				String scopeKey, String currentExternalReferenceCode,
+				String objectRelationshipName,
+				String relatedExternalReferenceCode)
+		throws Exception {
+
+		DefaultObjectEntryManager defaultObjectEntryManager =
+			DefaultObjectEntryManagerProvider.provide(
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					_objectDefinition.getCompanyId(),
+					_objectDefinition.getStorageType()));
+
+		defaultObjectEntryManager.disassociateRelatedModel(
+			_getDTOConverterContext(null), currentExternalReferenceCode,
+			_objectDefinition,
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectDefinition.getObjectDefinitionId(),
+				objectRelationshipName),
+			relatedExternalReferenceCode, scopeKey);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -1291,6 +1291,14 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testPostByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate()
+		throws Exception {
+
+		_testDisassociateRelatedModels(
+			_objectDefinition1, _objectDefinition2, null);
+	}
+
+	@Test
 	public void testPostCustomObjectEntryWithInvalidNestedSystemObjectEntries()
 		throws Exception {
 
@@ -1432,6 +1440,41 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		Assert.assertEquals(
 			objectFieldValue2,
 			relatedObjectEntryJSONObject.get(_OBJECT_FIELD_NAME_2));
+	}
+
+	@Test
+	public void testPostScopeScopeKeyByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNameRelatedExternalReferenceCodeDisassociate()
+		throws Exception {
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				List.of(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						_OBJECT_FIELD_NAME_1
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		_objectDefinitions.add(objectDefinition1);
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				List.of(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						_OBJECT_FIELD_NAME_1
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		_objectDefinitions.add(objectDefinition2);
+
+		_testDisassociateRelatedModels(
+			objectDefinition1, objectDefinition2,
+			String.valueOf(TestPropsValues.getGroupId()));
 	}
 
 	@Test
@@ -2305,6 +2348,77 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
+	private void _testDisassociateRelatedModels(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, String scopeKey)
+		throws Exception {
+
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			objectDefinition1, objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getPrimaryKey(), objectEntry3.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			_getEndpoint(
+				objectRelationship.getName(), objectDefinition1,
+				objectEntry1.getObjectEntryId()),
+			Http.Method.GET);
+
+		JSONArray jsonArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+
+		_assertEquals(objectEntry2, jsonArray.getJSONObject(0));
+		_assertEquals(objectEntry3, jsonArray.getJSONObject(1));
+
+		String endpoint = StringBundler.concat(
+			"/by-external-reference-code/",
+			objectEntry1.getExternalReferenceCode(), StringPool.SLASH,
+			objectRelationship.getName(), StringPool.SLASH,
+			objectEntry2.getExternalReferenceCode(), "/disassociate");
+
+		if (scopeKey == null) {
+			Assert.assertEquals(
+				204,
+				HTTPTestUtil.invokeToHttpCode(
+					null, objectDefinition1.getRESTContextPath() + endpoint,
+					Http.Method.POST));
+		}
+		else {
+			Assert.assertEquals(
+				204,
+				HTTPTestUtil.invokeToHttpCode(
+					null,
+					StringBundler.concat(
+						objectDefinition1.getRESTContextPath(), "/scopes/",
+						scopeKey, endpoint),
+					Http.Method.POST));
+		}
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			_getEndpoint(
+				objectRelationship.getName(), objectDefinition1,
+				objectEntry1.getObjectEntryId()),
+			Http.Method.GET);
+
+		_assertEquals(objectEntry3, jsonObject.getJSONArray("items"));
 	}
 
 	private void _testPostCustomObjectEntryWithInvalidNestedSystemObjectEntries(

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
@@ -11,8 +11,8 @@ import {generateExternalReferenceCode} from '../../utils/externalReferenceCode';
 import {required, requiredLocalized, validate} from '../../utils/validations';
 import {DEFAULT_AGENT_DEFINITION} from '../constants';
 import {
-	deleteAgentDefinitionToContentRetrievers,
-	deleteAgentDefinitionToGuardrails,
+	disassociateAgentDefinitionFromContentRetriever,
+	disassociateAgentDefinitionFromGuardrail,
 	getAgentDefinition,
 	postAgentDefinition,
 	putAgentDefinition,
@@ -42,12 +42,12 @@ export function useAgentDefinitionForm({
 	);
 
 	const contentRetrievers = useRelationshipPicker<ContentRetriever>({
-		deleteRelationship: deleteAgentDefinitionToContentRetrievers,
+		deleteRelationship: disassociateAgentDefinitionFromContentRetriever,
 		fetchSourceList: getContentRetrievers,
 		putRelationship: putAgentDefinitionToContentRetrievers,
 	});
 	const guardrails = useRelationshipPicker<Guardrail>({
-		deleteRelationship: deleteAgentDefinitionToGuardrails,
+		deleteRelationship: disassociateAgentDefinitionFromGuardrail,
 		fetchSourceList: getGuardrails,
 		putRelationship: putAgentDefinitionToGuardrails,
 	});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -11,25 +11,25 @@ const AGENT_DEFINITION_BASE_URI = '/o/ai-hub/agent-definitions';
 
 const AGENT_DEFINITION_BY_ERC_URI = `${AGENT_DEFINITION_BASE_URI}/by-external-reference-code/`;
 
-async function deleteAgentDefinitionToContentRetrievers(
+async function disassociateAgentDefinitionFromContentRetriever(
 	agentDefinitionERC: string,
 	contentRetrieverERC: string
 ) {
 	return fetch(
 		`${AGENT_DEFINITION_BY_ERC_URI}${agentDefinitionERC}` +
-			`/agentDefinitionsToContentRetrievers/${contentRetrieverERC}`,
-		{method: 'DELETE'}
+			`/agentDefinitionsToContentRetrievers/${contentRetrieverERC}/disassociate`,
+		{method: 'POST'}
 	);
 }
 
-async function deleteAgentDefinitionToGuardrails(
+async function disassociateAgentDefinitionFromGuardrail(
 	agentDefinitionERC: string,
 	guardrailERC: string
 ) {
 	return fetch(
 		`${AGENT_DEFINITION_BY_ERC_URI}${agentDefinitionERC}` +
-			`/aiHubAgentDefinitionsToAIHubGuardrails/${guardrailERC}`,
-		{method: 'DELETE'}
+			`/aiHubAgentDefinitionsToAIHubGuardrails/${guardrailERC}/disassociate`,
+		{method: 'POST'}
 	);
 }
 
@@ -109,8 +109,8 @@ async function putAgentDefinitionToGuardrails(
 }
 
 export {
-	deleteAgentDefinitionToContentRetrievers,
-	deleteAgentDefinitionToGuardrails,
+	disassociateAgentDefinitionFromContentRetriever,
+	disassociateAgentDefinitionFromGuardrail,
 	getAgentDefinition,
 	getAgentDefinitions,
 	postAgentDefinition,

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
@@ -20,7 +20,7 @@ import './ChatbotForm.scss';
 import {getAgentDefinitions} from '../agent_definition_form/services/AgentDefinitionService';
 import Toolbar from '../components/ToolBar';
 import {
-	deleteChatbotAgentDefinitionRelationship,
+	disassociateChatbotFromAgentDefinition,
 	getChatbot,
 	postChatbot,
 	putChatbot,
@@ -314,7 +314,7 @@ export default function ChatbotForm({
 
 			await Promise.all(
 				removedAgents.map((agent) =>
-					deleteChatbotAgentDefinitionRelationship(
+					disassociateChatbotFromAgentDefinition(
 						chatbotExternalReferenceCode,
 						agent.externalReferenceCode
 					)

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
@@ -17,6 +17,19 @@ const HEADERS = new Headers({
 	'Content-Type': 'application/json',
 });
 
+async function disassociateChatbotFromAgentDefinition(
+	chatbotERC: string,
+	agentERC: string
+) {
+	return fetch(
+		`${CHATBOT_BY_ERC_URI}${chatbotERC}/agentDefinitionsToChatbots/${agentERC}/disassociate`,
+		{
+			headers: HEADERS,
+			method: 'POST',
+		}
+	);
+}
+
 async function getChatbots() {
 	const response = await fetch(CHATBOT_BASE_URI, {
 		headers: HEADERS,
@@ -84,19 +97,6 @@ async function putChatbot(
 	return response.json();
 }
 
-async function deleteChatbotAgentDefinitionRelationship(
-	chatbotERC: string,
-	agentERC: string
-) {
-	return fetch(
-		`${CHATBOT_BY_ERC_URI}${chatbotERC}/agentDefinitionsToChatbots/${agentERC}`,
-		{
-			headers: HEADERS,
-			method: 'DELETE',
-		}
-	);
-}
-
 async function putChatbotAgentDefinitionRelationship(
 	chatbotERC: string,
 	agentERC: string
@@ -111,7 +111,7 @@ async function putChatbotAgentDefinitionRelationship(
 }
 
 export {
-	deleteChatbotAgentDefinitionRelationship,
+	disassociateChatbotFromAgentDefinition,
 	getChatbot,
 	getChatbots,
 	postChatbot,

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/AgentDefinitionForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/AgentDefinitionForm.test.tsx
@@ -15,8 +15,8 @@ import React from 'react';
 
 import AgentDefinitionForm from '../../../src/main/resources/META-INF/resources/js/agent_definition_form/AgentDefinitionForm';
 
-const mockDeleteAgentDefinitionToContentRetrievers = jest.fn();
-const mockDeleteAgentDefinitionToGuardrails = jest.fn();
+const mockDisassociateAgentDefinitionFromContentRetriever = jest.fn();
+const mockDisassociateAgentDefinitionFromGuardrail = jest.fn();
 const mockGetAgentDefinition = jest.fn();
 const mockGetContentRetrievers = jest.fn();
 const mockGetGuardrails = jest.fn();
@@ -31,10 +31,10 @@ const mockPutAgentDefinitionToGuardrails = jest.fn();
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService',
 	() => ({
-		deleteAgentDefinitionToContentRetrievers: (...args: any[]) =>
-			mockDeleteAgentDefinitionToContentRetrievers(...args),
-		deleteAgentDefinitionToGuardrails: (...args: any[]) =>
-			mockDeleteAgentDefinitionToGuardrails(...args),
+		disassociateAgentDefinitionFromContentRetriever: (...args: any[]) =>
+			mockDisassociateAgentDefinitionFromContentRetriever(...args),
+		disassociateAgentDefinitionFromGuardrail: (...args: any[]) =>
+			mockDisassociateAgentDefinitionFromGuardrail(...args),
 		getAgentDefinition: (...args: any[]) => mockGetAgentDefinition(...args),
 		postAgentDefinition: (...args: any[]) =>
 			mockPostAgentDefinition(...args),
@@ -167,8 +167,8 @@ const defaultProps = {
 
 describe('AgentDefinitionForm', () => {
 	beforeEach(() => {
-		mockDeleteAgentDefinitionToContentRetrievers.mockReset();
-		mockDeleteAgentDefinitionToGuardrails.mockReset();
+		mockDisassociateAgentDefinitionFromContentRetriever.mockReset();
+		mockDisassociateAgentDefinitionFromGuardrail.mockReset();
 		mockGetAgentDefinition.mockReset();
 		mockGetContentRetrievers.mockReset();
 		mockGetGuardrails.mockReset();

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/hooks/useAgentDefinitionForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/hooks/useAgentDefinitionForm.test.tsx
@@ -7,8 +7,8 @@ import {act, renderHook, waitFor} from '@testing-library/react';
 
 import {useAgentDefinitionForm} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm';
 
-const mockDeleteAgentDefinitionToContentRetrievers = jest.fn();
-const mockDeleteAgentDefinitionToGuardrails = jest.fn();
+const mockDisassociateAgentDefinitionFromContentRetriever = jest.fn();
+const mockDisassociateAgentDefinitionFromGuardrail = jest.fn();
 const mockGetAgentDefinition = jest.fn();
 const mockGetContentRetrievers = jest.fn();
 const mockGetGuardrails = jest.fn();
@@ -21,10 +21,10 @@ const mockPutAgentDefinitionToGuardrails = jest.fn();
 jest.mock(
 	'../../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService',
 	() => ({
-		deleteAgentDefinitionToContentRetrievers: (...args: any[]) =>
-			mockDeleteAgentDefinitionToContentRetrievers(...args),
-		deleteAgentDefinitionToGuardrails: (...args: any[]) =>
-			mockDeleteAgentDefinitionToGuardrails(...args),
+		disassociateAgentDefinitionFromContentRetriever: (...args: any[]) =>
+			mockDisassociateAgentDefinitionFromContentRetriever(...args),
+		disassociateAgentDefinitionFromGuardrail: (...args: any[]) =>
+			mockDisassociateAgentDefinitionFromGuardrail(...args),
 		getAgentDefinition: (...args: any[]) => mockGetAgentDefinition(...args),
 		postAgentDefinition: (...args: any[]) =>
 			mockPostAgentDefinition(...args),
@@ -94,8 +94,8 @@ async function fillRequiredFields(result: any) {
 
 describe('useAgentDefinitionForm', () => {
 	beforeEach(() => {
-		mockDeleteAgentDefinitionToContentRetrievers.mockReset();
-		mockDeleteAgentDefinitionToGuardrails.mockReset();
+		mockDisassociateAgentDefinitionFromContentRetriever.mockReset();
+		mockDisassociateAgentDefinitionFromGuardrail.mockReset();
 		mockGetAgentDefinition.mockReset();
 		mockGetContentRetrievers.mockReset();
 		mockGetGuardrails.mockReset();
@@ -171,7 +171,7 @@ describe('useAgentDefinitionForm', () => {
 				mockPutAgentDefinitionToContentRetrievers
 			).not.toHaveBeenCalled();
 			expect(
-				mockDeleteAgentDefinitionToContentRetrievers
+				mockDisassociateAgentDefinitionFromContentRetriever
 			).not.toHaveBeenCalled();
 		});
 
@@ -300,8 +300,10 @@ describe('useAgentDefinitionForm', () => {
 				externalReferenceCode: 'AGENT_X',
 				status: {label: 'approved'},
 			});
-			mockDeleteAgentDefinitionToContentRetrievers.mockResolvedValue({});
-			mockDeleteAgentDefinitionToGuardrails.mockResolvedValue({});
+			mockDisassociateAgentDefinitionFromContentRetriever.mockResolvedValue(
+				{}
+			);
+			mockDisassociateAgentDefinitionFromGuardrail.mockResolvedValue({});
 
 			const {result} = renderAgentHook({
 				externalReferenceCode: 'AGENT_X',
@@ -326,14 +328,13 @@ describe('useAgentDefinitionForm', () => {
 
 			await waitFor(() => {
 				expect(
-					mockDeleteAgentDefinitionToContentRetrievers
+					mockDisassociateAgentDefinitionFromContentRetriever
 				).toHaveBeenCalledWith('AGENT_X', 'CR_2');
 			});
 
-			expect(mockDeleteAgentDefinitionToGuardrails).toHaveBeenCalledWith(
-				'AGENT_X',
-				'MAT_1'
-			);
+			expect(
+				mockDisassociateAgentDefinitionFromGuardrail
+			).toHaveBeenCalledWith('AGENT_X', 'MAT_1');
 		});
 
 		it('issues PUT requests for added relationships only', async () => {
@@ -394,7 +395,7 @@ describe('useAgentDefinitionForm', () => {
 				'MAT_1'
 			);
 			expect(
-				mockDeleteAgentDefinitionToContentRetrievers
+				mockDisassociateAgentDefinitionFromContentRetriever
 			).not.toHaveBeenCalled();
 		});
 
@@ -511,10 +512,10 @@ describe('useAgentDefinitionForm', () => {
 			).not.toHaveBeenCalled();
 			expect(mockPutAgentDefinitionToGuardrails).not.toHaveBeenCalled();
 			expect(
-				mockDeleteAgentDefinitionToContentRetrievers
+				mockDisassociateAgentDefinitionFromContentRetriever
 			).not.toHaveBeenCalled();
 			expect(
-				mockDeleteAgentDefinitionToGuardrails
+				mockDisassociateAgentDefinitionFromGuardrail
 			).not.toHaveBeenCalled();
 		});
 	});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/ChatbotForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/ChatbotForm.test.tsx
@@ -31,9 +31,7 @@ jest.mock(
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService',
 	() => ({
-		deleteChatbotAgentDefinitionRelationship: jest
-			.fn()
-			.mockResolvedValue({}),
+		disassociateChatbotFromAgentDefinition: jest.fn().mockResolvedValue({}),
 		getChatbot: (...args: any[]) => mockGetChatbot(...args),
 		postChatbot: (...args: any[]) => mockPostChatbot(...args),
 		putChatbot: (...args: any[]) => mockPutChatbot(...args),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95305

## What Is Being Fixed

In the AI Hub Chatbot section, removing an assigned agent (and its agent data sources) did not work. Agents and data sources are linked to the chatbot through many-to-many object relationships, and there was no way to sever the link between two specific related entries, so the assignment persisted even after the user removed it.

## How It Is Being Fixed

A new endpoint disassociates two specific entries in a many-to-many object relationship, identified by their external reference codes, without deleting either record. `DefaultObjectEntryManager` gains a `disassociateRelatedModels` method that resolves both entries and removes only the relationship row between them, and the AI Hub agent definition and chatbot services are updated to call this endpoint when an assignment is removed.

The endpoint is exposed as a `POST` to `.../{relatedExternalReferenceCode}/disassociate` rather than as a `DELETE`, for two reasons. First, the existing `DELETE` at `/by-external-reference-code/{currentExternalReferenceCode}/{objectRelationshipName}/{relatedExternalReferenceCode}` is already bound to a different, destructive operation: it deletes the related object entry record itself. Second, disassociation is not a deletion — both entries must survive and only the link between them is removed. Reusing `DELETE` would collide with that existing path and verb and overload it with two incompatible meanings, so modeling disassociation as a `POST` action sub-resource (`/disassociate`) keeps it distinct from record deletion and makes the non-destructive intent explicit.

## PR Check

**pr-check: PASS** — tested on `d9660a334e8323a6b599faa09a66b6bf6fe33209`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile was scoped to the base deploy set (object-rest-api, object-rest-impl, ai-hub-web); the ~46-consumer expansion was trimmed since the new interface method is additive. Java Unit Tests matched the diff but no src/test counterpart exists (coverage is the integration test), so nothing ran.

<!-- pr-check {"result": "success", "sha": "d9660a334e8323a6b599faa09a66b6bf6fe33209"} -->
