### PR TITLE
LPD-90670 Send password setup email when provisioning regular users

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
@@ -308,11 +308,17 @@ public class ProvisioningRequestManagerImpl
 			return user;
 		}
 
+		boolean sendEmail = true;
+
+		if (type == UserConstants.TYPE_SERVICE_ACCOUNT) {
+			sendEmail = false;
+		}
+
 		user = _userLocalService.addUser(
 			UserConstants.USER_ID_DEFAULT, companyId, true, null, null, false,
 			screenName, emailAddress, locale, firstName, StringPool.BLANK,
 			lastName, 0, 0, true, Calendar.JANUARY, 1, 1970, StringPool.BLANK,
-			type, null, null, null, null, false, serviceContext);
+			type, null, null, null, null, sendEmail, serviceContext);
 
 		if (!user.isServiceAccountUser()) {
 			return user;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90670

## What Is Being Fixed

When provisioning a regular (non-service-account) user through the AI Hub provisioning REST API, the user was created without the password setup email being sent. Regular users were left with no way to set their password and access the account.

## How It Is Being Fixed

The provisioning request manager now derives a sendEmail flag from the user type before calling UserLocalService.addUser. For service account users the flag stays false, since they authenticate via OAuth and need no password setup email; for every other (regular) user the flag is true, so the standard password setup email is sent.

## Why Are There No Tests?

The provisioning flow is already covered by existing integration tests (ProvisioningRequestResourceTest). This change only flips the addUser email flag based on user type and introduces no new code path warranting a dedicated test.

## PR Check

**pr-check: PASS** — tested on `f23fadb4a2d1a2ac3a788f5bb9d023b6698bcbef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f23fadb4a2d1a2ac3a788f5bb9d023b6698bcbef"} -->
