### PR TITLE
LPD-87447 Add the content generation REST services and types

### DIFF
--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/services/generations.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/services/generations.ts
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch as liferayFetch} from 'frontend-js-web';
+
+import {buildPages} from '../util/contentModel';
+
+import type {GeneratedPage} from '../types/GeneratedPage';
+import type {Generation} from '../types/Generation';
+import type {GenerationItem} from '../types/GenerationItem';
+
+const MAX_BATCH_FILE_SIZE = 2 * 1024 * 1024;
+
+interface CreateGenerationInput {
+	prompt: string;
+	title: string;
+}
+
+async function call<T>(url: string, init?: RequestInit): Promise<T> {
+	const response = await liferayFetch(url, {
+		headers: {
+			'Accept': 'application/json',
+			'Content-Type': 'application/json',
+		},
+		...init,
+	});
+
+	if (!response.ok) {
+		let detail = '';
+
+		try {
+			const json = await response.json();
+
+			detail = json.title || json.detail || '';
+		}
+		catch {}
+
+		throw new Error(
+			detail ||
+				`${response.status} ${response.statusText || 'Request failed'}`
+		);
+	}
+
+	if (response.status === 204) {
+		return undefined as unknown as T;
+	}
+
+	return response.json();
+}
+
+export function commitGeneration(
+	apiURL: string,
+	generationId: number
+): Promise<void> {
+	return call(`${apiURL}/${generationId}/object-actions/commit`, {
+		method: 'PUT',
+	});
+}
+
+export function createGeneration(
+	apiURL: string,
+	{prompt, title}: CreateGenerationInput
+): Promise<Generation> {
+	return call(apiURL, {
+		body: JSON.stringify({
+			generationStatus: {key: 'refining'},
+			prompt,
+			title,
+		}),
+		method: 'POST',
+	});
+}
+
+export function getGeneration(
+	apiURL: string,
+	generationId: number
+): Promise<Generation> {
+	return call(`${apiURL}/${generationId}`);
+}
+
+export async function getGenerationItems(
+	apiURL: string,
+	generationId: number
+): Promise<GenerationItem[]> {
+	const page = await call<{items?: GenerationItem[]}>(
+		`${apiURL}/${generationId}/items?pageSize=100&sort=loadOrder:asc`
+	);
+
+	return page.items ?? [];
+}
+
+export async function getGenerationPages(
+	items: GenerationItem[]
+): Promise<GeneratedPage[]> {
+	const pageGroups = await Promise.all(items.map(_getItemPages));
+
+	return pageGroups.flat();
+}
+
+async function _getItemPages(item: GenerationItem): Promise<GeneratedPage[]> {
+	let entries: Record<string, unknown>[] | null = null;
+
+	const href = item.batchFile?.link?.href;
+
+	if (href) {
+		try {
+			const response = await liferayFetch(href, {
+				headers: {Accept: 'application/json'},
+			});
+
+			if (response.ok) {
+				const text = await response.text();
+
+				if (text.length <= MAX_BATCH_FILE_SIZE) {
+					const parsed = JSON.parse(text);
+
+					const list = Array.isArray(parsed) ? parsed : parsed?.items;
+
+					if (Array.isArray(list)) {
+						entries = list;
+					}
+				}
+			}
+		}
+		catch (exception) {
+			entries = null;
+		}
+	}
+
+	if (!entries && item.previewItem) {
+		try {
+			entries = [JSON.parse(item.previewItem)];
+		}
+		catch (exception) {
+			entries = null;
+		}
+	}
+
+	return entries ? buildPages(item, entries) : [];
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/services/sites.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/services/sites.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch as liferayFetch} from 'frontend-js-web';
+
+interface Site {
+	friendlyUrlPath?: string;
+}
+
+export async function getSiteByExternalReferenceCode(
+	externalReferenceCode: string
+): Promise<Site | null> {
+	const response = await liferayFetch(
+		`/o/headless-admin-site/v1.0/sites/by-external-reference-code/${encodeURIComponent(
+			externalReferenceCode
+		)}`,
+		{headers: {Accept: 'application/json'}}
+	);
+
+	if (!response.ok) {
+		return null;
+	}
+
+	return response.json();
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/ContentModel.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/ContentModel.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface ContentSampleField {
+	label: string;
+	value: string;
+}
+
+export interface ContentSample {
+	chips: string[];
+	fields: ContentSampleField[];
+	title: string;
+}
+
+export interface DetectedConfig {
+	languageLabels: string[];
+}
+
+export interface SummaryStat {
+	icon: string;
+	label: string;
+	value: number | string;
+}
+
+export interface Template {
+	icon: string;
+	itemCount: number;
+	label: string;
+	languageCount: number;
+	pageCount: number;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/Example.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/Example.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface Example {
+	icon: string;
+	label: string;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/GeneratedPage.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/GeneratedPage.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface GeneratedPage {
+	icon: string;
+	id: string;
+	itemCount: number;
+	languages: string[];
+	templateLabel: string;
+	title: string;
+	url: string | null;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/Generation.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/Generation.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export type GenerationStatusKey =
+	| 'committed'
+	| 'failed'
+	| 'generating'
+	| 'ready'
+	| 'refining';
+
+export interface Generation {
+	commitDate?: string;
+	externalReferenceCode: string;
+	failureReason?: string;
+	generatedSiteERC?: string;
+	generationStatus: {
+		key: GenerationStatusKey;
+		name?: string;
+	};
+	id: number;
+	prompt: string;
+	targetLanguages?: string;
+	title: string;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/GenerationItem.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/types/GenerationItem.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface GenerationItem {
+	batchFile?: {
+		link?: {
+			href?: string;
+		};
+	};
+	externalReferenceCode: string;
+	fileName: string;
+	id: number;
+	itemCount?: number;
+	languages?: string;
+	loadOrder?: number;
+	previewItem?: string;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/util/contentModel.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/util/contentModel.ts
@@ -1,0 +1,350 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type {
+	ContentSample,
+	ContentSampleField,
+	DetectedConfig,
+	SummaryStat,
+	Template,
+} from '../types/ContentModel';
+import type {GeneratedPage} from '../types/GeneratedPage';
+import type {Generation} from '../types/Generation';
+import type {GenerationItem} from '../types/GenerationItem';
+
+const LANGUAGE_LABELS: Record<string, string> = {
+	de: 'German',
+	en: 'English',
+	es: 'Spanish',
+	fr: 'French',
+	it: 'Italian',
+	ja: 'Japanese',
+	pt: 'Portuguese',
+};
+
+const METADATA_KEYS = new Set([
+	'actions',
+	'classNameId',
+	'classPK',
+	'createDate',
+	'creator',
+	'dateCreated',
+	'dateModified',
+	'externalReferenceCode',
+	'groupId',
+	'id',
+	'modifiedDate',
+	'parentExternalReferenceCode',
+	'priority',
+	'siteId',
+	'sortOrder',
+	'status',
+	'userId',
+]);
+
+const PAGE_FILE_TOKENS = new Set(['blogs', 'pages']);
+
+const TEMPLATE_ICONS: Record<string, string> = {
+	'asset-library': 'documents-and-media',
+	'blogs': 'document-text',
+	'connected-site': 'link',
+	'fragment-set': 'code',
+	'fragments': 'code',
+	'pages': 'page',
+	'site': 'home',
+};
+
+export function getFileToken(fileName: string): string {
+	const base = fileName.replace(/\.batch-engine-data\.json$/i, '');
+
+	return base.replace(/^\d+-/, '');
+}
+
+export function getLanguageLabel(code: string): string {
+	return LANGUAGE_LABELS[code.toLowerCase()] ?? code.toUpperCase();
+}
+
+export function getTemplateLabel(fileName: string): string {
+	const token = getFileToken(fileName);
+
+	if (token === 'asset-library') {
+		return Liferay.Language.get('asset-library');
+	}
+	else if (token === 'blogs') {
+		return Liferay.Language.get('blog-article');
+	}
+	else if (token === 'connected-site') {
+		return Liferay.Language.get('connected-site');
+	}
+	else if (token === 'fragment-set') {
+		return Liferay.Language.get('fragment-set');
+	}
+	else if (token === 'fragments') {
+		return Liferay.Language.get('fragment');
+	}
+	else if (token === 'pages') {
+		return Liferay.Language.get('page');
+	}
+	else if (token === 'site') {
+		return Liferay.Language.get('site');
+	}
+
+	return fileName;
+}
+
+export function getTemplateIcon(fileName: string): string {
+	return TEMPLATE_ICONS[getFileToken(fileName)] ?? 'document';
+}
+
+export function getItemLanguages(item: GenerationItem): string[] {
+	if (!item.languages) {
+		return [];
+	}
+
+	return item.languages
+		.split(',')
+		.map((language) => language.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+export function getItemURL(item: GenerationItem): string | null {
+	if (!item.previewItem) {
+		return null;
+	}
+
+	try {
+		return getEntryURL(JSON.parse(item.previewItem));
+	}
+	catch (exception) {
+		return null;
+	}
+}
+
+export function buildTemplates(items: GenerationItem[]): Template[] {
+	return items.map((item) => ({
+		icon: getTemplateIcon(item.fileName),
+		itemCount: item.itemCount ?? 0,
+		label: getTemplateLabel(item.fileName),
+		languageCount: getItemLanguages(item).length,
+		pageCount: PAGE_FILE_TOKENS.has(getFileToken(item.fileName))
+			? item.itemCount ?? 0
+			: 0,
+	}));
+}
+
+export function buildSummary(
+	generation: Generation,
+	items: GenerationItem[]
+): SummaryStat[] {
+	const languages = new Set<string>();
+
+	let pages = 0;
+	let totalEntries = 0;
+
+	for (const item of items) {
+		totalEntries += item.itemCount ?? 0;
+
+		if (PAGE_FILE_TOKENS.has(getFileToken(item.fileName))) {
+			pages += item.itemCount ?? 0;
+		}
+
+		for (const language of getItemLanguages(item)) {
+			languages.add(language);
+		}
+	}
+
+	if (!languages.size && generation.targetLanguages) {
+		for (const language of generation.targetLanguages.split(',')) {
+			languages.add(language.trim().toLowerCase());
+		}
+	}
+
+	return [
+		{
+			icon: 'document',
+			label: Liferay.Language.get('total-pages'),
+			value: pages,
+		},
+		{
+			icon: 'automatic-translate',
+			label: Liferay.Language.get('languages'),
+			value: languages.size,
+		},
+		{
+			icon: 'stars',
+			label: Liferay.Language.get('templates'),
+			value: items.length,
+		},
+		{
+			icon: 'document',
+			label: Liferay.Language.get('total-entries'),
+			value: totalEntries,
+		},
+	];
+}
+
+export function buildDetectedConfig(
+	generation: Generation,
+	items: GenerationItem[]
+): DetectedConfig {
+	const languages = new Set<string>();
+
+	for (const item of items) {
+		for (const language of getItemLanguages(item)) {
+			languages.add(language);
+		}
+	}
+
+	if (!languages.size && generation.targetLanguages) {
+		for (const language of generation.targetLanguages.split(',')) {
+			const trimmed = language.trim().toLowerCase();
+
+			if (trimmed) {
+				languages.add(trimmed);
+			}
+		}
+	}
+
+	return {
+		languageLabels: [...languages].map(getLanguageLabel),
+	};
+}
+
+function getKnownFieldLabel(key: string): string | null {
+	if (key === 'excerpt') {
+		return Liferay.Language.get('excerpt');
+	}
+	else if (key === 'friendlyURLPath' || key === 'urlTitle') {
+		return Liferay.Language.get('url');
+	}
+	else if (key === 'h1Heading') {
+		return Liferay.Language.get('h1-heading');
+	}
+	else if (key === 'metaDescription') {
+		return Liferay.Language.get('meta-description');
+	}
+	else if (key === 'seoTitle') {
+		return Liferay.Language.get('seo-title');
+	}
+
+	return null;
+}
+
+function humanizeKey(key: string): string {
+	return key
+		.replace(/_i18n$/, '')
+		.replace(/([A-Z])/g, ' $1')
+		.replace(/[_-]+/g, ' ')
+		.replace(/^./, (character) => character.toUpperCase())
+		.trim();
+}
+
+function stringifyValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return '';
+	}
+
+	if (typeof value === 'string') {
+		return value;
+	}
+
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+
+	if (typeof value === 'object') {
+		const map = value as Record<string, string>;
+
+		const localized = map.en_US ?? map[Object.keys(map)[0] ?? ''];
+
+		if (typeof localized === 'string') {
+			return localized;
+		}
+	}
+
+	return '';
+}
+
+export function parseContentSample(item: GenerationItem): ContentSample | null {
+	if (!item.previewItem) {
+		return null;
+	}
+
+	let parsed: Record<string, unknown>;
+
+	try {
+		parsed = JSON.parse(item.previewItem);
+	}
+	catch (exception) {
+		return null;
+	}
+
+	const chips: string[] = [];
+	const fields: ContentSampleField[] = [];
+
+	for (const [key, value] of Object.entries(parsed)) {
+		if (METADATA_KEYS.has(key)) {
+			continue;
+		}
+
+		const label = humanizeKey(key);
+
+		chips.push(label);
+
+		const stringValue = stringifyValue(value);
+
+		if (stringValue) {
+			fields.push({
+				label: getKnownFieldLabel(key) ?? label,
+				value: stringValue,
+			});
+		}
+	}
+
+	return {
+		chips,
+		fields,
+		title: getTemplateLabel(item.fileName),
+	};
+}
+
+export function getEntryTitle(entry: Record<string, unknown>): string {
+	return (
+		stringifyValue(entry.title) ||
+		stringifyValue(entry.title_i18n) ||
+		stringifyValue(entry.name) ||
+		stringifyValue(entry.name_i18n) ||
+		stringifyValue(entry.headline)
+	);
+}
+
+export function getEntryURL(entry: Record<string, unknown>): string | null {
+	const url =
+		stringifyValue(entry.friendlyUrlPath) ||
+		stringifyValue(entry.friendlyUrlPath_i18n) ||
+		stringifyValue(entry.friendlyURLPath) ||
+		stringifyValue(entry.urlTitle);
+
+	return url || null;
+}
+
+export function buildPages(
+	item: GenerationItem,
+	entries: Record<string, unknown>[]
+): GeneratedPage[] {
+	const icon = getTemplateIcon(item.fileName);
+	const languages = getItemLanguages(item);
+	const templateLabel = getTemplateLabel(item.fileName);
+
+	return entries.map((entry, index) => ({
+		icon,
+		id: `${item.id}-${index}`,
+		itemCount: 1,
+		languages,
+		templateLabel,
+		title: getEntryTitle(entry) || `${templateLabel} ${index + 1}`,
+		url: getEntryURL(entry),
+	}));
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/test/js/util/contentModel.test.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/test/js/util/contentModel.test.ts
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	buildDetectedConfig,
+	buildSummary,
+	buildTemplates,
+	getFileToken,
+	getItemLanguages,
+	getItemURL,
+	getLanguageLabel,
+	getTemplateIcon,
+	getTemplateLabel,
+	parseContentSample,
+} from '../../../src/main/resources/META-INF/resources/js/util/contentModel';
+
+import type {Generation} from '../../../src/main/resources/META-INF/resources/js/types/Generation';
+import type {GenerationItem} from '../../../src/main/resources/META-INF/resources/js/types/GenerationItem';
+
+beforeAll(() => {
+	const liferay = Liferay as unknown as Record<string, unknown>;
+
+	liferay.Language = {
+		get: (key: string) => key,
+	};
+});
+
+const generation: Generation = {
+	externalReferenceCode: 'erc',
+	generationStatus: {key: 'ready'},
+	id: 1,
+	prompt: 'Build a landing page',
+	targetLanguages: 'en,es',
+	title: 'Landing page',
+};
+
+const items: GenerationItem[] = [
+	{
+		externalReferenceCode: 'i1',
+		fileName: '01-site.batch-engine-data.json',
+		id: 1,
+		itemCount: 1,
+		languages: 'en,es',
+	},
+	{
+		externalReferenceCode: 'i2',
+		fileName: '06-pages.batch-engine-data.json',
+		id: 2,
+		itemCount: 3,
+		languages: 'en,es',
+	},
+	{
+		externalReferenceCode: 'i3',
+		fileName: '07-blogs.batch-engine-data.json',
+		id: 3,
+		itemCount: 8,
+		languages: 'en',
+		previewItem: JSON.stringify({
+			externalReferenceCode: 'should-be-stripped',
+			headline: 'Welcome',
+			id: 99,
+			subtitle: {en_US: 'A great intro'},
+		}),
+	},
+];
+
+describe('contentModel', () => {
+	it('derives the file token from a batch file name', () => {
+		expect(getFileToken('06-pages.batch-engine-data.json')).toBe('pages');
+		expect(getFileToken('04-fragment-set.batch-engine-data.json')).toBe(
+			'fragment-set'
+		);
+	});
+
+	it('maps language codes to labels', () => {
+		expect(getLanguageLabel('es')).toBe('Spanish');
+		expect(getLanguageLabel('zz')).toBe('ZZ');
+	});
+
+	it('splits item languages', () => {
+		expect(getItemLanguages(items[0])).toEqual(['en', 'es']);
+		expect(getItemLanguages({...items[0], languages: undefined})).toEqual(
+			[]
+		);
+	});
+
+	it('builds one template per item with counts and icons', () => {
+		const templates = buildTemplates(items);
+
+		expect(templates).toHaveLength(3);
+		expect(templates[0].icon).toBe('home');
+		expect(templates[1].itemCount).toBe(3);
+		expect(templates[1].pageCount).toBe(3);
+		expect(templates[0].pageCount).toBe(0);
+		expect(templates[2].languageCount).toBe(1);
+	});
+
+	it('builds summary stats: pages, languages, templates, total entries', () => {
+		const summary = buildSummary(generation, items);
+
+		expect(summary[0].value).toBe(11);
+		expect(summary[1].value).toBe(2);
+		expect(summary[2].value).toBe(3);
+		expect(summary[3].value).toBe(12);
+	});
+
+	it('falls back to target languages when items carry none', () => {
+		const config = buildDetectedConfig(generation, [
+			{...items[0], languages: undefined},
+		]);
+
+		expect(config.languageLabels).toEqual(['English', 'Spanish']);
+	});
+
+	it('parses a content sample, stripping metadata and localizing maps', () => {
+		const sample = parseContentSample(items[2]);
+
+		expect(sample).not.toBeNull();
+		expect(sample?.chips).toEqual(['Headline', 'Subtitle']);
+		expect(sample?.fields).toEqual([
+			{label: 'Headline', value: 'Welcome'},
+			{label: 'Subtitle', value: 'A great intro'},
+		]);
+	});
+
+	it('returns null for a missing or malformed preview item', () => {
+		expect(
+			parseContentSample({...items[0], previewItem: undefined})
+		).toBeNull();
+		expect(
+			parseContentSample({...items[0], previewItem: '{not json'})
+		).toBeNull();
+	});
+
+	it('resolves template labels and icons by file token', () => {
+		expect(getTemplateLabel('06-pages.batch-engine-data.json')).toBe(
+			'page'
+		);
+		expect(getTemplateLabel('07-blogs.batch-engine-data.json')).toBe(
+			'blog-article'
+		);
+		expect(getTemplateIcon('06-pages.batch-engine-data.json')).toBe('page');
+		expect(getTemplateIcon('99-unknown.batch-engine-data.json')).toBe(
+			'document'
+		);
+	});
+
+	it('labels known content keys and keeps chips for every key', () => {
+		const sample = parseContentSample({
+			...items[0],
+			previewItem: JSON.stringify({
+				excerpt: 'A short intro',
+				friendlyURLPath: '/products/widget',
+				metaDescription: 'Buy widgets',
+				seoTitle: 'Widgets | Buy Online',
+			}),
+		});
+
+		expect(sample?.fields).toEqual([
+			{label: 'excerpt', value: 'A short intro'},
+			{label: 'url', value: '/products/widget'},
+			{label: 'meta-description', value: 'Buy widgets'},
+			{label: 'seo-title', value: 'Widgets | Buy Online'},
+		]);
+		expect(sample?.chips).toEqual([
+			'Excerpt',
+			'Friendly U R L Path',
+			'Meta Description',
+			'Seo Title',
+		]);
+	});
+
+	it('derives an item URL only when the preview carries one', () => {
+		expect(getItemURL(items[0])).toBeNull();
+		expect(
+			getItemURL({
+				...items[0],
+				previewItem: JSON.stringify({friendlyURLPath: '/about'}),
+			})
+		).toBe('/about');
+		expect(
+			getItemURL({
+				...items[0],
+				previewItem: JSON.stringify({urlTitle: 'about-us'}),
+			})
+		).toBe('about-us');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87447

Part of the Content Site Generator stack (decomposes #562 / #564). **Stacked on #572 — merge after it.**

## Scope

The data layer for the wizard: REST service wrappers (`services/generations.ts`, `services/sites.ts`), the TypeScript types, the `contentModel` derivation utilities, and the `contentModel` unit test.

No UI yet — these modules are consumed by the columns, wizard, and chat PRs above.
