### PR TITLE
LPD-96790 Expose the AI Hub crawler log level as an env variable

### DIFF
--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
@@ -76,6 +76,7 @@ public class KubernetesJobService {
 				_createEnvVar(
 					"CRAWLER_DOMAIN_URL",
 					uri.getScheme() + "://" + uri.getAuthority()),
+				_createEnvVar("CRAWLER_LOG_LEVEL", _crawlerLogLevel),
 				_createEnvVar("CRAWLER_OUTPUT_INDEX", indexName),
 				_createEnvVar("CRAWLER_SEED_URL", url),
 				_createEnvVar("ELASTICSEARCH_HOST", _elasticsearchHost),
@@ -154,6 +155,9 @@ public class KubernetesJobService {
 
 	private static final Log _log = LogFactory.getLog(
 		KubernetesJobService.class);
+
+	@Value("${liferay.ai.hub.crawler.log.level}")
+	private String _crawlerLogLevel;
 
 	@Value("${liferay.ai.hub.crawler.elasticsearch.host}")
 	private String _elasticsearchHost;

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/resources/application-default.properties
@@ -6,6 +6,7 @@ liferay.ai.hub.crawler.elasticsearch.host=${LIFERAY_AI_HUB_CRAWLER_ELASTICSEARCH
 liferay.ai.hub.crawler.elasticsearch.port=${LIFERAY_AI_HUB_CRAWLER_ELASTICSEARCH_PORT}
 liferay.ai.hub.crawler.k8s.image.name=${LIFERAY_AI_HUB_CRAWLER_K8S_IMAGE_NAME}
 liferay.ai.hub.crawler.k8s.namespace=${LIFERAY_AI_HUB_CRAWLER_K8S_NAMESPACE}
+liferay.ai.hub.crawler.log.level=${LIFERAY_AI_HUB_CRAWLER_LOG_LEVEL:info}
 
 #
 # LXC


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96790

## What is being fixed

The AI Hub crawler ran the Elastic Open Crawler at its default `info` log level with no way to change it from Liferay Cloud. Diagnosing a crawl — for example, understanding why far more pages are visited than documents get indexed — meant the log level could not be raised without rebuilding the crawler image.

## How it is being fixed

A new Liferay Cloud environment variable `LIFERAY_AI_HUB_CRAWLER_LOG_LEVEL` (default `info`) maps to the Spring property `liferay.ai.hub.crawler.log.level` in the `liferay-aihub-etc-spring-boot` client extension. `KubernetesJobService` reads it and injects it as the `CRAWLER_LOG_LEVEL` environment variable on the crawler Job container, which the crawler image reads to set the Elastic Open Crawler log level. Valid values are `debug`, `info`, `warn`, `error`, `fatal`.

## Why are there no tests?

The change only wires a configuration value through Spring `@Value` into the Kubernetes Job spec built by `KubernetesJobService`; its effect is observable only when a Job is dispatched against a live cluster, for which the client extension has no unit or integration test harness (the surrounding executor code is likewise untested here).
