### PR TITLE
LPD-94974 Copy body to text_embedding for semantic search

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/META-INF/search/ContentRetrieverType-mappings.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/META-INF/search/ContentRetrieverType-mappings.json
@@ -2,6 +2,7 @@
 	"date_detection": false,
 	"properties": {
 		"body": {
+			"copy_to": "text_embedding",
 			"type": "text"
 		},
 		"last_crawled_at": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94974

## What Is Being Fixed

The ContentRetrieverType search mapping indexed `body` as a plain text field, so document body content never reached the `text_embedding` semantic_text field because the ingest pipeline was not being used. Semantic search over retrieved content therefore had no body text to embed and match against.

## How It Is Being Fixed

Added `copy_to: text_embedding` on the `body` field in `ContentRetrieverType-mappings.json`, so at index time the body content is copied into `text_embedding`, which produces semantic embeddings through the `google-vertex-ai-gemini-embedding-001` inference endpoint.

## Why Are There No Tests?

The change is an Elasticsearch field-mapping configuration (`copy_to`), not executable code; its behavior is exercised by existing search integration coverage.

## PR Check

**pr-check: PASS** — tested on `b896e61217d1f4b6855b3f74dc0aacbe495cd58a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b896e61217d1f4b6855b3f74dc0aacbe495cd58a"} -->
