### PR TITLE
LPD-96136 [BE] Create Site Builder Agent Service Node Delegates

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/util/AgentUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/util/AgentUtil.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.ai.hub.internal.agent.util;
+package com.liferay.ai.hub.util;
 
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.util.HashMapBuilder;

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/resources/com/liferay/ai/hub/util/packageinfo
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/resources/com/liferay/ai/hub/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
@@ -6,10 +6,10 @@
 package com.liferay.ai.hub.internal.langchain4j.agentic.internal;
 
 import com.liferay.ai.hub.agent.AgentContext;
-import com.liferay.ai.hub.internal.agent.util.AgentUtil;
 import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
 import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
 import com.liferay.ai.hub.quota.QuotaManager;
+import com.liferay.ai.hub.util.AgentUtil;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowInstanceMessageListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowInstanceMessageListener.java
@@ -5,9 +5,9 @@
 
 package com.liferay.ai.hub.internal.messaging;
 
-import com.liferay.ai.hub.internal.agent.util.AgentUtil;
 import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
 import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
+import com.liferay.ai.hub.util.AgentUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/build.gradle
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:batch-engine:batch-engine-api")
+	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
@@ -10,4 +13,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":dxp:apps:ai-hub:ai-hub-api")
+	compileOnly project(":dxp:apps:ai-hub:ai-hub-rest-api")
 }

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/AcknowledgeAgentServiceNodeDelegate.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/AcknowledgeAgentServiceNodeDelegate.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.util.AgentUtil;
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iliyan Peychev
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class AcknowledgeAgentServiceNodeDelegate
+	implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+		Map<String, String> inputVariables,
+		Map<String, Serializable> workflowContext) {
+
+		String acknowledgment = inputVariables.get("acknowledgment");
+
+		if (Validator.isNull(acknowledgment)) {
+			ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+				WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
+
+			acknowledgment = _language.get(
+				serviceContext.getLocale(), "generating");
+		}
+
+		Message message = new Message();
+
+		message.put(
+			"workflowContext",
+			HashMapBuilder.<String, Serializable>put(
+				"output", acknowledgment
+			).build());
+		message.put(
+			"workflowInstanceId",
+			GetterUtil.getLong(workflowContext.get("workflowInstanceId")));
+
+		AgentUtil.complete(message);
+
+		return acknowledgment;
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#acknowledgeAgent";
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/IRToPageSpecServiceNodeDelegate.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/IRToPageSpecServiceNodeDelegate.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.content.site.generator.internal.workflow.node.delegate.util.IRToPageSpecConverter;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class IRToPageSpecServiceNodeDelegate implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+			Map<String, String> inputVariables,
+			Map<String, Serializable> workflowContext)
+		throws Exception {
+
+		IRToPageSpecConverter irToPageSpecConverter = new IRToPageSpecConverter(
+			GetterUtil.getString(
+				inputVariables.get("fragmentCatalog"),
+				GetterUtil.getString(
+					inputVariables.get("fullFragmentsCatalog"), "[]")));
+
+		String sitePageExternalReferenceCode = inputVariables.get(
+			"sitePageExternalReferenceCode");
+
+		return irToPageSpecConverter.convert(
+			inputVariables.get("updatedPageIR"),
+			GetterUtil.getString(
+				inputVariables.get("draftERC"),
+				sitePageExternalReferenceCode + "-draft"),
+			GetterUtil.getString(
+				inputVariables.get("experienceERC"),
+				sitePageExternalReferenceCode + "-default"),
+			GetterUtil.getString(inputVariables.get("locale"), "en-US"));
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#irToPageSpec";
+	}
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/JSONRepairServiceNodeDelegate.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/JSONRepairServiceNodeDelegate.java
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class JSONRepairServiceNodeDelegate implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+		Map<String, String> inputVariables,
+		Map<String, Serializable> workflowContext) {
+
+		if (inputVariables.isEmpty()) {
+			return "";
+		}
+
+		Set<Map.Entry<String, String>> entrySet = inputVariables.entrySet();
+
+		Iterator<Map.Entry<String, String>> iterator = entrySet.iterator();
+
+		Map.Entry<String, String> entry = iterator.next();
+
+		return _repairJSON(_stripMarkdownFences(entry.getValue()));
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#jsonRepair";
+	}
+
+	private String _repairJSON(String json) {
+		try {
+			_jsonFactory.createJSONObject(json);
+
+			return json;
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		StringBuilder fixedSB = new StringBuilder();
+
+		boolean inString = false;
+		char previousChar = 0;
+
+		for (int i = 0; i < json.length(); i++) {
+			char c = json.charAt(i);
+
+			if (inString) {
+				if ((c == '"') && (previousChar != '\\')) {
+					inString = false;
+
+					fixedSB.append(c);
+				}
+				else if (c == '\n') {
+					fixedSB.append("\\n");
+				}
+				else if (c == '\r') {
+					fixedSB.append("\\r");
+				}
+				else {
+					fixedSB.append(c);
+				}
+			}
+			else {
+				if (c == '"') {
+					inString = true;
+				}
+
+				fixedSB.append(c);
+			}
+
+			previousChar = c;
+		}
+
+		if (inString) {
+			fixedSB.append('"');
+		}
+
+		String repaired = fixedSB.toString();
+
+		repaired = _trailingCommaPattern.matcher(
+			repaired
+		).replaceAll(
+			"$1"
+		);
+
+		repaired = _missingCommaPattern.matcher(
+			repaired
+		).replaceAll(
+			"$1,$2"
+		);
+
+		int braces = 0;
+		int brackets = 0;
+
+		inString = false;
+		previousChar = 0;
+
+		for (int i = 0; i < repaired.length(); i++) {
+			char c = repaired.charAt(i);
+
+			if (inString) {
+				if ((c == '"') && (previousChar != '\\')) {
+					inString = false;
+				}
+			}
+			else if (c == '"') {
+				inString = true;
+			}
+			else if (c == '{') {
+				braces++;
+			}
+			else if (c == '}') {
+				braces--;
+			}
+			else if (c == '[') {
+				brackets++;
+			}
+			else if (c == ']') {
+				brackets--;
+			}
+
+			previousChar = c;
+		}
+
+		StringBuilder repairedSB = new StringBuilder(repaired);
+
+		while (brackets > 0) {
+			repairedSB.append(']');
+
+			brackets--;
+		}
+
+		while (braces > 0) {
+			repairedSB.append('}');
+
+			braces--;
+		}
+
+		repaired = repairedSB.toString();
+
+		try {
+			_jsonFactory.createJSONObject(repaired);
+
+			if (_log.isWarnEnabled()) {
+				_log.warn("Repaired malformed JSON");
+			}
+
+			return repaired;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to repair malformed JSON", exception);
+			}
+
+			return json;
+		}
+	}
+
+	private String _stripMarkdownFences(String text) {
+		if (text == null) {
+			return "";
+		}
+
+		text = text.trim();
+
+		if (text.startsWith("```")) {
+			int index = text.indexOf('\n');
+
+			if (index != -1) {
+				text = text.substring(index + 1);
+			}
+		}
+
+		if (text.endsWith("```")) {
+			text = text.substring(0, text.length() - 3);
+		}
+
+		return text.trim();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JSONRepairServiceNodeDelegate.class);
+
+	private static final Pattern _missingCommaPattern = Pattern.compile(
+		"(\"[^\"]*\")\\s*\\n\\s*(\")");
+	private static final Pattern _trailingCommaPattern = Pattern.compile(
+		",\\s*([}\\]])");
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/PageSpecToIRServiceNodeDelegate.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/PageSpecToIRServiceNodeDelegate.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.content.site.generator.internal.workflow.node.delegate.util.PageSpecToIRConverter;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class PageSpecToIRServiceNodeDelegate implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+			Map<String, String> inputVariables,
+			Map<String, Serializable> workflowContext)
+		throws Exception {
+
+		PageSpecToIRConverter pageSpecToIRConverter =
+			new PageSpecToIRConverter();
+
+		return pageSpecToIRConverter.convert(
+			inputVariables.get("currentPageSpecification"),
+			inputVariables.get("pageTitle"),
+			GetterUtil.getString(inputVariables.get("locale"), "en-US"));
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#pageSpecToIR";
+	}
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/WriteCSGGenerationItemsServiceNodeDelegate.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/WriteCSGGenerationItemsServiceNodeDelegate.java
@@ -1,0 +1,304 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.content.site.generator.internal.workflow.node.delegate.util.SitePlanBatchFileBuilder;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.io.Serializable;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class WriteCSGGenerationItemsServiceNodeDelegate
+	implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+			Map<String, String> inputVariables,
+			Map<String, Serializable> workflowContext)
+		throws Exception {
+
+		String generationExternalReferenceCode = inputVariables.get(
+			"generationExternalReferenceCode");
+
+		if (Validator.isBlank(generationExternalReferenceCode)) {
+			throw new IllegalArgumentException(
+				"The \"generationExternalReferenceCode\" input variable is " +
+					"required");
+		}
+
+		long companyId = _getCompanyId(workflowContext);
+		long userId = _getUserId(workflowContext);
+
+		String sseEventSinkKey = GetterUtil.getString(
+			workflowContext.get("sseEventSinkKey"));
+
+		ObjectDefinition csgGenerationObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CSG_GENERATION", companyId);
+
+		ObjectEntry csgGenerationObjectEntry =
+			_objectEntryLocalService.getObjectEntry(
+				generationExternalReferenceCode, 0L,
+				csgGenerationObjectDefinition.getObjectDefinitionId());
+
+		try {
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				userId, csgGenerationObjectEntry.getObjectEntryId(),
+				csgGenerationObjectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.<String, Serializable>put(
+					"generationStatus", "generating"
+				).build(),
+				new ServiceContext());
+
+			String enrichedSitePlan = inputVariables.get("enrichedSitePlan");
+
+			String blogEntries = _normalizeBlogEntries(
+				inputVariables.get("blogEntries"));
+
+			SitePlanBatchFileBuilder sitePlanBatchFileBuilder =
+				new SitePlanBatchFileBuilder(enrichedSitePlan, blogEntries);
+
+			List<SitePlanBatchFileBuilder.BatchFile> batchFiles =
+				sitePlanBatchFileBuilder.build();
+
+			ObjectDefinition csgGenerationItemObjectDefinition =
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						"L_CSG_GENERATION_ITEM", companyId);
+
+			Company company = _companyLocalService.getCompany(companyId);
+
+			Set<String> targetLanguages = new LinkedHashSet<>();
+
+			int loadOrder = 0;
+
+			for (SitePlanBatchFileBuilder.BatchFile batchFile : batchFiles) {
+				loadOrder++;
+
+				String languages = _writeGenerationItem(
+					batchFile, company.getGroupId(),
+					generationExternalReferenceCode,
+					csgGenerationItemObjectDefinition.getObjectDefinitionId(),
+					csgGenerationObjectEntry.getObjectEntryId(), loadOrder,
+					userId);
+
+				for (String language : StringUtil.split(languages, ',')) {
+					String trimmedLanguage = StringUtil.trim(language);
+
+					if (Validator.isNotNull(trimmedLanguage)) {
+						targetLanguages.add(trimmedLanguage);
+					}
+				}
+
+				if (Validator.isNotNull(sseEventSinkKey)) {
+					SseUtil.send(
+						batchFile.getFileName(), "Artifacts Updated", null,
+						sseEventSinkKey);
+				}
+			}
+
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				userId, csgGenerationObjectEntry.getObjectEntryId(),
+				csgGenerationObjectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.<String, Serializable>put(
+					"targetLanguages", StringUtil.merge(targetLanguages, ",")
+				).build(),
+				new ServiceContext());
+
+			return StringBundler.concat(
+				"Wrote ", batchFiles.size(), " generation items.");
+		}
+		catch (Exception exception1) {
+			_log.error(
+				"Unable to write CSG generation items for generation " +
+					generationExternalReferenceCode,
+				exception1);
+
+			try {
+				_objectEntryLocalService.partialUpdateObjectEntry(
+					userId, csgGenerationObjectEntry.getObjectEntryId(),
+					csgGenerationObjectEntry.getObjectEntryFolderId(),
+					HashMapBuilder.<String, Serializable>put(
+						"failureReason", exception1.getMessage()
+					).put(
+						"generationStatus", "failed"
+					).build(),
+					new ServiceContext());
+			}
+			catch (Exception exception2) {
+				_log.error(exception2);
+			}
+
+			throw exception1;
+		}
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#writeCSGGenerationItems";
+	}
+
+	private long _addBatchFileEntry(
+			long groupId, long userId, String generationExternalReferenceCode,
+			int loadOrder, String fileName, JSONObject envelopeJSONObject)
+		throws Exception {
+
+		String sourceFileName = StringBundler.concat(
+			generationExternalReferenceCode, "-", loadOrder, "-", fileName);
+
+		return GetterUtil.getLong(
+			_dlAppLocalService.addFileEntry(
+				null, userId, groupId, 0L, sourceFileName,
+				ContentTypes.APPLICATION_JSON,
+				envelopeJSONObject.toString(
+				).getBytes(
+					StandardCharsets.UTF_8
+				),
+				null, null, null, new ServiceContext()
+			).getFileEntryId());
+	}
+
+	private long _getCompanyId(Map<String, Serializable> workflowContext) {
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
+
+		if ((serviceContext != null) && (serviceContext.getCompanyId() > 0)) {
+			return serviceContext.getCompanyId();
+		}
+
+		return CompanyThreadLocal.getCompanyId();
+	}
+
+	private long _getUserId(Map<String, Serializable> workflowContext) {
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
+
+		if (serviceContext != null) {
+			return serviceContext.getUserId();
+		}
+
+		return 0;
+	}
+
+	private String _normalizeBlogEntries(String blogEntries) {
+		if (Validator.isBlank(blogEntries)) {
+			return null;
+		}
+
+		String trimmedBlogEntries = blogEntries.trim();
+
+		if (!trimmedBlogEntries.startsWith("[") &&
+			!trimmedBlogEntries.startsWith("{")) {
+
+			return null;
+		}
+
+		return trimmedBlogEntries;
+	}
+
+	private String _writeGenerationItem(
+			SitePlanBatchFileBuilder.BatchFile batchFile, long groupId,
+			String generationExternalReferenceCode, long objectDefinitionId,
+			long csgGenerationId, int loadOrder, long userId)
+		throws Exception {
+
+		String fileName = batchFile.getFileName();
+
+		JSONObject envelopeJSONObject = batchFile.getEnvelopeJSONObject();
+
+		JSONArray itemsJSONArray = envelopeJSONObject.getJSONArray("items");
+
+		int itemCount = (itemsJSONArray == null) ? 0 : itemsJSONArray.length();
+
+		String previewItem = "";
+
+		if (itemCount > 0) {
+			previewItem = String.valueOf(
+				SitePlanBatchFileBuilder.stripMetadata(
+					itemsJSONArray.getJSONObject(0)));
+		}
+
+		String languages = SitePlanBatchFileBuilder.detectLanguages(
+			itemsJSONArray, fileName);
+
+		long fileEntryId = _addBatchFileEntry(
+			groupId, userId, generationExternalReferenceCode, loadOrder,
+			fileName, envelopeJSONObject);
+
+		_objectEntryLocalService.addObjectEntry(
+			0L, userId, objectDefinitionId, 0L, "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"batchFile", fileEntryId
+			).put(
+				"fileName", fileName
+			).put(
+				"itemCount", itemCount
+			).put(
+				"languages", languages
+			).put(
+				"loadOrder", loadOrder
+			).put(
+				"previewItem", previewItem
+			).put(
+				"r_items_l_csgGenerationId", csgGenerationId
+			).build(),
+			new ServiceContext());
+
+		return languages;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		WriteCSGGenerationItemsServiceNodeDelegate.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/IRToPageSpecConverter.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/IRToPageSpecConverter.java
@@ -1,0 +1,998 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+public class IRToPageSpecConverter {
+
+	public IRToPageSpecConverter(String fullFragmentsCatalog) {
+		JSONArray catalogJSONArray = null;
+
+		if (Validator.isNotNull(fullFragmentsCatalog)) {
+			try {
+				catalogJSONArray = JSONFactoryUtil.createJSONArray(
+					fullFragmentsCatalog);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
+				}
+
+				catalogJSONArray = null;
+			}
+		}
+
+		_customEditableTypesMap = _parseCustomEditableTypes(catalogJSONArray);
+		_customFragmentSourcesMap = _parseCustomFragmentSources(
+			catalogJSONArray);
+	}
+
+	public String convert(
+		String irJSON, String draftERC, String experienceERC, String locale) {
+
+		if ((locale == null) || locale.isEmpty()) {
+			locale = "en-US";
+		}
+
+		try {
+			JSONObject irJSONObject = JSONFactoryUtil.createJSONObject(
+				_stripMarkdownFences(irJSON));
+
+			JSONArray irElementsJSONArray = irJSONObject.getJSONArray(
+				"elements");
+
+			if (irElementsJSONArray == null) {
+				irElementsJSONArray = JSONFactoryUtil.createJSONArray();
+			}
+
+			JSONArray pageElementsJSONArray = JSONFactoryUtil.createJSONArray();
+
+			for (int i = 0; i < irElementsJSONArray.length(); i++) {
+				JSONObject elementJSONObject = _convertElement(
+					irElementsJSONArray.getJSONObject(i), null, i, locale);
+
+				if (elementJSONObject != null) {
+					pageElementsJSONArray.put(elementJSONObject);
+				}
+			}
+
+			return JSONUtil.put(
+				"customFields", JSONFactoryUtil.createJSONArray()
+			).put(
+				"externalReferenceCode", draftERC
+			).put(
+				"pageExperiences",
+				JSONUtil.put(
+					JSONUtil.put(
+						"externalReferenceCode", experienceERC
+					).put(
+						"key", "DEFAULT"
+					).put(
+						"name_i18n", _i18n(locale, "Default")
+					).put(
+						"pageElements", pageElementsJSONArray
+					).put(
+						"priority", 0
+					))
+			).put(
+				"status", "Draft"
+			).put(
+				"type", "ContentPageSpecification"
+			).toString();
+		}
+		catch (Exception exception) {
+			return "Error converting IR to page spec: " +
+				exception.getMessage();
+		}
+	}
+
+	private void _applySpacing(
+			JSONObject sourceJSONObject, JSONObject targetJSONObject,
+			String prefix, String defaultValue)
+		throws Exception {
+
+		JSONObject spacingJSONObject = sourceJSONObject.getJSONObject(prefix);
+
+		for (String side : _SIDES) {
+			String value = null;
+
+			if (spacingJSONObject != null) {
+				value = spacingJSONObject.getString(
+					StringUtil.toLowerCase(side));
+			}
+
+			if ((value == null) || value.isEmpty()) {
+				value = defaultValue;
+			}
+
+			if (value != null) {
+				targetJSONObject.put(prefix + side, value);
+			}
+		}
+	}
+
+	private void _applyStyleProperties(
+		JSONObject sourceJSONObject, JSONObject styleJSONObject) {
+
+		for (String colorKey : _colorStyleKeys) {
+			String value = sourceJSONObject.getString(colorKey);
+
+			if (Validator.isNotNull(value)) {
+				styleJSONObject.put(colorKey, _normalizeColor(value));
+			}
+		}
+
+		for (String key : _stringStyleKeys) {
+			String value = sourceJSONObject.getString(key);
+
+			if (Validator.isNotNull(value)) {
+				styleJSONObject.put(key, value);
+			}
+		}
+
+		if (sourceJSONObject.has("hidden")) {
+			styleJSONObject.put(
+				"hidden", sourceJSONObject.getBoolean("hidden"));
+		}
+	}
+
+	private JSONObject _buildContainerLayout(JSONObject irJSONObject)
+		throws Exception {
+
+		JSONObject layoutJSONObject = JSONUtil.put(
+			"align", "Center"
+		).put(
+			"contentDisplay", "Block"
+		).put(
+			"justify", "Center"
+		).put(
+			"widthType", "Fluid"
+		);
+
+		String contentDisplay = irJSONObject.getString("contentDisplay");
+
+		if (Objects.equals(contentDisplay, "flex-row")) {
+			layoutJSONObject.put("contentDisplay", "FlexRow");
+		}
+		else if (Objects.equals(contentDisplay, "flex-column")) {
+			layoutJSONObject.put("contentDisplay", "FlexColumn");
+		}
+
+		String widthType = irJSONObject.getString("widthType");
+
+		if (Objects.equals(widthType, "fixed")) {
+			layoutJSONObject.put("widthType", "Fixed");
+		}
+
+		return layoutJSONObject;
+	}
+
+	private JSONObject _buildEditable(
+			String id, String type, Object raw, String locale)
+		throws Exception {
+
+		if (Objects.equals(type, "text")) {
+			return _buildTextEditable(id, _toString(raw), locale);
+		}
+		else if (Objects.equals(type, "richText")) {
+			return _buildRichTextEditable(id, _toString(raw), locale);
+		}
+		else if (Objects.equals(type, "image")) {
+			return _buildImageEditable(id, raw, locale);
+		}
+		else if (Objects.equals(type, "link")) {
+			return _buildLinkEditable(id, raw, locale);
+		}
+
+		return null;
+	}
+
+	private JSONArray _buildEditableElements(
+			JSONObject contentJSONObject, String fragmentKey, String locale)
+		throws Exception {
+
+		JSONArray elementsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		Map<String, String> editableTypesMap = _ootbEditableTypes.get(
+			fragmentKey);
+
+		if (editableTypesMap == null) {
+			editableTypesMap = _customEditableTypesMap.get(fragmentKey);
+		}
+
+		Iterator<String> keysIterator = contentJSONObject.keys();
+
+		while (keysIterator.hasNext()) {
+			String id = keysIterator.next();
+
+			Object raw = contentJSONObject.get(id);
+
+			String editableType = "text";
+
+			if (editableTypesMap != null) {
+				String mapped = editableTypesMap.get(id);
+
+				if (mapped != null) {
+					editableType = mapped;
+				}
+			}
+
+			JSONObject editableJSONObject = _buildEditable(
+				id, editableType, raw, locale);
+
+			if (editableJSONObject != null) {
+				elementsJSONArray.put(editableJSONObject);
+			}
+		}
+
+		return elementsJSONArray;
+	}
+
+	private JSONObject _buildImageEditable(String id, Object raw, String locale)
+		throws Exception {
+
+		String url;
+
+		if (raw instanceof JSONObject) {
+			JSONObject rawJSONObject = (JSONObject)raw;
+
+			url = rawJSONObject.getString("url");
+		}
+		else {
+			url = (raw == null) ? StringPool.BLANK : String.valueOf(raw);
+		}
+
+		return JSONUtil.put(
+			"fragmentEditableElementValue",
+			JSONUtil.put(
+				"fragmentImage",
+				JSONUtil.put(
+					"fragmentImageValue",
+					JSONUtil.put(
+						"type", "Direct"
+					).put(
+						"value_i18n",
+						_i18nObject(
+							locale,
+							JSONUtil.put(
+								"type", "URL"
+							).put(
+								"url", url
+							))
+					))
+			).put(
+				"type", "Image"
+			)
+		).put(
+			"id", id
+		);
+	}
+
+	private JSONObject _buildLinkEditable(String id, Object raw, String locale)
+		throws Exception {
+
+		String text = "Learn more";
+		String url = "#";
+		String target = "Self";
+
+		if (raw instanceof JSONObject) {
+			JSONObject linkJSONObject = (JSONObject)raw;
+
+			text = linkJSONObject.getString("text", "Learn more");
+			url = linkJSONObject.getString("url", "#");
+
+			String rawTarget = linkJSONObject.getString("target");
+
+			if ((rawTarget != null) && !rawTarget.isEmpty()) {
+				target = _normalizeLinkTarget(rawTarget);
+			}
+		}
+		else if (raw instanceof String) {
+			url = (String)raw;
+		}
+
+		return JSONUtil.put(
+			"fragmentEditableElementValue",
+			JSONUtil.put(
+				"fragmentLinkTextValue",
+				JSONUtil.put(
+					"fragmentEditableElementValueFragmentLink",
+					JSONUtil.put(
+						"fragmentLink",
+						JSONUtil.put(
+							"target", target
+						).put(
+							"value",
+							JSONUtil.put(
+								"type", "FragmentInlineValue"
+							).put(
+								"value_i18n", _i18n(locale, url)
+							)
+						))
+				).put(
+					"textFragmentValue",
+					JSONUtil.put(
+						"fragmentInlineValue",
+						JSONUtil.put("value_i18n", _i18n(locale, text))
+					).put(
+						"type", "Inline"
+					)
+				)
+			).put(
+				"type", "Text"
+			)
+		).put(
+			"id", id
+		);
+	}
+
+	private JSONObject _buildRichTextEditable(
+			String id, String value, String locale)
+		throws Exception {
+
+		return JSONUtil.put(
+			"fragmentEditableElementValue",
+			JSONUtil.put(
+				"htmlFragmentValue",
+				JSONUtil.put(
+					"fragmentInlineValue",
+					JSONUtil.put("value_i18n", _i18n(locale, value))
+				).put(
+					"type", "Inline"
+				)
+			).put(
+				"type", "RichText"
+			)
+		).put(
+			"id", id
+		);
+	}
+
+	private JSONObject _buildTextEditable(
+			String id, String value, String locale)
+		throws Exception {
+
+		return JSONUtil.put(
+			"fragmentEditableElementValue",
+			JSONUtil.put(
+				"fragmentLinkTextValue",
+				JSONUtil.put(
+					"textFragmentValue",
+					JSONUtil.put(
+						"fragmentInlineValue",
+						JSONUtil.put("value_i18n", _i18n(locale, value))
+					).put(
+						"type", "Inline"
+					))
+			).put(
+				"type", "Text"
+			)
+		).put(
+			"id", id
+		);
+	}
+
+	private JSONObject _buildViewportStyle(JSONObject irJSONObject)
+		throws Exception {
+
+		JSONObject styleJSONObject = JSONFactoryUtil.createJSONObject();
+
+		_applySpacing(irJSONObject, styleJSONObject, "padding", "5");
+		_applySpacing(irJSONObject, styleJSONObject, "margin", null);
+		_applyStyleProperties(irJSONObject, styleJSONObject);
+
+		JSONObject irStyleJSONObject = irJSONObject.getJSONObject("style");
+
+		if (irStyleJSONObject != null) {
+			_applySpacing(irStyleJSONObject, styleJSONObject, "padding", null);
+			_applySpacing(irStyleJSONObject, styleJSONObject, "margin", null);
+			_applyStyleProperties(irStyleJSONObject, styleJSONObject);
+		}
+
+		return styleJSONObject;
+	}
+
+	private JSONArray _convertChildren(
+			JSONArray childrenJSONArray, String parentERC, String locale)
+		throws Exception {
+
+		JSONArray resultJSONArray = JSONFactoryUtil.createJSONArray();
+
+		if (childrenJSONArray == null) {
+			return resultJSONArray;
+		}
+
+		for (int i = 0; i < childrenJSONArray.length(); i++) {
+			JSONObject convertedJSONObject = _convertElement(
+				childrenJSONArray.getJSONObject(i), parentERC, i, locale);
+
+			if (convertedJSONObject != null) {
+				resultJSONArray.put(convertedJSONObject);
+			}
+		}
+
+		return resultJSONArray;
+	}
+
+	private JSONObject _convertContainer(
+			JSONObject irJSONObject, String parentERC, int position,
+			String locale)
+		throws Exception {
+
+		String erc = irJSONObject.getString("erc");
+
+		JSONObject definitionJSONObject = JSONUtil.put(
+			"fragmentViewports",
+			JSONUtil.put(
+				JSONUtil.put(
+					"fragmentViewportStyle", _buildViewportStyle(irJSONObject)
+				).put(
+					"id", "Desktop"
+				))
+		).put(
+			"layout", _buildContainerLayout(irJSONObject)
+		).put(
+			"type", "Container"
+		);
+
+		JSONArray childrenJSONArray = _convertChildren(
+			irJSONObject.getJSONArray("children"), erc, locale);
+
+		JSONObject nodeJSONObject = JSONUtil.put(
+			"externalReferenceCode", erc
+		).put(
+			"pageElementDefinition", definitionJSONObject
+		).put(
+			"pageElements", childrenJSONArray
+		).put(
+			"position", position
+		);
+
+		if (parentERC != null) {
+			nodeJSONObject.put("parentExternalReferenceCode", parentERC);
+		}
+
+		return nodeJSONObject;
+	}
+
+	private JSONObject _convertElement(
+			JSONObject irJSONObject, String parentERC, int position,
+			String locale)
+		throws Exception {
+
+		String type = irJSONObject.getString("type");
+
+		if (Objects.equals(type, "container")) {
+			return _convertContainer(irJSONObject, parentERC, position, locale);
+		}
+		else if (Objects.equals(type, "grid")) {
+			return _convertGrid(irJSONObject, parentERC, position, locale);
+		}
+		else if (Objects.equals(type, "fragment")) {
+			return _convertFragment(irJSONObject, parentERC, position, locale);
+		}
+
+		return null;
+	}
+
+	private JSONObject _convertFragment(
+			JSONObject irJSONObject, String parentERC, int position,
+			String locale)
+		throws Exception {
+
+		String erc = irJSONObject.getString("erc");
+
+		JSONObject fragmentReferenceJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
+		String source = irJSONObject.getString("source");
+
+		if (Objects.equals(source, "ootb")) {
+			String key = irJSONObject.getString("key");
+
+			String fragmentKey = _ootbNameToKey.get(key);
+
+			if (fragmentKey == null) {
+				fragmentKey = key;
+			}
+
+			fragmentReferenceJSONObject.put(
+				"defaultFragmentKey", fragmentKey
+			).put(
+				"fragmentReferenceType", "DefaultFragmentReference"
+			);
+		}
+		else if (Objects.equals(source, "custom")) {
+			fragmentReferenceJSONObject.put(
+				"externalReferenceCode", irJSONObject.getString("key")
+			).put(
+				"fragmentReferenceType", "FragmentItemExternalReference"
+			);
+		}
+
+		JSONObject instanceJSONObject = JSONUtil.put(
+			"fragmentInstanceExternalReferenceCode", erc + "-inst"
+		).put(
+			"fragmentReference", fragmentReferenceJSONObject
+		).put(
+			"indexed", true
+		);
+
+		JSONObject contentJSONObject = irJSONObject.getJSONObject("content");
+
+		if (contentJSONObject != null) {
+			String fragmentKey = null;
+
+			if (Objects.equals(source, "ootb")) {
+				String key = irJSONObject.getString("key");
+
+				fragmentKey = _ootbNameToKey.get(key);
+
+				if (fragmentKey == null) {
+					fragmentKey = key;
+				}
+			}
+			else if (Objects.equals(source, "custom")) {
+				fragmentKey = irJSONObject.getString("key");
+			}
+
+			JSONArray editableElementsJSONArray = _buildEditableElements(
+				contentJSONObject, fragmentKey, locale);
+
+			if (editableElementsJSONArray.length() > 0) {
+				instanceJSONObject.put(
+					"fragmentEditableElements", editableElementsJSONArray);
+			}
+		}
+
+		JSONObject irStyleJSONObject = irJSONObject.getJSONObject("style");
+
+		if (irStyleJSONObject != null) {
+			instanceJSONObject.put(
+				"fragmentViewports",
+				JSONUtil.put(
+					JSONUtil.put(
+						"fragmentViewportStyle",
+						_buildViewportStyle(irJSONObject)
+					).put(
+						"id", "Desktop"
+					)));
+		}
+
+		if (Objects.equals(source, "custom")) {
+			String fragmentKey = irJSONObject.getString("key");
+
+			JSONObject fragmentSourcesJSONObject =
+				_customFragmentSourcesMap.get(fragmentKey);
+
+			if (fragmentSourcesJSONObject != null) {
+				String configuration = fragmentSourcesJSONObject.getString(
+					"configuration");
+
+				if (Validator.isNotNull(configuration)) {
+					instanceJSONObject.put("configuration", configuration);
+				}
+
+				String css = fragmentSourcesJSONObject.getString("css");
+
+				if (Validator.isNotNull(css)) {
+					instanceJSONObject.put("css", css);
+				}
+
+				String html = fragmentSourcesJSONObject.getString("html");
+
+				if (Validator.isNotNull(html)) {
+					instanceJSONObject.put("html", html);
+				}
+
+				String js = fragmentSourcesJSONObject.getString("js");
+
+				if (Validator.isNotNull(js)) {
+					instanceJSONObject.put("js", js);
+				}
+			}
+		}
+
+		JSONObject nodeJSONObject = JSONUtil.put(
+			"externalReferenceCode", erc
+		).put(
+			"pageElementDefinition",
+			JSONUtil.put(
+				"fragmentInstance", instanceJSONObject
+			).put(
+				"type", "BasicFragment"
+			)
+		).put(
+			"pageElements", JSONFactoryUtil.createJSONArray()
+		).put(
+			"position", position
+		);
+
+		if (parentERC != null) {
+			nodeJSONObject.put("parentExternalReferenceCode", parentERC);
+		}
+
+		return nodeJSONObject;
+	}
+
+	private JSONObject _convertGrid(
+			JSONObject irJSONObject, String parentERC, int position,
+			String locale)
+		throws Exception {
+
+		String erc = irJSONObject.getString("erc");
+
+		JSONArray columnsJSONArray = irJSONObject.getJSONArray("columns");
+
+		if (columnsJSONArray == null) {
+			columnsJSONArray = JSONFactoryUtil.createJSONArray();
+		}
+
+		int columnCount = columnsJSONArray.length();
+
+		boolean gutters = irJSONObject.getBoolean("gutters", true);
+
+		JSONObject modulesPerRowJSONObject = irJSONObject.getJSONObject(
+			"modulesPerRow");
+
+		int desktopPerRow = columnCount;
+		int tabletPerRow = 0;
+		int mobilePerRow = 0;
+
+		if (modulesPerRowJSONObject != null) {
+			desktopPerRow = modulesPerRowJSONObject.getInt(
+				"desktop", columnCount);
+			tabletPerRow = modulesPerRowJSONObject.getInt("tablet", 0);
+			mobilePerRow = modulesPerRowJSONObject.getInt("mobile", 0);
+		}
+
+		JSONArray gridViewportsJSONArray = JSONUtil.put(
+			JSONUtil.put(
+				"gridViewportDefinition",
+				JSONUtil.put(
+					"modulesPerRow", desktopPerRow
+				).put(
+					"verticalAlignment", "Top"
+				)
+			).put(
+				"id", "Desktop"
+			));
+
+		if (tabletPerRow > 0) {
+			gridViewportsJSONArray.put(
+				JSONUtil.put(
+					"gridViewportDefinition",
+					JSONUtil.put(
+						"modulesPerRow", tabletPerRow
+					).put(
+						"verticalAlignment", "Top"
+					)
+				).put(
+					"id", "Tablet"
+				));
+		}
+
+		if (mobilePerRow > 0) {
+			gridViewportsJSONArray.put(
+				JSONUtil.put(
+					"gridViewportDefinition",
+					JSONUtil.put(
+						"modulesPerRow", mobilePerRow
+					).put(
+						"verticalAlignment", "Top"
+					)
+				).put(
+					"id", "PortraitMobile"
+				));
+		}
+
+		JSONObject definitionJSONObject = JSONUtil.put(
+			"gridViewports", gridViewportsJSONArray
+		).put(
+			"gutters", gutters
+		).put(
+			"numberOfModules", columnCount
+		).put(
+			"type", "Grid"
+		);
+
+		JSONArray moduleElementsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		for (int i = 0; i < columnCount; i++) {
+			JSONObject columnJSONObject = columnsJSONArray.getJSONObject(i);
+
+			moduleElementsJSONArray.put(
+				_convertModule(columnJSONObject, erc, i, columnCount, locale));
+		}
+
+		JSONObject nodeJSONObject = JSONUtil.put(
+			"externalReferenceCode", erc
+		).put(
+			"pageElementDefinition", definitionJSONObject
+		).put(
+			"pageElements", moduleElementsJSONArray
+		).put(
+			"position", position
+		);
+
+		if (parentERC != null) {
+			nodeJSONObject.put("parentExternalReferenceCode", parentERC);
+		}
+
+		return nodeJSONObject;
+	}
+
+	private JSONObject _convertModule(
+			JSONObject columnJSONObject, String gridERC, int position,
+			int columnCount, String locale)
+		throws Exception {
+
+		int defaultSize = (columnCount > 0) ? (12 / columnCount) : 6;
+
+		int size = columnJSONObject.getInt("size", defaultSize);
+
+		String colERC = StringBundler.concat(
+			"mod-", gridERC, "-", position + 1);
+
+		JSONObject definitionJSONObject = JSONUtil.put(
+			"moduleViewports",
+			JSONUtil.put(
+				JSONUtil.put(
+					"id", "Desktop"
+				).put(
+					"moduleViewportDefinition", JSONUtil.put("size", size)
+				))
+		).put(
+			"type", "Module"
+		);
+
+		JSONArray childrenJSONArray = _convertChildren(
+			columnJSONObject.getJSONArray("children"), colERC, locale);
+
+		return JSONUtil.put(
+			"externalReferenceCode", colERC
+		).put(
+			"pageElementDefinition", definitionJSONObject
+		).put(
+			"pageElements", childrenJSONArray
+		).put(
+			"parentExternalReferenceCode", gridERC
+		).put(
+			"position", position
+		);
+	}
+
+	private JSONObject _i18n(String locale, String value) throws Exception {
+		return JSONUtil.put(locale, value);
+	}
+
+	private JSONObject _i18nObject(String locale, JSONObject valueJSONObject)
+		throws Exception {
+
+		return JSONUtil.put(locale, valueJSONObject);
+	}
+
+	private String _normalizeColor(String color) {
+		if ((color != null) && !color.endsWith("Color")) {
+			return color + "Color";
+		}
+
+		return color;
+	}
+
+	private String _normalizeLinkTarget(String target) {
+		if (target == null) {
+			return "Self";
+		}
+
+		String cleaned = StringUtil.toLowerCase(target.replaceFirst("^_", ""));
+
+		if (Objects.equals(cleaned, "blank")) {
+			return "Blank";
+		}
+		else if (Objects.equals(cleaned, "parent")) {
+			return "Parent";
+		}
+		else if (Objects.equals(cleaned, "top")) {
+			return "Top";
+		}
+
+		return "Self";
+	}
+
+	private Map<String, Map<String, String>> _parseCustomEditableTypes(
+		JSONArray catalogJSONArray) {
+
+		Map<String, Map<String, String>> resultMap = new HashMap<>();
+
+		if (catalogJSONArray == null) {
+			return resultMap;
+		}
+
+		try {
+			for (int i = 0; i < catalogJSONArray.length(); i++) {
+				JSONObject fragmentJSONObject = catalogJSONArray.getJSONObject(
+					i);
+
+				JSONArray editablesJSONArray = fragmentJSONObject.getJSONArray(
+					"editables");
+
+				if ((editablesJSONArray == null) ||
+					(editablesJSONArray.length() == 0)) {
+
+					continue;
+				}
+
+				String erc = fragmentJSONObject.getString(
+					"externalReferenceCode");
+
+				Map<String, String> editableMap = new HashMap<>();
+
+				for (int j = 0; j < editablesJSONArray.length(); j++) {
+					JSONObject editableJSONObject =
+						editablesJSONArray.getJSONObject(j);
+
+					editableMap.put(
+						editableJSONObject.getString("id"),
+						editableJSONObject.getString("type"));
+				}
+
+				resultMap.put(erc, editableMap);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return resultMap;
+	}
+
+	private Map<String, JSONObject> _parseCustomFragmentSources(
+		JSONArray catalogJSONArray) {
+
+		Map<String, JSONObject> resultMap = new HashMap<>();
+
+		if (catalogJSONArray == null) {
+			return resultMap;
+		}
+
+		try {
+			for (int i = 0; i < catalogJSONArray.length(); i++) {
+				JSONObject fragmentJSONObject = catalogJSONArray.getJSONObject(
+					i);
+
+				resultMap.put(
+					fragmentJSONObject.getString("externalReferenceCode"),
+					JSONUtil.put(
+						"configuration",
+						fragmentJSONObject.getString("configuration")
+					).put(
+						"css", fragmentJSONObject.getString("css")
+					).put(
+						"html", fragmentJSONObject.getString("html")
+					).put(
+						"js", fragmentJSONObject.getString("js")
+					));
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return resultMap;
+	}
+
+	private String _stripMarkdownFences(String input) {
+		if (input == null) {
+			return input;
+		}
+
+		input = input.trim();
+
+		if (input.startsWith("```")) {
+			int firstNewline = input.indexOf('\n');
+
+			if (firstNewline > 0) {
+				input = input.substring(firstNewline + 1);
+			}
+			else {
+				input = input.substring(3);
+			}
+		}
+
+		if (input.endsWith("```")) {
+			input = input.substring(0, input.length() - 3);
+		}
+
+		return input.trim();
+	}
+
+	private String _toString(Object value) {
+		if (value instanceof String) {
+			return (String)value;
+		}
+
+		if (value instanceof JSONObject) {
+			JSONObject valueJSONObject = (JSONObject)value;
+
+			if (valueJSONObject.has("text")) {
+				return valueJSONObject.getString("text");
+			}
+
+			if (valueJSONObject.has("value")) {
+				return valueJSONObject.getString("value");
+			}
+
+			if (valueJSONObject.has("content")) {
+				return valueJSONObject.getString("content");
+			}
+		}
+
+		if (value == null) {
+			return StringPool.BLANK;
+		}
+
+		return String.valueOf(value);
+	}
+
+	private static final String[] _SIDES = {"Top", "Bottom", "Left", "Right"};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		IRToPageSpecConverter.class);
+
+	private static final Set<String> _colorStyleKeys = Set.of(
+		"backgroundColor", "borderColor", "textColor");
+	private static final Map<String, Map<String, String>> _ootbEditableTypes =
+		Map.of(
+			"BASIC_COMPONENT-heading", Map.of("element-text", "text"),
+			"BASIC_COMPONENT-paragraph", Map.of("element-text", "richText"),
+			"BASIC_COMPONENT-card",
+			Map.of(
+				"01-img", "image", "02-title", "richText", "03-content",
+				"richText", "04-link", "link"),
+			"BASIC_COMPONENT-image", Map.of("image-square", "image"),
+			"BASIC_COMPONENT-button",
+			Map.of("element-text", "text", "element-link", "link"),
+			"BASIC_COMPONENT-video", Map.of("element-video", "link"));
+	private static final Map<String, String> _ootbNameToKey = Map.of(
+		"button", "BASIC_COMPONENT-button", "card", "BASIC_COMPONENT-card",
+		"heading", "BASIC_COMPONENT-heading", "image", "BASIC_COMPONENT-image",
+		"paragraph", "BASIC_COMPONENT-paragraph", "separator",
+		"BASIC_COMPONENT-separator", "spacer", "BASIC_COMPONENT-spacer",
+		"video", "BASIC_COMPONENT-video");
+	private static final Set<String> _stringStyleKeys = Set.of(
+		"borderRadius", "borderWidth", "fontFamily", "fontSize", "fontWeight",
+		"height", "maxHeight", "maxWidth", "minHeight", "minWidth", "opacity",
+		"overflow", "shadow", "textAlign", "width");
+
+	private final Map<String, Map<String, String>> _customEditableTypesMap;
+	private final Map<String, JSONObject> _customFragmentSourcesMap;
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/PageSpecToIRConverter.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/PageSpecToIRConverter.java
@@ -1,0 +1,929 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate.util;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+public class PageSpecToIRConverter {
+
+	public String convert(String pageSpecJSON, String title, String locale) {
+		if ((locale == null) || locale.isEmpty()) {
+			locale = "en-US";
+		}
+
+		try {
+			JSONObject specJSONObject = _unwrapSpec(
+				JSONFactoryUtil.createJSONObject(
+					_stripMarkdownFences(pageSpecJSON)));
+
+			String erc = specJSONObject.getString("externalReferenceCode");
+
+			JSONArray pageExperiencesJSONArray = specJSONObject.getJSONArray(
+				"pageExperiences");
+
+			JSONArray pageElementsJSONArray = _resolvePageElements(
+				pageExperiencesJSONArray);
+
+			JSONArray elementsJSONArray = JSONFactoryUtil.createJSONArray();
+
+			for (int i = 0; i < pageElementsJSONArray.length(); i++) {
+				JSONObject convertedJSONObject = _convertElement(
+					pageElementsJSONArray.getJSONObject(i), locale);
+
+				if (convertedJSONObject != null) {
+					elementsJSONArray.put(convertedJSONObject);
+				}
+			}
+
+			return JSONUtil.put(
+				"elements", elementsJSONArray
+			).put(
+				"erc", erc
+			).put(
+				"locale", locale
+			).put(
+				"title", title
+			).toString();
+		}
+		catch (Exception exception) {
+			return "Error converting page spec to IR: " +
+				exception.getMessage();
+		}
+	}
+
+	private void _addSpacingValue(
+		JSONObject vpStyleJSONObject, JSONObject spacingJSONObject,
+		String prefix) {
+
+		for (String side : _SIDES) {
+			String value = vpStyleJSONObject.getString(prefix + side);
+
+			if ((value != null) && !value.isEmpty()) {
+				spacingJSONObject.put(
+					StringUtil.toLowerCase(side), _parseIntSafe(value));
+			}
+		}
+	}
+
+	private void _applySpacingFromStyle(
+			JSONObject vpStyleJSONObject, JSONObject targetJSONObject,
+			String prefix)
+		throws Exception {
+
+		String top = vpStyleJSONObject.getString(prefix + "Top");
+		String bottom = vpStyleJSONObject.getString(prefix + "Bottom");
+		String left = vpStyleJSONObject.getString(prefix + "Left");
+		String right = vpStyleJSONObject.getString(prefix + "Right");
+
+		boolean hasValue = false;
+
+		if (((top != null) && !top.isEmpty()) ||
+			((bottom != null) && !bottom.isEmpty()) ||
+			((left != null) && !left.isEmpty()) ||
+			((right != null) && !right.isEmpty())) {
+
+			hasValue = true;
+		}
+
+		if (!hasValue) {
+			return;
+		}
+
+		JSONObject spacingJSONObject = JSONFactoryUtil.createJSONObject();
+
+		if ((top != null) && !top.isEmpty()) {
+			spacingJSONObject.put("top", _parseIntSafe(top));
+		}
+
+		if ((bottom != null) && !bottom.isEmpty()) {
+			spacingJSONObject.put("bottom", _parseIntSafe(bottom));
+		}
+
+		if ((left != null) && !left.isEmpty()) {
+			spacingJSONObject.put("left", _parseIntSafe(left));
+		}
+
+		if ((right != null) && !right.isEmpty()) {
+			spacingJSONObject.put("right", _parseIntSafe(right));
+		}
+
+		targetJSONObject.put(prefix, spacingJSONObject);
+	}
+
+	private JSONArray _convertChildren(
+			JSONObject elementJSONObject, String locale)
+		throws Exception {
+
+		JSONArray childrenJSONArray = JSONFactoryUtil.createJSONArray();
+
+		JSONArray pageElementsJSONArray = elementJSONObject.getJSONArray(
+			"pageElements");
+
+		if (pageElementsJSONArray == null) {
+			return childrenJSONArray;
+		}
+
+		for (int i = 0; i < pageElementsJSONArray.length(); i++) {
+			JSONObject convertedJSONObject = _convertElement(
+				pageElementsJSONArray.getJSONObject(i), locale);
+
+			if (convertedJSONObject != null) {
+				childrenJSONArray.put(convertedJSONObject);
+			}
+		}
+
+		return childrenJSONArray;
+	}
+
+	private JSONObject _convertColumn(
+			JSONObject elementJSONObject, String locale)
+		throws Exception {
+
+		JSONObject definitionJSONObject = elementJSONObject.getJSONObject(
+			"pageElementDefinition");
+
+		JSONArray moduleViewportsJSONArray = definitionJSONObject.getJSONArray(
+			"moduleViewports");
+
+		int size = 6;
+
+		if (moduleViewportsJSONArray != null) {
+			for (int i = 0; i < moduleViewportsJSONArray.length(); i++) {
+				JSONObject viewportJSONObject =
+					moduleViewportsJSONArray.getJSONObject(i);
+
+				if (Objects.equals(
+						viewportJSONObject.getString("id"), "Desktop")) {
+
+					JSONObject viewportDefJSONObject =
+						viewportJSONObject.getJSONObject(
+							"moduleViewportDefinition");
+
+					if (viewportDefJSONObject != null) {
+						size = viewportDefJSONObject.getInt("size", 6);
+					}
+				}
+			}
+		}
+
+		JSONObject columnJSONObject = JSONUtil.put("size", size);
+
+		JSONArray childrenJSONArray = _convertChildren(
+			elementJSONObject, locale);
+
+		if (childrenJSONArray.length() > 0) {
+			columnJSONObject.put("children", childrenJSONArray);
+		}
+
+		return columnJSONObject;
+	}
+
+	private JSONObject _convertContainer(
+			JSONObject elementJSONObject, JSONObject definitionJSONObject,
+			String locale)
+		throws Exception {
+
+		JSONObject containerJSONObject = JSONUtil.put(
+			"erc", elementJSONObject.getString("externalReferenceCode")
+		).put(
+			"type", "container"
+		);
+
+		JSONObject layoutJSONObject = definitionJSONObject.getJSONObject(
+			"layout");
+
+		if (layoutJSONObject != null) {
+			String contentDisplay = layoutJSONObject.getString(
+				"contentDisplay");
+
+			if (Objects.equals(contentDisplay, "FlexRow")) {
+				containerJSONObject.put("contentDisplay", "flex-row");
+			}
+			else if (Objects.equals(contentDisplay, "FlexColumn")) {
+				containerJSONObject.put("contentDisplay", "flex-column");
+			}
+
+			String widthType = layoutJSONObject.getString("widthType");
+
+			if (Objects.equals(widthType, "Fixed")) {
+				containerJSONObject.put("widthType", "fixed");
+			}
+		}
+
+		_extractViewportStyle(definitionJSONObject, containerJSONObject);
+
+		JSONArray childrenJSONArray = _convertChildren(
+			elementJSONObject, locale);
+
+		if (childrenJSONArray.length() > 0) {
+			containerJSONObject.put("children", childrenJSONArray);
+		}
+
+		return containerJSONObject;
+	}
+
+	private JSONObject _convertElement(
+			JSONObject elementJSONObject, String locale)
+		throws Exception {
+
+		JSONObject definitionJSONObject = elementJSONObject.getJSONObject(
+			"pageElementDefinition");
+
+		if (definitionJSONObject == null) {
+			return null;
+		}
+
+		String type = definitionJSONObject.getString("type");
+
+		if (Objects.equals(type, "Container")) {
+			return _convertContainer(
+				elementJSONObject, definitionJSONObject, locale);
+		}
+		else if (Objects.equals(type, "Grid")) {
+			return _convertGrid(
+				elementJSONObject, definitionJSONObject, locale);
+		}
+		else if (Objects.equals(type, "BasicFragment")) {
+			return _convertFragment(
+				elementJSONObject, definitionJSONObject, locale);
+		}
+
+		return null;
+	}
+
+	private JSONObject _convertFragment(
+			JSONObject elementJSONObject, JSONObject definitionJSONObject,
+			String locale)
+		throws Exception {
+
+		JSONObject fragmentJSONObject = JSONUtil.put(
+			"erc", elementJSONObject.getString("externalReferenceCode")
+		).put(
+			"type", "fragment"
+		);
+
+		JSONObject instanceJSONObject = definitionJSONObject.getJSONObject(
+			"fragmentInstance");
+
+		if (instanceJSONObject == null) {
+			return fragmentJSONObject;
+		}
+
+		JSONObject refJSONObject = instanceJSONObject.getJSONObject(
+			"fragmentReference");
+
+		if (refJSONObject != null) {
+			String refType = refJSONObject.getString("fragmentReferenceType");
+
+			if (Objects.equals(refType, "DefaultFragmentReference")) {
+				fragmentJSONObject.put("source", "ootb");
+
+				String fragmentKey = refJSONObject.getString(
+					"defaultFragmentKey");
+
+				String friendlyName = _ootbKeyToName.get(fragmentKey);
+
+				fragmentJSONObject.put(
+					"key", (friendlyName != null) ? friendlyName : fragmentKey);
+			}
+			else if (Objects.equals(refType, "FragmentItemExternalReference")) {
+				fragmentJSONObject.put(
+					"key", refJSONObject.getString("externalReferenceCode")
+				).put(
+					"source", "custom"
+				);
+			}
+		}
+
+		JSONArray editableElementsJSONArray = instanceJSONObject.getJSONArray(
+			"fragmentEditableElements");
+
+		if ((editableElementsJSONArray != null) &&
+			(editableElementsJSONArray.length() > 0)) {
+
+			JSONObject contentJSONObject = JSONFactoryUtil.createJSONObject();
+
+			for (int i = 0; i < editableElementsJSONArray.length(); i++) {
+				JSONObject editableJSONObject =
+					editableElementsJSONArray.getJSONObject(i);
+
+				String id = editableJSONObject.getString("id");
+
+				Object value = _extractEditableValue(
+					editableJSONObject, locale);
+
+				if (value != null) {
+					contentJSONObject.put(id, value);
+				}
+			}
+
+			if (contentJSONObject.length() > 0) {
+				fragmentJSONObject.put("content", contentJSONObject);
+			}
+		}
+
+		_extractFragmentStyle(instanceJSONObject, fragmentJSONObject);
+
+		return fragmentJSONObject;
+	}
+
+	private JSONObject _convertGrid(
+			JSONObject elementJSONObject, JSONObject definitionJSONObject,
+			String locale)
+		throws Exception {
+
+		JSONObject gridJSONObject = JSONUtil.put(
+			"erc", elementJSONObject.getString("externalReferenceCode")
+		).put(
+			"type", "grid"
+		);
+
+		boolean gutters = definitionJSONObject.getBoolean("gutters", true);
+
+		if (!gutters) {
+			gridJSONObject.put("gutters", false);
+		}
+
+		JSONArray gridViewportsJSONArray = definitionJSONObject.getJSONArray(
+			"gridViewports");
+
+		if (gridViewportsJSONArray != null) {
+			JSONObject modulesPerRowJSONObject =
+				JSONFactoryUtil.createJSONObject();
+
+			for (int i = 0; i < gridViewportsJSONArray.length(); i++) {
+				JSONObject viewportJSONObject =
+					gridViewportsJSONArray.getJSONObject(i);
+
+				JSONObject vpDefJSONObject = viewportJSONObject.getJSONObject(
+					"gridViewportDefinition");
+
+				if (vpDefJSONObject == null) {
+					continue;
+				}
+
+				int perRow = vpDefJSONObject.getInt("modulesPerRow", 0);
+
+				if (perRow <= 0) {
+					continue;
+				}
+
+				String vpId = viewportJSONObject.getString("id");
+
+				if (Objects.equals(vpId, "Desktop")) {
+					modulesPerRowJSONObject.put("desktop", perRow);
+				}
+				else if (Objects.equals(vpId, "Tablet")) {
+					modulesPerRowJSONObject.put("tablet", perRow);
+				}
+				else if (Objects.equals(vpId, "PortraitMobile")) {
+					modulesPerRowJSONObject.put("mobile", perRow);
+				}
+			}
+
+			if (modulesPerRowJSONObject.length() > 0) {
+				gridJSONObject.put("modulesPerRow", modulesPerRowJSONObject);
+			}
+		}
+
+		JSONArray pageElementsJSONArray = elementJSONObject.getJSONArray(
+			"pageElements");
+
+		JSONArray columnsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		if (pageElementsJSONArray != null) {
+			for (int i = 0; i < pageElementsJSONArray.length(); i++) {
+				JSONObject moduleElementJSONObject =
+					pageElementsJSONArray.getJSONObject(i);
+
+				JSONObject moduleDefJSONObject =
+					moduleElementJSONObject.getJSONObject(
+						"pageElementDefinition");
+
+				if ((moduleDefJSONObject != null) &&
+					Objects.equals(
+						moduleDefJSONObject.getString("type"), "Module")) {
+
+					columnsJSONArray.put(
+						_convertColumn(moduleElementJSONObject, locale));
+				}
+			}
+		}
+
+		gridJSONObject.put("columns", columnsJSONArray);
+
+		return gridJSONObject;
+	}
+
+	private String _denormalizeColor(String color) {
+		if ((color != null) && color.endsWith("Color")) {
+			return color.substring(0, color.length() - 5);
+		}
+
+		return color;
+	}
+
+	private Object _extractEditableValue(
+			JSONObject editableJSONObject, String locale)
+		throws Exception {
+
+		JSONObject elementValueJSONObject = editableJSONObject.getJSONObject(
+			"fragmentEditableElementValue");
+
+		if (elementValueJSONObject == null) {
+			return null;
+		}
+
+		String type = elementValueJSONObject.getString("type");
+
+		if (Objects.equals(type, "Text")) {
+			return _extractTextValue(elementValueJSONObject, locale);
+		}
+		else if (Objects.equals(type, "RichText")) {
+			return _extractRichTextValue(elementValueJSONObject, locale);
+		}
+		else if (Objects.equals(type, "Image")) {
+			return _extractImageValue(elementValueJSONObject, locale);
+		}
+
+		return null;
+	}
+
+	private void _extractFragmentStyle(
+			JSONObject instanceJSONObject, JSONObject fragmentJSONObject)
+		throws Exception {
+
+		JSONArray viewportsJSONArray = instanceJSONObject.getJSONArray(
+			"fragmentViewports");
+
+		if (viewportsJSONArray == null) {
+			return;
+		}
+
+		for (int i = 0; i < viewportsJSONArray.length(); i++) {
+			JSONObject viewportJSONObject = viewportsJSONArray.getJSONObject(i);
+
+			if (!Objects.equals(
+					viewportJSONObject.getString("id"), "Desktop")) {
+
+				continue;
+			}
+
+			JSONObject vpStyleJSONObject = viewportJSONObject.getJSONObject(
+				"fragmentViewportStyle");
+
+			if (vpStyleJSONObject == null) {
+				continue;
+			}
+
+			JSONObject styleJSONObject = _parseViewportStyle(vpStyleJSONObject);
+
+			if (styleJSONObject.length() > 0) {
+				fragmentJSONObject.put("style", styleJSONObject);
+			}
+		}
+	}
+
+	private Object _extractImageValue(
+			JSONObject elementValueJSONObject, String locale)
+		throws Exception {
+
+		JSONObject fragmentImageJSONObject =
+			elementValueJSONObject.getJSONObject("fragmentImage");
+
+		if (fragmentImageJSONObject == null) {
+			return null;
+		}
+
+		JSONObject imageValueJSONObject = fragmentImageJSONObject.getJSONObject(
+			"fragmentImageValue");
+
+		if (imageValueJSONObject == null) {
+			return null;
+		}
+
+		JSONObject i18nJSONObject = imageValueJSONObject.getJSONObject(
+			"value_i18n");
+
+		if (i18nJSONObject == null) {
+			return null;
+		}
+
+		JSONObject localeValueJSONObject = i18nJSONObject.getJSONObject(locale);
+
+		if (localeValueJSONObject == null) {
+			Iterator<String> keysIterator = i18nJSONObject.keys();
+
+			if (keysIterator.hasNext()) {
+				localeValueJSONObject = i18nJSONObject.getJSONObject(
+					keysIterator.next());
+			}
+		}
+
+		if (localeValueJSONObject == null) {
+			return null;
+		}
+
+		String url = localeValueJSONObject.getString("url");
+
+		if ((url == null) || url.isEmpty()) {
+			return null;
+		}
+
+		return JSONUtil.put("url", url);
+	}
+
+	private Object _extractRichTextValue(
+			JSONObject elementValueJSONObject, String locale)
+		throws Exception {
+
+		JSONObject htmlValueJSONObject = elementValueJSONObject.getJSONObject(
+			"htmlFragmentValue");
+
+		if (htmlValueJSONObject == null) {
+			return null;
+		}
+
+		JSONObject inlineValueJSONObject = htmlValueJSONObject.getJSONObject(
+			"fragmentInlineValue");
+
+		if (inlineValueJSONObject == null) {
+			return null;
+		}
+
+		return _getI18nValue(inlineValueJSONObject, locale);
+	}
+
+	private Object _extractTextValue(
+			JSONObject elementValueJSONObject, String locale)
+		throws Exception {
+
+		JSONObject linkTextValueJSONObject =
+			elementValueJSONObject.getJSONObject("fragmentLinkTextValue");
+
+		if (linkTextValueJSONObject == null) {
+			return null;
+		}
+
+		JSONObject fragmentLinkJSONObject = null;
+
+		JSONObject linkRefJSONObject = linkTextValueJSONObject.getJSONObject(
+			"fragmentEditableElementValueFragmentLink");
+
+		if (linkRefJSONObject != null) {
+			fragmentLinkJSONObject = linkRefJSONObject.getJSONObject(
+				"fragmentLink");
+		}
+
+		JSONObject textValueJSONObject = linkTextValueJSONObject.getJSONObject(
+			"textFragmentValue");
+
+		String text = null;
+
+		if (textValueJSONObject != null) {
+			JSONObject inlineValueJSONObject =
+				textValueJSONObject.getJSONObject("fragmentInlineValue");
+
+			if (inlineValueJSONObject != null) {
+				text = _getI18nValue(inlineValueJSONObject, locale);
+			}
+		}
+
+		if (fragmentLinkJSONObject == null) {
+			return text;
+		}
+
+		JSONObject linkJSONObject = JSONFactoryUtil.createJSONObject();
+
+		if (text != null) {
+			linkJSONObject.put("text", text);
+		}
+
+		JSONObject linkValueJSONObject = fragmentLinkJSONObject.getJSONObject(
+			"value");
+
+		if (linkValueJSONObject != null) {
+			JSONObject linkI18nJSONObject = linkValueJSONObject.getJSONObject(
+				"value_i18n");
+
+			if (linkI18nJSONObject != null) {
+				String url = _getI18nValue(linkI18nJSONObject, locale);
+
+				if (url != null) {
+					linkJSONObject.put("url", url);
+				}
+			}
+		}
+
+		String target = fragmentLinkJSONObject.getString("target");
+
+		if ((target != null) && !target.isEmpty() &&
+			!Objects.equals(target, "Self")) {
+
+			linkJSONObject.put("target", StringUtil.toLowerCase(target));
+		}
+
+		return linkJSONObject;
+	}
+
+	private void _extractViewportStyle(
+			JSONObject definitionJSONObject, JSONObject containerJSONObject)
+		throws Exception {
+
+		JSONArray viewportsJSONArray = definitionJSONObject.getJSONArray(
+			"fragmentViewports");
+
+		if (viewportsJSONArray == null) {
+			return;
+		}
+
+		for (int i = 0; i < viewportsJSONArray.length(); i++) {
+			JSONObject viewportJSONObject = viewportsJSONArray.getJSONObject(i);
+
+			if (!Objects.equals(
+					viewportJSONObject.getString("id"), "Desktop")) {
+
+				continue;
+			}
+
+			JSONObject vpStyleJSONObject = viewportJSONObject.getJSONObject(
+				"fragmentViewportStyle");
+
+			if (vpStyleJSONObject == null) {
+				continue;
+			}
+
+			_applySpacingFromStyle(
+				vpStyleJSONObject, containerJSONObject, "padding");
+			_applySpacingFromStyle(
+				vpStyleJSONObject, containerJSONObject, "margin");
+
+			String backgroundColor = vpStyleJSONObject.getString(
+				"backgroundColor");
+
+			if ((backgroundColor != null) && !backgroundColor.isEmpty()) {
+				containerJSONObject.put(
+					"backgroundColor", _denormalizeColor(backgroundColor));
+			}
+
+			String textColor = vpStyleJSONObject.getString("textColor");
+
+			if ((textColor != null) && !textColor.isEmpty()) {
+				containerJSONObject.put(
+					"textColor", _denormalizeColor(textColor));
+			}
+
+			String textAlign = vpStyleJSONObject.getString("textAlign");
+
+			if ((textAlign != null) && !textAlign.isEmpty()) {
+				containerJSONObject.put("textAlign", textAlign);
+			}
+		}
+	}
+
+	private String _getI18nValue(JSONObject i18nJSONObject, String locale) {
+		String value = i18nJSONObject.getString(locale);
+
+		if ((value != null) && !value.isEmpty()) {
+			return value;
+		}
+
+		JSONObject valueI18nJSONObject = i18nJSONObject.getJSONObject(
+			"value_i18n");
+
+		if (valueI18nJSONObject != null) {
+			value = valueI18nJSONObject.getString(locale);
+
+			if ((value != null) && !value.isEmpty()) {
+				return value;
+			}
+
+			Iterator<String> keysIterator = valueI18nJSONObject.keys();
+
+			if (keysIterator.hasNext()) {
+				return valueI18nJSONObject.getString(keysIterator.next());
+			}
+		}
+
+		Iterator<String> keysIterator = i18nJSONObject.keys();
+
+		if (keysIterator.hasNext()) {
+			String key = keysIterator.next();
+
+			if (!Objects.equals(key, "value_i18n")) {
+				return i18nJSONObject.getString(key);
+			}
+		}
+
+		return null;
+	}
+
+	private int _parseIntSafe(String value) {
+		try {
+			return Integer.parseInt(value);
+		}
+		catch (NumberFormatException numberFormatException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(numberFormatException);
+			}
+
+			return 0;
+		}
+	}
+
+	private JSONObject _parseViewportStyle(JSONObject vpStyleJSONObject)
+		throws Exception {
+
+		JSONObject styleJSONObject = JSONFactoryUtil.createJSONObject();
+
+		String backgroundColor = vpStyleJSONObject.getString("backgroundColor");
+
+		if ((backgroundColor != null) && !backgroundColor.isEmpty()) {
+			styleJSONObject.put(
+				"backgroundColor", _denormalizeColor(backgroundColor));
+		}
+
+		String textColor = vpStyleJSONObject.getString("textColor");
+
+		if ((textColor != null) && !textColor.isEmpty()) {
+			styleJSONObject.put("textColor", _denormalizeColor(textColor));
+		}
+
+		String textAlign = vpStyleJSONObject.getString("textAlign");
+
+		if ((textAlign != null) && !textAlign.isEmpty()) {
+			styleJSONObject.put("textAlign", textAlign);
+		}
+
+		JSONObject paddingJSONObject = JSONFactoryUtil.createJSONObject();
+
+		_addSpacingValue(vpStyleJSONObject, paddingJSONObject, "padding");
+
+		if (paddingJSONObject.length() > 0) {
+			styleJSONObject.put("padding", paddingJSONObject);
+		}
+
+		JSONObject marginJSONObject = JSONFactoryUtil.createJSONObject();
+
+		_addSpacingValue(vpStyleJSONObject, marginJSONObject, "margin");
+
+		if (marginJSONObject.length() > 0) {
+			styleJSONObject.put("margin", marginJSONObject);
+		}
+
+		return styleJSONObject;
+	}
+
+	private JSONArray _resolvePageElements(JSONArray pageExperiencesJSONArray) {
+		if (pageExperiencesJSONArray == null) {
+			return JSONFactoryUtil.createJSONArray();
+		}
+
+		for (int i = 0; i < pageExperiencesJSONArray.length(); i++) {
+			JSONObject experienceJSONObject =
+				pageExperiencesJSONArray.getJSONObject(i);
+
+			if (Objects.equals(
+					experienceJSONObject.getString("key"), "DEFAULT")) {
+
+				JSONArray elementsJSONArray = experienceJSONObject.getJSONArray(
+					"pageElements");
+
+				if (elementsJSONArray != null) {
+					return elementsJSONArray;
+				}
+			}
+		}
+
+		if (pageExperiencesJSONArray.length() > 0) {
+			JSONObject firstExperienceJSONObject =
+				pageExperiencesJSONArray.getJSONObject(0);
+
+			JSONArray elementsJSONArray =
+				firstExperienceJSONObject.getJSONArray("pageElements");
+
+			if (elementsJSONArray != null) {
+				return elementsJSONArray;
+			}
+		}
+
+		return JSONFactoryUtil.createJSONArray();
+	}
+
+	private String _stripMarkdownFences(String input) {
+		if (input == null) {
+			return input;
+		}
+
+		input = input.trim();
+
+		if (input.startsWith("```")) {
+			int firstNewline = input.indexOf('\n');
+
+			if (firstNewline > 0) {
+				input = input.substring(firstNewline + 1);
+			}
+			else {
+				input = input.substring(3);
+			}
+		}
+
+		if (input.endsWith("```")) {
+			input = input.substring(0, input.length() - 3);
+		}
+
+		return input.trim();
+	}
+
+	private JSONObject _unwrapSpec(JSONObject jsonObject) {
+		if (jsonObject.has("pageExperiences")) {
+			return jsonObject;
+		}
+
+		if (jsonObject.has("result")) {
+			Object result = jsonObject.get("result");
+
+			if (result instanceof JSONObject) {
+				return _unwrapSpec((JSONObject)result);
+			}
+
+			if (result instanceof String) {
+				try {
+					return _unwrapSpec(
+						JSONFactoryUtil.createJSONObject((String)result));
+				}
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(exception);
+					}
+				}
+			}
+		}
+
+		if (jsonObject.has("pageSpecifications")) {
+			JSONArray specsJSONArray = jsonObject.getJSONArray(
+				"pageSpecifications");
+
+			if (specsJSONArray != null) {
+				for (int i = 0; i < specsJSONArray.length(); i++) {
+					JSONObject candidateJSONObject =
+						specsJSONArray.getJSONObject(i);
+
+					if (Objects.equals(
+							candidateJSONObject.getString("status"), "Draft")) {
+
+						return candidateJSONObject;
+					}
+				}
+
+				if (specsJSONArray.length() > 0) {
+					return specsJSONArray.getJSONObject(0);
+				}
+			}
+		}
+
+		for (String key : jsonObject.keySet()) {
+			Object value = jsonObject.get(key);
+
+			if (value instanceof JSONObject) {
+				JSONObject nestedJSONObject = (JSONObject)value;
+
+				if (nestedJSONObject.has("pageExperiences")) {
+					return nestedJSONObject;
+				}
+			}
+		}
+
+		return jsonObject;
+	}
+
+	private static final String[] _SIDES = {"Top", "Bottom", "Left", "Right"};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PageSpecToIRConverter.class);
+
+	private static final Map<String, String> _ootbKeyToName = Map.of(
+		"BASIC_COMPONENT-button", "button", "BASIC_COMPONENT-card", "card",
+		"BASIC_COMPONENT-heading", "heading", "BASIC_COMPONENT-image", "image",
+		"BASIC_COMPONENT-paragraph", "paragraph", "BASIC_COMPONENT-separator",
+		"separator", "BASIC_COMPONENT-spacer", "spacer",
+		"BASIC_COMPONENT-video", "video");
+
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/SitePlanBatchFileBuilder.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-impl/src/main/java/com/liferay/content/site/generator/internal/workflow/node/delegate/util/SitePlanBatchFileBuilder.java
@@ -1,0 +1,859 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.site.generator.internal.workflow.node.delegate.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Mario Gomes
+ * @author Iliyan Peychev
+ */
+public class SitePlanBatchFileBuilder {
+
+	public static String detectLanguages(
+		JSONArray itemsJSONArray, String fileName) {
+
+		Set<String> locales = new TreeSet<>();
+
+		if ((itemsJSONArray != null) && (itemsJSONArray.length() > 0)) {
+			Matcher i18nMatcher = _i18nBlockPattern.matcher(
+				itemsJSONArray.toString());
+
+			while (i18nMatcher.find()) {
+				Matcher localeMatcher = _localeKeyPattern.matcher(
+					i18nMatcher.group(1));
+
+				while (localeMatcher.find()) {
+					String locale = localeMatcher.group(1);
+
+					locales.add(StringUtil.toLowerCase(locale));
+				}
+			}
+		}
+
+		if (locales.isEmpty()) {
+			Matcher matcher = _fileNameLanguagePattern.matcher(fileName);
+
+			if (matcher.find()) {
+				String locale = matcher.group(1);
+
+				locales.add(StringUtil.toLowerCase(locale));
+			}
+		}
+
+		return String.join(",", locales);
+	}
+
+	public static JSONObject stripMetadata(JSONObject itemJSONObject) {
+		JSONObject strippedJSONObject = JSONFactoryUtil.createJSONObject();
+
+		for (String key : itemJSONObject.keySet()) {
+			if (_metadataKeys.contains(key)) {
+				continue;
+			}
+
+			strippedJSONObject.put(key, itemJSONObject.get(key));
+		}
+
+		return strippedJSONObject;
+	}
+
+	public SitePlanBatchFileBuilder(
+		String enrichedSitePlan, String blogEntries) {
+
+		_enrichedSitePlan = enrichedSitePlan;
+		_blogEntries = blogEntries;
+	}
+
+	public List<BatchFile> build() throws Exception {
+		if (Validator.isNull(_enrichedSitePlan)) {
+			throw new IllegalArgumentException(
+				"Enriched site plan is required");
+		}
+
+		JSONObject planJSONObject = JSONFactoryUtil.createJSONObject(
+			_enrichedSitePlan);
+
+		JSONObject siteJSONObject = planJSONObject.getJSONObject("site");
+
+		if (siteJSONObject == null) {
+			throw new IllegalArgumentException(
+				"Enriched site plan does not contain a \"site\" object");
+		}
+
+		String siteERC = siteJSONObject.getString("externalReferenceCode");
+		String siteTitle = siteJSONObject.getString("name");
+
+		List<BatchFile> batchFiles = new ArrayList<>();
+
+		batchFiles.add(_buildSiteBatchFile(siteERC, siteJSONObject, siteTitle));
+		batchFiles.add(_buildAssetLibraryBatchFile(siteERC, siteTitle));
+		batchFiles.add(_buildConnectedSiteBatchFile(siteERC, siteTitle));
+		batchFiles.add(_buildFragmentSetBatchFile(siteERC, siteTitle));
+		batchFiles.add(_buildFragmentsBatchFile(planJSONObject, siteERC));
+		batchFiles.add(_buildPagesBatchFile(planJSONObject, siteERC));
+
+		BatchFile blogsBatchFile = _buildBlogsBatchFile(siteERC);
+
+		if (blogsBatchFile != null) {
+			batchFiles.add(blogsBatchFile);
+		}
+
+		return batchFiles;
+	}
+
+	public static class BatchFile {
+
+		public BatchFile(String fileName, JSONObject envelopeJSONObject) {
+			_fileName = fileName;
+			_envelopeJSONObject = envelopeJSONObject;
+		}
+
+		public JSONObject getEnvelopeJSONObject() {
+			return _envelopeJSONObject;
+		}
+
+		public String getFileName() {
+			return _fileName;
+		}
+
+		private final JSONObject _envelopeJSONObject;
+		private final String _fileName;
+
+	}
+
+	private void _appendDraftSuffix(JSONArray elementsJSONArray) {
+		for (int i = 0; i < elementsJSONArray.length(); i++) {
+			JSONObject elementJSONObject = elementsJSONArray.getJSONObject(i);
+
+			String erc = elementJSONObject.getString("externalReferenceCode");
+
+			if (Validator.isNotNull(erc)) {
+				elementJSONObject.put("externalReferenceCode", erc + "-draft");
+			}
+
+			String parentERC = elementJSONObject.getString(
+				"parentExternalReferenceCode");
+
+			if (Validator.isNotNull(parentERC)) {
+				elementJSONObject.put(
+					"parentExternalReferenceCode", parentERC + "-draft");
+			}
+
+			JSONObject definitionJSONObject = elementJSONObject.getJSONObject(
+				"pageElementDefinition");
+
+			if (definitionJSONObject != null) {
+				JSONObject fragmentInstanceJSONObject =
+					definitionJSONObject.getJSONObject("fragmentInstance");
+
+				if (fragmentInstanceJSONObject != null) {
+					String instanceERC = fragmentInstanceJSONObject.getString(
+						"fragmentInstanceExternalReferenceCode");
+
+					if (Validator.isNotNull(instanceERC)) {
+						fragmentInstanceJSONObject.put(
+							"fragmentInstanceExternalReferenceCode",
+							instanceERC + "-draft");
+					}
+				}
+			}
+
+			JSONArray childrenJSONArray = elementJSONObject.getJSONArray(
+				"pageElements");
+
+			if ((childrenJSONArray != null) &&
+				(childrenJSONArray.length() > 0)) {
+
+				_appendDraftSuffix(childrenJSONArray);
+			}
+		}
+	}
+
+	private BatchFile _buildAssetLibraryBatchFile(
+			String siteERC, String siteTitle)
+		throws Exception {
+
+		String assetLibraryERC = siteERC + "-space";
+
+		JSONObject assetLibraryBatchJSONObject = _createBatchWrapper(
+			"com.liferay.headless.asset.library.dto.v1_0.AssetLibrary", false,
+			siteERC, false);
+
+		assetLibraryBatchJSONObject.put(
+			"items",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				JSONUtil.put(
+					"assetLibraryKey", assetLibraryERC
+				).put(
+					"externalReferenceCode", assetLibraryERC
+				).put(
+					"name", siteTitle + " Space"
+				).put(
+					"name_i18n", _createI18nJSON("en-US", siteTitle + " Space")
+				).put(
+					"settings", JSONFactoryUtil.createJSONObject()
+				).put(
+					"type", "Space"
+				)
+			));
+
+		return new BatchFile(
+			"02-asset-library.batch-engine-data.json",
+			assetLibraryBatchJSONObject);
+	}
+
+	private BatchFile _buildBlogsBatchFile(String siteERC) {
+		if (Validator.isNull(_blogEntries)) {
+			return null;
+		}
+
+		String trimmedBlogEntries = _blogEntries.trim();
+
+		JSONArray blogJSONArray = null;
+
+		try {
+			if (trimmedBlogEntries.startsWith("[")) {
+				blogJSONArray = JSONFactoryUtil.createJSONArray(
+					trimmedBlogEntries);
+			}
+			else if (trimmedBlogEntries.startsWith("{")) {
+				JSONObject wrapperJSONObject = JSONFactoryUtil.createJSONObject(
+					trimmedBlogEntries);
+
+				for (String key : wrapperJSONObject.keySet()) {
+					Object value = wrapperJSONObject.get(key);
+
+					if (value instanceof JSONArray) {
+						blogJSONArray = (JSONArray)value;
+
+						break;
+					}
+				}
+			}
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to parse blogEntries as JSON; skipping 07-blogs",
+				exception);
+
+			return null;
+		}
+
+		if (blogJSONArray == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to parse blogEntries as a JSON array");
+			}
+
+			return null;
+		}
+
+		_sanitizeBlogKeywords(blogJSONArray);
+
+		return new BatchFile(
+			"07-blogs.batch-engine-data.json",
+			JSONUtil.put(
+				"configuration",
+				JSONUtil.put(
+					"className", "com.liferay.object.rest.dto.v1_0.ObjectEntry"
+				).put(
+					"multiCompany", true
+				).put(
+					"parameters",
+					JSONUtil.put(
+						"containsHeaders", "true"
+					).put(
+						"createStrategy", "UPSERT"
+					).put(
+						"featureFlag", "LPD-17564"
+					).put(
+						"importStrategy", "ON_ERROR_FAIL"
+					).put(
+						"scopeKey", siteERC + "-space"
+					).put(
+						"updateStrategy", "UPDATE"
+					)
+				).put(
+					"taskItemDelegateName", "CMSBlog"
+				)
+			).put(
+				"items", blogJSONArray
+			));
+	}
+
+	private BatchFile _buildConnectedSiteBatchFile(
+		String siteERC, String siteTitle) {
+
+		String assetLibraryERC = siteERC + "-space";
+
+		JSONObject connectedSiteConfigurationJSONObject = JSONUtil.put(
+			"className",
+			"com.liferay.headless.asset.library.dto.v1_0.ConnectedSite"
+		).put(
+			"multiCompany", true
+		).put(
+			"parameters",
+			JSONUtil.put(
+				"assetLibraryExternalReferenceCode", assetLibraryERC
+			).put(
+				"containsHeaders", "true"
+			).put(
+				"createStrategy", "UPSERT"
+			).put(
+				"importStrategy", "ON_ERROR_FAIL"
+			)
+		).put(
+			"taskItemDelegateName", "DEFAULT"
+		);
+
+		return new BatchFile(
+			"03-connected-site.batch-engine-data.json",
+			JSONUtil.put(
+				"configuration", connectedSiteConfigurationJSONObject
+			).put(
+				"items",
+				JSONFactoryUtil.createJSONArray(
+				).put(
+					JSONUtil.put(
+						"descriptiveName", siteTitle
+					).put(
+						"externalReferenceCode", siteERC
+					).put(
+						"name", siteTitle
+					).put(
+						"searchable", true
+					)
+				)
+			));
+	}
+
+	private BatchFile _buildFragmentsBatchFile(
+			JSONObject planJSONObject, String siteERC)
+		throws Exception {
+
+		String fragmentSetERC = siteERC + "-fragments";
+
+		JSONArray customFragmentsJSONArray = planJSONObject.getJSONArray(
+			"customFragments");
+
+		JSONObject fragmentsBatchJSONObject = _createBatchWrapper(
+			"com.liferay.headless.admin.fragment.dto.v1_0.Fragment", true,
+			siteERC, false);
+
+		JSONArray fragmentItemsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		if ((customFragmentsJSONArray != null) &&
+			(customFragmentsJSONArray.length() > 0)) {
+
+			for (int i = 0; i < customFragmentsJSONArray.length(); i++) {
+				JSONObject fragmentJSONObject =
+					customFragmentsJSONArray.getJSONObject(i);
+
+				String fragmentKey = fragmentJSONObject.getString("key");
+
+				JSONObject approvedVersionJSONObject = JSONUtil.put(
+					"css", fragmentJSONObject.getString("css")
+				).put(
+					"html",
+					_fixImageEditables(fragmentJSONObject.getString("html"))
+				).put(
+					"js", fragmentJSONObject.getString("js")
+				).put(
+					"status", "Approved"
+				);
+
+				if (fragmentJSONObject.getBoolean("isNavigationMenu")) {
+					approvedVersionJSONObject.put(
+						"configuration", _NAV_MENU_CONFIGURATION);
+				}
+
+				fragmentItemsJSONArray.put(
+					JSONUtil.put(
+						"externalReferenceCode", fragmentKey
+					).put(
+						"fragmentSet",
+						JSONUtil.put("externalReferenceCode", fragmentSetERC)
+					).put(
+						"fragmentVersions",
+						JSONFactoryUtil.createJSONArray(
+						).put(
+							approvedVersionJSONObject
+						)
+					).put(
+						"key", fragmentKey
+					).put(
+						"name", fragmentJSONObject.getString("name")
+					).put(
+						"type", "Component"
+					));
+			}
+		}
+
+		fragmentsBatchJSONObject.put("items", fragmentItemsJSONArray);
+
+		return new BatchFile(
+			"05-fragments.batch-engine-data.json", fragmentsBatchJSONObject);
+	}
+
+	private String _buildFragmentsCatalog(JSONArray customFragmentsJSONArray) {
+		if ((customFragmentsJSONArray == null) ||
+			(customFragmentsJSONArray.length() == 0)) {
+
+			return "[]";
+		}
+
+		JSONArray catalogJSONArray = JSONFactoryUtil.createJSONArray();
+
+		for (int i = 0; i < customFragmentsJSONArray.length(); i++) {
+			JSONObject fragmentJSONObject =
+				customFragmentsJSONArray.getJSONObject(i);
+
+			JSONObject catalogEntryJSONObject = JSONUtil.put(
+				"css", fragmentJSONObject.getString("css")
+			).put(
+				"editables", fragmentJSONObject.getJSONArray("editables")
+			).put(
+				"externalReferenceCode", fragmentJSONObject.getString("key")
+			).put(
+				"html", fragmentJSONObject.getString("html")
+			).put(
+				"js", fragmentJSONObject.getString("js")
+			);
+
+			if (fragmentJSONObject.getBoolean("isNavigationMenu")) {
+				catalogEntryJSONObject.put(
+					"configuration", _NAV_MENU_CONFIGURATION);
+			}
+
+			catalogJSONArray.put(catalogEntryJSONObject);
+		}
+
+		return catalogJSONArray.toString();
+	}
+
+	private BatchFile _buildFragmentSetBatchFile(
+			String siteERC, String siteTitle)
+		throws Exception {
+
+		String fragmentSetERC = siteERC + "-fragments";
+
+		JSONObject fragmentSetBatchJSONObject = _createBatchWrapper(
+			"com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet", true,
+			siteERC, false);
+
+		fragmentSetBatchJSONObject.put(
+			"items",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				JSONUtil.put(
+					"externalReferenceCode", fragmentSetERC
+				).put(
+					"key", fragmentSetERC
+				).put(
+					"name", siteTitle + " Fragments"
+				)
+			));
+
+		return new BatchFile(
+			"04-fragment-set.batch-engine-data.json",
+			fragmentSetBatchJSONObject);
+	}
+
+	private JSONObject _buildPageBody(
+			String pageERC, String pageTitle, JSONArray pageElementsJSONArray)
+		throws Exception {
+
+		// Approved spec
+
+		JSONObject approvedExperienceJSONObject = JSONUtil.put(
+			"externalReferenceCode", pageERC + "-default"
+		).put(
+			"key", "DEFAULT"
+		).put(
+			"name_i18n", _createI18nJSON("en-US", "Default")
+		).put(
+			"pageElements", pageElementsJSONArray
+		).put(
+			"priority", 0
+		);
+
+		JSONObject approvedSpecJSONObject = JSONUtil.put(
+			"draftContentPageSpecificationExternalReferenceCode",
+			pageERC + "-draft"
+		).put(
+			"externalReferenceCode", pageERC
+		).put(
+			"pageExperiences",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				approvedExperienceJSONObject
+			)
+		).put(
+			"settings", _createThemeSettings()
+		).put(
+			"status", "Approved"
+		).put(
+			"type", "ContentPageSpecification"
+		);
+
+		// Draft spec
+
+		JSONArray draftPageElementsJSONArray =
+			JSONFactoryUtil.createJSONArray();
+
+		if (pageElementsJSONArray.length() > 0) {
+			draftPageElementsJSONArray = JSONFactoryUtil.createJSONArray(
+				pageElementsJSONArray.toString());
+
+			_appendDraftSuffix(draftPageElementsJSONArray);
+		}
+
+		JSONObject draftSpecJSONObject = JSONUtil.put(
+			"externalReferenceCode", pageERC + "-draft"
+		).put(
+			"pageExperiences",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				JSONUtil.put(
+					"externalReferenceCode", pageERC + "-draft-default"
+				).put(
+					"key", "DEFAULT"
+				).put(
+					"name_i18n", _createI18nJSON("en-US", "Default")
+				).put(
+					"pageElements", draftPageElementsJSONArray
+				).put(
+					"priority", 0
+				)
+			)
+		).put(
+			"settings", _createThemeSettings()
+		).put(
+			"status", "Draft"
+		).put(
+			"type", "ContentPageSpecification"
+		);
+
+		// Page body
+
+		return JSONUtil.put(
+			"externalReferenceCode", pageERC
+		).put(
+			"name_i18n", _createI18nJSON("en-US", pageTitle)
+		).put(
+			"pageSettings", JSONUtil.put("type", "ContentPageSettings")
+		).put(
+			"pageSpecifications",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				approvedSpecJSONObject
+			).put(
+				draftSpecJSONObject
+			)
+		).put(
+			"type", "ContentPage"
+		);
+	}
+
+	private BatchFile _buildPagesBatchFile(
+			JSONObject planJSONObject, String siteERC)
+		throws Exception {
+
+		JSONArray pagesJSONArray = planJSONObject.getJSONArray("pages");
+
+		JSONObject pagesBatchJSONObject = _createBatchWrapper(
+			"com.liferay.headless.admin.site.dto.v1_0.SitePage", true, siteERC,
+			true);
+
+		JSONArray pageItemsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		if ((pagesJSONArray != null) && (pagesJSONArray.length() > 0)) {
+			String fragmentsCatalog = _buildFragmentsCatalog(
+				planJSONObject.getJSONArray("customFragments"));
+
+			IRToPageSpecConverter irToPageSpecConverter =
+				new IRToPageSpecConverter(fragmentsCatalog);
+
+			for (int i = 0; i < pagesJSONArray.length(); i++) {
+				JSONObject pageJSONObject = pagesJSONArray.getJSONObject(i);
+
+				String pageERC = pageJSONObject.getString(
+					"externalReferenceCode");
+				String pageTitle = pageJSONObject.getString("title");
+
+				JSONObject irJSONObject = pageJSONObject.getJSONObject("ir");
+
+				JSONArray pageElementsJSONArray =
+					JSONFactoryUtil.createJSONArray();
+
+				if (irJSONObject != null) {
+					String approvedSpec = irToPageSpecConverter.convert(
+						irJSONObject.toString(), pageERC, pageERC + "-default",
+						"en-US");
+
+					if (!approvedSpec.startsWith("Error")) {
+						JSONObject specJSONObject =
+							JSONFactoryUtil.createJSONObject(approvedSpec);
+
+						JSONArray experiencesJSONArray =
+							specJSONObject.getJSONArray("pageExperiences");
+
+						if ((experiencesJSONArray != null) &&
+							(experiencesJSONArray.length() > 0)) {
+
+							JSONObject experienceJSONObject =
+								experiencesJSONArray.getJSONObject(0);
+
+							pageElementsJSONArray =
+								experienceJSONObject.getJSONArray(
+									"pageElements");
+						}
+					}
+				}
+
+				pageItemsJSONArray.put(
+					_buildPageBody(pageERC, pageTitle, pageElementsJSONArray));
+			}
+		}
+
+		pagesBatchJSONObject.put("items", pageItemsJSONArray);
+
+		return new BatchFile(
+			"06-pages.batch-engine-data.json", pagesBatchJSONObject);
+	}
+
+	private BatchFile _buildSiteBatchFile(
+			String siteERC, JSONObject siteJSONObject, String siteTitle)
+		throws Exception {
+
+		JSONObject siteBatchJSONObject = _createBatchWrapper(
+			"com.liferay.headless.admin.site.dto.v1_0.Site", false, siteERC,
+			false);
+
+		siteBatchJSONObject.put(
+			"items",
+			JSONFactoryUtil.createJSONArray(
+			).put(
+				JSONUtil.put(
+					"active", true
+				).put(
+					"description", siteJSONObject.getString("description")
+				).put(
+					"externalReferenceCode", siteERC
+				).put(
+					"membershipType", "open"
+				).put(
+					"name", siteTitle
+				)
+			));
+
+		return new BatchFile(
+			"01-site.batch-engine-data.json", siteBatchJSONObject);
+	}
+
+	private JSONObject _createBatchWrapper(
+		String className, boolean includeSiteERC, String siteERC,
+		boolean includePrivateLayout) {
+
+		JSONObject parametersJSONObject = JSONUtil.put(
+			"containsHeaders", "true"
+		).put(
+			"createStrategy", "UPSERT"
+		).put(
+			"featureFlag", "LPD-39244"
+		).put(
+			"importStrategy", "ON_ERROR_FAIL"
+		);
+
+		if (includeSiteERC) {
+			parametersJSONObject.put("siteExternalReferenceCode", siteERC);
+		}
+
+		if (includePrivateLayout) {
+			parametersJSONObject.put("privateLayout", "false");
+		}
+
+		return JSONUtil.put(
+			"configuration",
+			JSONUtil.put(
+				"className", className
+			).put(
+				"multiCompany", true
+			).put(
+				"parameters", parametersJSONObject
+			).put(
+				"taskItemDelegateName", "DEFAULT"
+			));
+	}
+
+	private JSONObject _createI18nJSON(String locale, String value) {
+		return JSONUtil.put(locale, value);
+	}
+
+	private JSONObject _createThemeSettings() {
+		return JSONUtil.put(
+			"colorSchemeName", "01"
+		).put(
+			"themeName", "classic_WAR_classictheme"
+		).put(
+			"themeSettings",
+			JSONUtil.put(
+				"lfr-theme:regular:show-footer", "false"
+			).put(
+				"lfr-theme:regular:show-header", "false"
+			).put(
+				"lfr-theme:regular:show-header-search", "false"
+			).put(
+				"lfr-theme:regular:wrap-widget-page-content", "false"
+			)
+		);
+	}
+
+	private String _fixImageEditables(String html) {
+		if (html == null) {
+			return html;
+		}
+
+		Matcher matcher = _imageEditableTagPattern.matcher(html);
+
+		StringBuilder sb = new StringBuilder();
+
+		int lastEnd = 0;
+
+		while (matcher.find()) {
+			String tagName = matcher.group(1);
+
+			String editableId = matcher.group(2);
+
+			String afterAttributes = matcher.group(3);
+
+			sb.append(html, lastEnd, matcher.start());
+
+			sb.append(
+				StringBundler.concat(
+					"<img data-lfr-editable-id=\"", editableId,
+					"\" data-lfr-editable-type=\"image\"", afterAttributes,
+					" alt=\"\" src=\"\">"));
+
+			int searchStart = matcher.end();
+
+			Pattern closingTagPattern = Pattern.compile(
+				StringBundler.concat("</", Pattern.quote(tagName), "\\s*>"));
+
+			Matcher closingTagMatcher = closingTagPattern.matcher(html);
+
+			if (closingTagMatcher.find(searchStart)) {
+				sb.append(html, searchStart, closingTagMatcher.start());
+
+				lastEnd = closingTagMatcher.end();
+			}
+			else {
+				lastEnd = searchStart;
+			}
+		}
+
+		sb.append(html, lastEnd, html.length());
+
+		return sb.toString();
+	}
+
+	private void _sanitizeBlogKeywords(JSONArray blogJSONArray) {
+
+		// Asset tag validation rejects ~26 special characters (see
+		// AssetTagLocalServiceImpl). LLM-emitted keywords with characters like
+		// '&', '/', or "'" would otherwise fail the entire batch under
+		// ON_ERROR_FAIL. Strip invalid characters; drop keywords that go blank.
+
+		for (int i = 0; i < blogJSONArray.length(); i++) {
+			JSONObject blogJSONObject = blogJSONArray.getJSONObject(i);
+
+			if (blogJSONObject == null) {
+				continue;
+			}
+
+			JSONArray keywordsJSONArray = blogJSONObject.getJSONArray(
+				"keywords");
+
+			if (keywordsJSONArray == null) {
+				continue;
+			}
+
+			JSONArray sanitizedJSONArray = JSONFactoryUtil.createJSONArray();
+
+			for (int j = 0; j < keywordsJSONArray.length(); j++) {
+				String keyword = keywordsJSONArray.getString(j);
+
+				if (Validator.isNull(keyword)) {
+					continue;
+				}
+
+				StringBuilder sb = new StringBuilder(keyword.length());
+
+				for (int k = 0; k < keyword.length(); k++) {
+					char c = keyword.charAt(k);
+
+					if (_INVALID_ASSET_TAG_CHARS.indexOf(c) < 0) {
+						sb.append(c);
+					}
+				}
+
+				String cleaned = sb.toString(
+				).trim();
+
+				if (!cleaned.isEmpty()) {
+					sanitizedJSONArray.put(cleaned);
+				}
+			}
+
+			blogJSONObject.put("keywords", sanitizedJSONArray);
+		}
+	}
+
+	private static final String _INVALID_ASSET_TAG_CHARS =
+		"&'@\\]}:,=>/<\n[{%|+#`?\"\r;*~";
+
+	private static final String _NAV_MENU_CONFIGURATION =
+		"{\"fieldSets\":[{\"fields\":[{\"name\":\"source\"," +
+			"\"label\":\"source\",\"type\":\"navigationMenuSelector\"}]}]}";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SitePlanBatchFileBuilder.class);
+
+	private static final Pattern _fileNameLanguagePattern = Pattern.compile(
+		"-([a-z]{2})(?:[-_][A-Z]{2})?\\.json$");
+	private static final Pattern _i18nBlockPattern = Pattern.compile(
+		"\"[a-zA-Z]+_i18n\"\\s*:\\s*\\{([^{}]*)\\}");
+	private static final Pattern _imageEditableTagPattern = Pattern.compile(
+		"<(?!img)(\\w+)\\s+[^>]*?data-lfr-editable-id=\"([^\"]+)\"\\s+" +
+			"data-lfr-editable-type=\"image\"([^>]*?)>");
+	private static final Pattern _localeKeyPattern = Pattern.compile(
+		"\"([a-z]{2})(?:_[A-Z]{2})?\"\\s*:");
+	private static final Set<String> _metadataKeys = Set.of(
+		"actions", "classNameId", "classPK", "createDate", "creator",
+		"dateCreated", "dateModified", "externalReferenceCode", "groupId", "id",
+		"modifiedDate", "parentExternalReferenceCode", "priority", "siteId",
+		"sortOrder", "status", "userId");
+
+	private final String _blogEntries;
+	private final String _enrichedSitePlan;
+
+}


