### PR TITLE
LPD-96431 Fix NullPointerException when routing AI Hub audit events

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/audit/AuditRouterUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/audit/AuditRouterUtil.java
@@ -34,6 +34,10 @@ public class AuditRouterUtil {
 		AccountEntry accountEntry = AccountEntryUtil.getUserAccountEntry(
 			userId);
 
+		if (accountEntry == null) {
+			return;
+		}
+
 		com.liferay.portal.kernel.audit.AuditRouterUtil.route(
 			new AuditMessage(
 				0, accountEntry.getCompanyId(), userId,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96431

## What Is Being Fixed

When an AI Hub site is created, the site initializer provisions agent definitions, which are persisted as Kaleo workflow definitions with scope "ai". Adding each definition publishes an ADD message on the liferay/workflow_definition destination, which WorkflowDefinitionMessageListener consumes and routes to the audit log via AuditRouterUtil.route. That method resolves the acting user's AI Hub account entry through AccountEntryUtil.getUserAccountEntry, but during site initialization the user has not yet been provisioned with the AI Hub account pair — that happens later, in the provisioning POST endpoint, not the site initializer. The lookup returns null and AuditRouterUtil.route dereferences it (accountEntry.getCompanyId()), throwing a NullPointerException and logging "Unable to process message" for every scope=ai agent created during site creation.

## How It Is Being Fixed

AuditRouterUtil.route now returns early when the account entry is null, skipping the audit event instead of dereferencing a null reference. The guard sits at the shared entry point used by all four audit listeners, so the same null-account condition is handled consistently. Skipping is the correct behavior here: with no provisioned account there is nothing to attribute the audit event to.

## Why Are There No Tests?

AuditRouterUtil is an all-static utility that delegates to other static utilities (AccountEntryUtil, PortalUtil, and the portal AuditRouterUtil). Covering the null-account guard would require static mocking solely to assert that the portal audit route is not invoked — significant scaffolding for a one-line defensive guard.

## PR Check

**pr-check: PASS** — tested on `05f39c550b99a98db8f3971a8a0838b91ec9b605`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "05f39c550b99a98db8f3971a8a0838b91ec9b605"} -->
