### PR TITLE
LPD-95961 Create CMS keywords in the asset library scope

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
@@ -29,7 +29,9 @@ async function createTag({
 		};
 	}
 
-	const url = `/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`;
+	const groupId = assetLibraryId ?? cmsGroupId;
+
+	const url = `/o/headless-admin-taxonomy/v1.0/sites/${groupId}/keywords`;
 
 	const {data, error} = await ApiHelper.get<{items: Tag[]}>(
 		`${url}?filter=name eq '${name}'`

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
@@ -31,7 +31,7 @@ describe('TagService.createTag', () => {
 		});
 
 		expect(postSpy).toHaveBeenCalledWith(
-			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			`/o/headless-admin-taxonomy/v1.0/sites/${assetLibraryId}/keywords`,
 			{
 				assetLibraries: [{id: assetLibraryId}],
 				name: 'Hola',
@@ -64,7 +64,7 @@ describe('TagService.createTag', () => {
 
 		expect(patchSpy).not.toHaveBeenCalled();
 		expect(postSpy).toHaveBeenCalledWith(
-			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			`/o/headless-admin-taxonomy/v1.0/sites/${assetLibraryId}/keywords`,
 			{
 				assetLibraries: [{id: assetLibraryId}],
 				name: 'Hola',
@@ -95,7 +95,7 @@ describe('TagService.createTag', () => {
 				assetLibraries: [{id: assetLibraryId}],
 				name: 'Hola',
 			},
-			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`
+			`/o/headless-admin-taxonomy/v1.0/sites/${assetLibraryId}/keywords`
 		);
 	});
 
@@ -119,5 +119,27 @@ describe('TagService.createTag', () => {
 		expect(patchSpy).not.toHaveBeenCalled();
 		expect(postSpy).not.toHaveBeenCalled();
 		expect(result).toEqual({data: existing, error: null, status: null});
+	});
+
+	it('POSTs to the CMS group scope when no asset library is given', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: []},
+			error: null,
+		} as any);
+
+		const postSpy = jest
+			.spyOn(ApiHelper, 'post')
+			.mockResolvedValue({data: {name: 'Hola'}} as any);
+
+		await TagService.createTag({
+			assetLibraryId: null,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(postSpy).toHaveBeenCalledWith(
+			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			{name: 'Hola'}
+		);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
@@ -14,6 +14,33 @@ describe('TagService.createTag', () => {
 		jest.restoreAllMocks();
 	});
 
+	it('PATCHes the existing tag when the same-case tag already exists in an asset library', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: [{name: 'hola'}, {name: 'Hola'}]},
+			error: null,
+		} as any);
+
+		const patchSpy = jest
+			.spyOn(ApiHelper, 'patch')
+			.mockResolvedValue({data: {name: 'Hola'}} as any);
+		const postSpy = jest.spyOn(ApiHelper, 'post');
+
+		await TagService.createTag({
+			assetLibraryId,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(postSpy).not.toHaveBeenCalled();
+		expect(patchSpy).toHaveBeenCalledWith(
+			{
+				assetLibraries: [{id: assetLibraryId}],
+				name: 'Hola',
+			},
+			`/o/headless-admin-taxonomy/v1.0/sites/${assetLibraryId}/keywords`
+		);
+	});
+
 	it('POSTs a new tag when no case-insensitive match exists', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: {items: []},
@@ -72,30 +99,25 @@ describe('TagService.createTag', () => {
 		);
 	});
 
-	it('PATCHes the existing tag when the same-case tag already exists in an asset library', async () => {
+	it('POSTs to the CMS group scope when no asset library is given', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {items: [{name: 'hola'}, {name: 'Hola'}]},
+			data: {items: []},
 			error: null,
 		} as any);
 
-		const patchSpy = jest
-			.spyOn(ApiHelper, 'patch')
+		const postSpy = jest
+			.spyOn(ApiHelper, 'post')
 			.mockResolvedValue({data: {name: 'Hola'}} as any);
-		const postSpy = jest.spyOn(ApiHelper, 'post');
 
 		await TagService.createTag({
-			assetLibraryId,
+			assetLibraryId: null,
 			cmsGroupId,
 			name: 'Hola',
 		});
 
-		expect(postSpy).not.toHaveBeenCalled();
-		expect(patchSpy).toHaveBeenCalledWith(
-			{
-				assetLibraries: [{id: assetLibraryId}],
-				name: 'Hola',
-			},
-			`/o/headless-admin-taxonomy/v1.0/sites/${assetLibraryId}/keywords`
+		expect(postSpy).toHaveBeenCalledWith(
+			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			{name: 'Hola'}
 		);
 	});
 
@@ -119,27 +141,5 @@ describe('TagService.createTag', () => {
 		expect(patchSpy).not.toHaveBeenCalled();
 		expect(postSpy).not.toHaveBeenCalled();
 		expect(result).toEqual({data: existing, error: null, status: null});
-	});
-
-	it('POSTs to the CMS group scope when no asset library is given', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {items: []},
-			error: null,
-		} as any);
-
-		const postSpy = jest
-			.spyOn(ApiHelper, 'post')
-			.mockResolvedValue({data: {name: 'Hola'}} as any);
-
-		await TagService.createTag({
-			assetLibraryId: null,
-			cmsGroupId,
-			name: 'Hola',
-		});
-
-		expect(postSpy).toHaveBeenCalledWith(
-			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
-			{name: 'Hola'}
-		);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95961

## What Is Being Fixed

For asset-library content, `TagService.createTag` created keywords in the CMS site scope (`cmsGroupId`), but the asset's tags belong in and are read from the asset-library scope (`scopeId`): both the `AssetTags`/`AssetCategories` autocomplete and the auto-categorization agent's existing-tags fetch read `/sites/{scopeId}/keywords`. A tag created for asset-library content was therefore invisible to those reads, so the categorization agent flagged an already-existing tag as new and the subsequent create returned a 409 conflict.

## How It Is Being Fixed

`createTag` now resolves the target group as `assetLibraryId ?? cmsGroupId` and checks and creates against that scope, so asset-library content's keywords are created in the asset library where they are read from. Regular site content, which has no asset library, is unchanged.

Verified on a fresh database with a healthy search index: a keyword posted to the CMS site with an `assetLibraries` reference landed in the site scope and was not returned by the library-scoped read, while posting directly to the library group lands it there and is readable.

## PR Check

**pr-check: PASS** - tested on `a887e1db400fefad54ab5d6f11f63efdee56a518`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a887e1db400fefad54ab5d6f11f63efdee56a518"} -->