### PR DESCRIPTION
## What

Adds the Site Builder workflow's service node delegates, split out of LPD-95356 (#547). Each implements the `ServiceNodeDelegate` SPI and is resolved by `ServiceNodeExecutor` (from #563) through its `javaDelegate` key:

- `AcknowledgeAgentServiceNodeDelegate`, `JSONRepairServiceNodeDelegate`, `IRToPageSpecServiceNodeDelegate`, `PageSpecToIRServiceNodeDelegate`, `WriteCSGGenerationItemsServiceNodeDelegate` (+ the IR/page-spec converters and the site-plan batch builder).

The delegates need `AgentUtil` from outside `ai-hub`, so `AgentUtil` moves from `ai-hub-impl`'s internal package to the exported `com.liferay.ai.hub.util` in `ai-hub-api` (in-module callers repointed, package version bumped to 1.1.0).

## Stacking

> **Stacked on #563 (LPD-96127).** This branch is based on the `ServiceNodeExecutor`/`ServiceNodeDelegate` branch, so the diff includes #563's commit until it merges. Review the top commit (`95e873e1957944ca6a346c05f40bd6c30a3fbd25`); merge #563 first. The workflow that drives these delegates is in #566 (LPD-96135).

**pr-check: PASS** — tested on `95e873e1957944ca6a346c05f40bd6c30a3fbd25`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "95e873e1957944ca6a346c05f40bd6c30a3fbd25"} -->
