### PR TITLE
LPD-95962 Skip the category fetch until the asset scope is known

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -46,6 +46,10 @@ const AssetCategories = ({
 			systemProperties: {objectDefinitionBrief: {classNameId = -1} = {}},
 		} = objectEntry;
 
+		if (typeof scopeId !== 'number') {
+			return '';
+		}
+
 		const assetTypes = ["'0'"];
 
 		if (classNameId >= 0) {
@@ -181,54 +185,58 @@ const AssetCategories = ({
 						errorMessage ? 'form-group has-error' : undefined
 					}
 				>
-					<ItemSelector<any>
-						apiURL={apiURL}
-						aria-describedby={errorMessage ? feedbackId : undefined}
-						disabled={!hasUpdatePermission}
-						estimateSize={49}
-						items={selectedCategories}
-						locator={{
-							id: 'id',
-							label: 'name',
-							value: 'id',
-						}}
-						onChange={setValue}
-						onItemsChange={(newItems: any) => {
-							if (newItems[0]) {
-								addCategory(newItems[0]);
-
-								// The reason for this timeout is because of react's
-								// batch rendering. Clay internals set the value of
-								// the input, but we need to wait for the next 'tick' to set the value.
-
-								setTimeout(() => setValue(''));
+					{apiURL ? (
+						<ItemSelector<any>
+							apiURL={apiURL}
+							aria-describedby={
+								errorMessage ? feedbackId : undefined
 							}
-						}}
-						placeholder={Liferay.Language.get('add-category')}
-						refetchOnActive
-						sizing={inputSize}
-						value={value}
-					>
-						{(item) => (
-							<ItemSelector.Item
-								key={item.id}
-								textValue={item.name}
-							>
-								<div>
-									<span className="font-weight-bold text-truncate">
-										{item?.name}
-									</span>
+							disabled={!hasUpdatePermission}
+							estimateSize={49}
+							items={selectedCategories}
+							locator={{
+								id: 'id',
+								label: 'name',
+								value: 'id',
+							}}
+							onChange={setValue}
+							onItemsChange={(newItems: any) => {
+								if (newItems[0]) {
+									addCategory(newItems[0]);
 
-									<span
-										className="text-1 text-secondary text-truncate text-uppercase"
-										title={item?.path}
-									>
-										{item?.path}
-									</span>
-								</div>
-							</ItemSelector.Item>
-						)}
-					</ItemSelector>
+									// The reason for this timeout is because of react's
+									// batch rendering. Clay internals set the value of
+									// the input, but we need to wait for the next 'tick' to set the value.
+
+									setTimeout(() => setValue(''));
+								}
+							}}
+							placeholder={Liferay.Language.get('add-category')}
+							refetchOnActive
+							sizing={inputSize}
+							value={value}
+						>
+							{(item) => (
+								<ItemSelector.Item
+									key={item.id}
+									textValue={item.name}
+								>
+									<div>
+										<span className="font-weight-bold text-truncate">
+											{item?.name}
+										</span>
+
+										<span
+											className="text-1 text-secondary text-truncate text-uppercase"
+											title={item?.path}
+										>
+											{item?.path}
+										</span>
+									</div>
+								</ItemSelector.Item>
+							)}
+						</ItemSelector>
+					) : null}
 
 					{errorMessage && (
 						<ClayForm.FeedbackGroup id={feedbackId} role="alert">

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -97,6 +97,26 @@ describe('AssetCategories', () => {
 		jest.resetAllMocks();
 	});
 
+	it('does not render the category selector before the asset scope is known', () => {
+		render(
+			<AssetCategories
+				cmsGroupId={456}
+				hasUpdatePermission={true}
+				objectEntry={
+					{
+						systemProperties: {
+							objectDefinitionBrief: {classNameId: 1},
+						},
+						taxonomyCategoryBriefs: [],
+					} as any
+				}
+				updateObjectEntry={jest.fn()}
+			/>
+		);
+
+		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
+	});
+
 	it('renders categories grouped under their vocabulary names', () => {
 		renderComponent({
 			taxonomyCategoryBriefs: [


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95962

## What Is Being Fixed

When the CMS content editor opens, the Categorization panel fires a taxonomy-categories request with an undefined asset scope, which 404s. `AssetCategories` builds the request URL from `objectEntry.scopeId`, and on the first render, before the object entry has loaded, `scopeId` is undefined, so the URL becomes `/o/headless-admin-taxonomy/v1.0/asset-libraries/undefined/taxonomy-categories`. The correct request fires once the entry loads, so the failure is masked, but the wasted 404 happens on every editor load.

## How It Is Being Fixed

The category selector and its fetch are now gated on a known scope. The `apiURL` memo returns an empty value while `scopeId` is not a number, and the `ItemSelector` is only rendered once the URL is set, so no request goes out until the asset scope is resolved.

## PR Check

**pr-check: PASS** - tested on `575cd29cc1f9bc8a62884e121b0327da7bf27584`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "575cd29cc1f9bc8a62884e121b0327da7bf27584"} -->
