### PR TITLE
LPD-87447 Add status and languages columns to the generation list

### DIFF
--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/java/com/liferay/content/site/generator/web/internal/frontend/data/set/view/ContentSiteGeneratorTableFDSView.java
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/java/com/liferay/content/site/generator/web/internal/frontend/data/set/view/ContentSiteGeneratorTableFDSView.java
@@ -13,6 +13,9 @@ import com.liferay.frontend.data.set.view.table.DateTimeFDSTableSchemaField;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
 import java.util.Locale;
 
@@ -33,21 +36,43 @@ public class ContentSiteGeneratorTableFDSView extends BaseTableFDSView {
 		FDSTableSchemaBuilder fdsTableSchemaBuilder =
 			_fdsTableSchemaBuilderFactory.create();
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		String moduleURL =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				serviceContext.getRequest()
+			).forESModule(
+				"content-site-generator-web", "index.js"
+			).build();
+
 		return fdsTableSchemaBuilder.add(
-			"title", "title",
+			"title", "name",
 			fdsTableSchemaField -> fdsTableSchemaField.setActionId(
 				"view"
 			).setContentRenderer(
 				"actionLink"
 			)
 		).add(
-			"prompt", "prompt",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"label")
+			"itemCount", "items"
 		).add(
-			_dateTimeField("dateCreated", "created")
+			"targetLanguages", "languages",
+			fdsTableSchemaField -> {
+				fdsTableSchemaField.setContentRendererClientExtension(true);
+				fdsTableSchemaField.setContentRendererModuleURL(
+					"{CSGGenerationLanguagesDataRenderer} from " + moduleURL);
+			}
 		).add(
-			_dateTimeField("commitDate", "committed")
+			"creator.name", "created-by"
+		).add(
+			"generationStatus", "status",
+			fdsTableSchemaField -> {
+				fdsTableSchemaField.setContentRendererClientExtension(true);
+				fdsTableSchemaField.setContentRendererModuleURL(
+					"{CSGGenerationStatusDataRenderer} from " + moduleURL);
+			}
+		).add(
+			_dateTimeField("dateModified", "modified")
 		).build();
 	}
 
@@ -75,6 +100,9 @@ public class ContentSiteGeneratorTableFDSView extends BaseTableFDSView {
 
 		return dateTimeFDSTableSchemaField;
 	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
 
 	@Reference
 	private FDSTableSchemaBuilderFactory _fdsTableSchemaBuilderFactory;

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/CSGGenerationLanguagesDataRenderer.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/CSGGenerationLanguagesDataRenderer.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getLanguageLabel} from './util/contentModel';
+
+interface Args {
+	value?: string;
+}
+
+export default function CSGGenerationLanguagesDataRenderer({
+	value,
+}: Args): HTMLElement {
+	const span = document.createElement('span');
+
+	if (!value) {
+		return span;
+	}
+
+	span.textContent = value
+		.split(',')
+		.map((code) => code.trim())
+		.filter(Boolean)
+		.map((code) => getLanguageLabel(code))
+		.join(', ');
+
+	return span;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/CSGGenerationStatusDataRenderer.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/CSGGenerationStatusDataRenderer.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const DISPLAY_TYPES: Record<string, string> = {
+	committed: 'success',
+	failed: 'danger',
+	generating: 'info',
+	ready: 'success',
+	refining: 'info',
+};
+
+interface Args {
+	value?: {
+		key?: string;
+		name?: string;
+	};
+}
+
+export default function CSGGenerationStatusDataRenderer({
+	value,
+}: Args): HTMLElement {
+	const span = document.createElement('span');
+
+	if (!value || !value.key) {
+		return span;
+	}
+
+	span.className = `label label-${DISPLAY_TYPES[value.key] ?? 'secondary'}`;
+	span.textContent = value.name || value.key;
+
+	return span;
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/index.ts
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as CSGGenerationLanguagesDataRenderer} from './CSGGenerationLanguagesDataRenderer';
+export {default as CSGGenerationStatusDataRenderer} from './CSGGenerationStatusDataRenderer';
 export {default as ContentSiteGenerator} from './ContentSiteGenerator';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87447

Part of the Content Site Generator stack (decomposes #562 / #564). **Stacked on #573 — merge after it.**

## Scope

Adds the status and languages columns to the generations list: the two FrontendDataSet data renderers, their registration in `index.ts`, and the table FDS view wiring on the Java side.
