### PR TITLE
LPD-96133 [BE] Append context to the message

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.agent.SupervisorAgent;
 import com.liferay.ai.hub.rest.dto.v1_0.Message;
 import com.liferay.ai.hub.rest.internal.util.ContextUserUtil;
+import com.liferay.ai.hub.rest.internal.util.MessageUtil;
 import com.liferay.ai.hub.rest.internal.util.OAuth2ApplicationIdResolverUtil;
 import com.liferay.ai.hub.rest.resource.v1_0.MessageResource;
 import com.liferay.ai.hub.util.AccountEntryUtil;
@@ -63,7 +64,10 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 			).groupId(
 				AccountEntryUtil.getUserAccountEntryGroupId(user.getUserId())
 			).input(
-				Map.of("message", message.getText())
+				Map.of(
+					"message",
+					MessageUtil.appendContext(
+						message.getText(), message.getContext()))
 			).instructionDefinitionScope(
 				message.getInstructionDefinitionScopeAsString()
 			).oAuth2ApplicationId(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/util/MessageUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/util/MessageUtil.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Iliyan Peychev
+ */
+public class MessageUtil {
+
+	public static String appendContext(String text, Map<String, ?> context) {
+		if (text == null) {
+			text = "";
+		}
+
+		if (MapUtil.isEmpty(context)) {
+			return text;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(text);
+		sb.append("\n\n# Context\n");
+
+		Map<String, ?> sortedContext = new TreeMap<>(context);
+
+		for (Map.Entry<String, ?> entry : sortedContext.entrySet()) {
+			if (Validator.isNull(entry.getValue())) {
+				continue;
+			}
+
+			sb.append(entry.getKey());
+			sb.append(": ");
+			sb.append(entry.getValue());
+			sb.append("\n");
+		}
+
+		return sb.toString();
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/test/java/com/liferay/ai/hub/rest/internal/util/MessageUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/test/java/com/liferay/ai/hub/rest/internal/util/MessageUtilTest.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.rest.internal.util;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Iliyan Peychev
+ */
+public class MessageUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAppendContext() {
+		Assert.assertEquals(
+			"Generate the content\n\n# Context\n" +
+				"generationExternalReferenceCode: abc-123\ngenerationId: 42\n",
+			MessageUtil.appendContext(
+				"Generate the content",
+				Map.of(
+					"generationExternalReferenceCode", "abc-123",
+					"generationId", 42)));
+	}
+
+	@Test
+	public void testAppendContextWhenContextIsEmpty() {
+		Assert.assertEquals(
+			"Generate the content",
+			MessageUtil.appendContext("Generate the content", Map.of()));
+	}
+
+	@Test
+	public void testAppendContextWhenContextIsNull() {
+		Assert.assertEquals(
+			"Generate the content",
+			MessageUtil.appendContext("Generate the content", null));
+	}
+
+	@Test
+	public void testAppendContextWhenContextValueIsNull() {
+		Assert.assertEquals(
+			"Generate the content\n\n# Context\n",
+			MessageUtil.appendContext(
+				"Generate the content",
+				Collections.singletonMap("nullValue", null)));
+	}
+
+	@Test
+	public void testAppendContextWhenTextIsNull() {
+		Assert.assertEquals(
+			"\n\n# Context\ngenerationId: 42\n",
+			MessageUtil.appendContext(null, Map.of("generationId", 42)));
+	}
+
+}


### PR DESCRIPTION
## What

Adds `MessageUtil.appendContext`, split out of LPD-95356 (#547): it folds the chat request's `context` map into the message text as a sorted `# Context` block (skipping null values), so the supervisor agent receives the caller-provided context alongside the message. `MessageResourceImpl` wraps the message text through it before invoking the agent.

Independent of #563 and the other LPD-95356 splits.

**pr-check: PASS** — tested on `f2bb90f9836101777cfd565213e51ec8e293797c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f2bb90f9836101777cfd565213e51ec8e293797c"} -->
