### PR TITLE
LPD-90670 Always update the existing AI Hub OAuth2 application

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
@@ -18,7 +18,6 @@ import com.liferay.ai.hub.rest.manager.v1_0.ProvisioningRequestManager;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
-import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.object.model.ObjectDefinition;
@@ -178,21 +177,10 @@ public class ProvisioningRequestManagerImpl
 			ServiceContext serviceContext)
 		throws Exception {
 
-		String externalReferenceCode =
-			customerAccountEntry.getAccountEntryId() +
-				"-ai-hub-oauth2-application";
-
-		OAuth2Application oAuth2Application =
-			_oAuth2ApplicationLocalService.
-				fetchOAuth2ApplicationByExternalReferenceCode(
-					externalReferenceCode, serviceContext.getCompanyId());
-
-		if (oAuth2Application != null) {
-			return;
-		}
-
 		_oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
-			externalReferenceCode, user.getUserId(), user.getFullName(),
+			customerAccountEntry.getAccountEntryId() +
+				"-ai-hub-oauth2-application",
+			user.getUserId(), user.getFullName(),
 			List.of(GrantType.CLIENT_CREDENTIALS), "client_secret_post",
 			user.getUserId(), OAuth2SecureRandomGenerator.generateClientId(),
 			ClientProfile.HEADLESS_SERVER.id(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90670

## What Is Being Fixed

When provisioning an AI Hub OAuth2 application for a customer account, the manager fetched the existing application by external reference code and returned early when one already existed. As a result, an already-provisioned OAuth2 application was never refreshed — any change to its attributes on a subsequent provisioning was silently dropped.

## How It Is Being Fixed

The fetch-and-early-return is removed. The code now always calls addOrUpdateOAuth2Application, which already performs an upsert keyed by the external reference code: it creates the application when absent and updates it when present. This keeps provisioning idempotent while ensuring an existing application stays in sync.

## Why Are There No Tests?

The behavior is already covered by the existing LPD-90670 integration tests; this change only removes redundant code, since addOrUpdateOAuth2Application handles the upsert.

## PR Check

**pr-check: PASS** — tested on `ecf56d3c9dba32dd8aedc6afda4c26e554729410`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ecf56d3c9dba32dd8aedc6afda4c26e554729410"} -->
