### PR TITLE
LPD-96487 Skip low-score chunks in the Elasticsearch RAG retriever

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
@@ -84,6 +84,10 @@ public class ElasticsearchContentRetriever extends BaseContentRetriever {
 		SearchHits searchHits = searchSearchResponse.getSearchHits();
 
 		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			if (searchHit.getScore() < _MIN_SCORE) {
+				continue;
+			}
+
 			Map<String, HighlightField> highlightFields =
 				searchHit.getHighlightFieldsMap();
 
@@ -101,6 +105,8 @@ public class ElasticsearchContentRetriever extends BaseContentRetriever {
 
 		return contents;
 	}
+
+	private static final float _MIN_SCORE = 0.75F;
 
 	private final FieldConfigBuilderFactory _fieldConfigBuilderFactory;
 	private final HighlightBuilderFactory _highlightBuilderFactory;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.langchain4j.rag.content.retriever;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
+import com.liferay.portal.search.highlight.FieldConfigBuilderFactory;
+import com.liferay.portal.search.highlight.HighlightBuilderFactory;
+import com.liferay.portal.search.highlight.HighlightField;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Iliyan Peychev
+ */
+public class ElasticsearchContentRetrieverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSearchSkipsHitsScoringBelowMinScore() {
+		String fragment = RandomTestUtil.randomString();
+
+		HighlightField highlightField = Mockito.mock(HighlightField.class);
+
+		Mockito.when(
+			highlightField.getFragments()
+		).thenReturn(
+			List.of(fragment)
+		);
+
+		SearchHit highScoreSearchHit = Mockito.mock(SearchHit.class);
+
+		Mockito.when(
+			highScoreSearchHit.getHighlightFieldsMap()
+		).thenReturn(
+			Map.of("text_embedding", highlightField)
+		);
+
+		Mockito.when(
+			highScoreSearchHit.getScore()
+		).thenReturn(
+			0.9F
+		);
+
+		SearchHit lowScoreSearchHit = Mockito.mock(SearchHit.class);
+
+		Mockito.when(
+			lowScoreSearchHit.getScore()
+		).thenReturn(
+			0.5F
+		);
+
+		SearchHits searchHits = Mockito.mock(SearchHits.class);
+
+		Mockito.when(
+			searchHits.getSearchHits()
+		).thenReturn(
+			List.of(lowScoreSearchHit, highScoreSearchHit)
+		);
+
+		SearchSearchResponse searchSearchResponse = Mockito.mock(
+			SearchSearchResponse.class);
+
+		Mockito.when(
+			searchSearchResponse.getSearchHits()
+		).thenReturn(
+			searchHits
+		);
+
+		SearchEngineAdapter searchEngineAdapter = Mockito.mock(
+			SearchEngineAdapter.class);
+
+		Mockito.when(
+			searchEngineAdapter.execute((SearchSearchRequest)Mockito.any())
+		).thenReturn(
+			searchSearchResponse
+		);
+
+		Query query = Mockito.mock(Query.class);
+
+		Mockito.when(
+			query.text()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		ElasticsearchContentRetriever elasticsearchContentRetriever =
+			new ElasticsearchContentRetriever(
+				Mockito.mock(
+					FieldConfigBuilderFactory.class,
+					Mockito.RETURNS_DEEP_STUBS),
+				Mockito.mock(
+					HighlightBuilderFactory.class, Mockito.RETURNS_DEEP_STUBS),
+				new String[] {RandomTestUtil.randomString()},
+				searchEngineAdapter, RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLong());
+
+		List<Content> contents = elasticsearchContentRetriever.search(query);
+
+		Assert.assertEquals(contents.toString(), 1, contents.size());
+
+		Content content = contents.get(0);
+
+		Assert.assertEquals(
+			fragment,
+			content.textSegment(
+			).text());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96487

## What Is Being Fixed

A RAG agent backed by an Elasticsearch data source would answer even when the indexed content had nothing relevant to the question. The Elasticsearch content retriever injected every highlight fragment from every search hit into the prompt, no matter how weak the semantic match was, so low-relevance chunks were handed to the model as if they were valid context.

## How It Is Being Fixed

`ElasticsearchContentRetriever` now reads each hit's relevance score and skips any hit scoring below a minimum threshold, so weak matches never reach the prompt as context. This mirrors the existing pattern in `LiferayWebSearchContentRetriever`, which already discards results scoring below 5.

The threshold is a constant (`_MIN_SCORE = 0.75F`). The index uses the `gemini-embedding-001` model (dense cosine, scores roughly 0.5 to 1.0), and the value still needs calibration against the real index by running in-scope and out-of-scope queries.

This is the retrieval half of the work. The generation half (a grounding instruction on the RAG agent's prompt so the model refuses when no context is retrieved) is configuration on the agent and is tracked separately.

## PR Check

**pr-check: PASS** — tested on `22f5e86e02501c848bd31d58f2fe25f10a10d59a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "22f5e86e02501c848bd31d58f2fe25f10a10d59a"} -->
