### PR TITLE
LPD-96619 Include the portal URL in provisioning request emails

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ProvisioningRequestManagerImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -70,6 +71,9 @@ public class ProvisioningRequestManagerImpl
 		).build();
 
 		serviceContext.setCompanyId(company.getCompanyId());
+		serviceContext.setPathMain(Portal.PATH_MAIN);
+		serviceContext.setPortalURL(
+			_portal.getPortalURL(dtoConverterContext.getHttpServletRequest()));
 		serviceContext.setUserId(dtoConverterContext.getUserId());
 
 		AccountEntry customerAccountEntry = _addCustomerAccountEntry(
@@ -392,6 +396,9 @@ public class ProvisioningRequestManagerImpl
 
 	@Reference(target = "(object.entry.manager.storage.type=default)")
 	private ObjectEntryManager _objectEntryManager;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(policyOption = ReferencePolicyOption.GREEDY)
 	private QuotaManager _quotaManager;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96619

## What Is Being Fixed

When a provisioning request created a customer account, the notification email it triggered was generated without the portal URL. The `ServiceContext` handed to the entity creation had no `portalURL` or `pathMain` set, so the links rendered in the resulting email were missing or incorrect.

## How It Is Being Fixed

`ProvisioningRequestManagerImpl` now resolves the portal URL from the request manager's `DTOConverterContext` HTTP servlet request and sets both `portalURL` and `pathMain` on the `ServiceContext` before the customer account entry is created. A `Portal` reference was injected to obtain the URL, so downstream notification emails render correct portal links.

## Why Are There No Tests?

The fix only sets `portalURL` and `pathMain` on the `ServiceContext`. The resulting behavior is observable only through the full provisioning and email-notification flow, which is not reachable at the unit level for this internal manager.

## PR Check

**pr-check: PASS** — tested on `f9a557b9305a2df9cc85a470d14d22e916a8575e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f9a557b9305a2df9cc85a470d14d22e916a8575e"} -->
