### PR TITLE
LPD-87447 Add the content site generator review step

### DIFF
--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/ContentSiteGeneratorWizard.tsx
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/ContentSiteGeneratorWizard.tsx
@@ -4,16 +4,19 @@
  */
 
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {openToast} from 'frontend-js-components-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import StepLayout from './components/StepLayout';
 import {
+	commitGeneration,
 	createGeneration,
 	getGeneration,
 	getGenerationItems,
 } from './services/generations';
 import IdeateStep from './steps/IdeateStep';
 import RefineStep from './steps/RefineStep';
+import ReviewStep from './steps/ReviewStep';
 
 import type {Generation} from './types/Generation';
 import type {GenerationItem} from './types/GenerationItem';
@@ -42,6 +45,7 @@ export default function ContentSiteGeneratorWizard({
 	const [generation, setGeneration] = useState<Generation>();
 	const [items, setItems] = useState<GenerationItem[]>([]);
 	const [loading, setLoading] = useState(!!generationId);
+	const [publishing, setPublishing] = useState(false);
 
 	const pollAttemptsRef = useRef(0);
 
@@ -74,7 +78,9 @@ export default function ContentSiteGeneratorWizard({
 				const statusKey = newGeneration.generationStatus.key;
 
 				setActiveStep(
-					statusKey === 'committed' || statusKey === 'ready'
+					statusKey === 'committed' ||
+						statusKey === 'generating' ||
+						statusKey === 'ready'
 						? STEP_REVIEW
 						: STEP_REFINE
 				);
@@ -167,6 +173,36 @@ export default function ContentSiteGeneratorWizard({
 		}
 	};
 
+	const handlePublish = async () => {
+		if (!generation) {
+			return;
+		}
+
+		setError(undefined);
+		setPublishing(true);
+
+		try {
+			await commitGeneration(apiURL, generation.id);
+
+			openToast({
+				message: Liferay.Language.get(
+					'the-generated-content-was-published'
+				),
+				type: 'success',
+			});
+
+			Liferay.Util.navigate(generationsURL);
+		}
+		catch (newError) {
+			setError(
+				newError instanceof Error ? newError.message : String(newError)
+			);
+		}
+		finally {
+			setPublishing(false);
+		}
+	};
+
 	if (loading && !generation) {
 		return <ClayLoadingIndicator displayType="secondary" size="md" />;
 	}
@@ -191,6 +227,20 @@ export default function ContentSiteGeneratorWizard({
 						onBack={() => setActiveStep(STEP_IDEATE)}
 						onCancel={handleCancel}
 						onContinue={() => setActiveStep(STEP_REVIEW)}
+					/>
+				</StepLayout>
+			)}
+
+			{activeStep === STEP_REVIEW && generation && (
+				<StepLayout activeStep={STEP_REVIEW}>
+					<ReviewStep
+						error={error}
+						generation={generation}
+						items={items}
+						onBack={() => setActiveStep(STEP_REFINE)}
+						onCancel={handleCancel}
+						onPublish={handlePublish}
+						publishing={publishing}
 					/>
 				</StepLayout>
 			)}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/components/GenerateProgress.tsx
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/components/GenerateProgress.tsx
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {buildTemplates, getItemLanguages} from '../util/contentModel';
+import SummaryStats from './SummaryStats';
+
+import type {SummaryStat} from '../types/ContentModel';
+import type {Generation} from '../types/Generation';
+import type {GenerationItem} from '../types/GenerationItem';
+
+const PHASE_ADVANCE_INTERVAL = 1800;
+
+interface IProps {
+	generation: Generation;
+	items: GenerationItem[];
+}
+
+export default function GenerateProgress({generation, items}: IProps) {
+	const ready =
+		generation.generationStatus.key === 'ready' ||
+		generation.generationStatus.key === 'committed';
+
+	const languages = useMemo(() => {
+		const languagesSet = new Set<string>();
+
+		for (const item of items) {
+			for (const language of getItemLanguages(item)) {
+				languagesSet.add(language);
+			}
+		}
+
+		return languagesSet;
+	}, [items]);
+
+	const phases = useMemo(() => {
+		const basePhases = [
+			Liferay.Language.get('analyzing-your-prompt'),
+			Liferay.Language.get('extracting-key-topics-and-features'),
+			Liferay.Language.get('generating-content'),
+			Liferay.Language.get('generating-content-pages'),
+		];
+
+		if (languages.size > 1) {
+			return [
+				...basePhases,
+				Liferay.Language.get('localizing-to-target-languages'),
+			];
+		}
+
+		return basePhases;
+	}, [languages]);
+
+	const [step, setStep] = useState(0);
+
+	useEffect(() => {
+		if (ready) {
+			return;
+		}
+
+		const intervalId = setInterval(() => {
+			setStep((current) => Math.min(current + 1, phases.length - 1));
+		}, PHASE_ADVANCE_INTERVAL);
+
+		return () => clearInterval(intervalId);
+	}, [phases.length, ready]);
+
+	const phaseIndex = ready ? phases.length : step;
+
+	const stats: SummaryStat[] = [
+		{
+			icon: 'document',
+			label: Liferay.Language.get('content-entries'),
+			value: items.reduce((sum, item) => sum + (item.itemCount ?? 0), 0),
+		},
+		{
+			icon: 'page',
+			label: Liferay.Language.get('content-pages'),
+			value: buildTemplates(items).reduce(
+				(sum, template) => sum + template.pageCount,
+				0
+			),
+		},
+		{
+			icon: 'automatic-translate',
+			label: Liferay.Language.get('languages'),
+			value: languages.size,
+		},
+	];
+
+	return (
+		<div className="content-site-generator__generate">
+			<h3 className="content-site-generator__section-title">
+				{Liferay.Language.get('generate')}
+			</h3>
+
+			<SummaryStats stats={stats} />
+
+			<ul className="content-site-generator__stages list-unstyled">
+				{phases.map((phaseLabel, index) => {
+					const completed = index < phaseIndex;
+					const active = index === phaseIndex && !ready;
+
+					const status = completed
+						? 'completed'
+						: active
+							? 'in-progress'
+							: 'pending';
+
+					return (
+						<li
+							className={`content-site-generator__stage content-site-generator__stage--${status}`}
+							key={phaseLabel}
+						>
+							<div className="content-site-generator__stage-header">
+								<span className="content-site-generator__stage-bullet">
+									{completed && (
+										<ClayIcon
+											className="text-success"
+											spritemap={Liferay.Icons.spritemap}
+											symbol="check-circle-full"
+										/>
+									)}
+
+									{active && (
+										<span
+											aria-hidden="true"
+											className="content-site-generator__stage-bullet--in-progress"
+										/>
+									)}
+
+									{!completed && !active && (
+										<span
+											aria-hidden="true"
+											className="content-site-generator__stage-bullet--pending"
+										/>
+									)}
+								</span>
+
+								<span className="content-site-generator__stage-label">
+									{phaseLabel}
+								</span>
+
+								{completed && (
+									<ClayLabel displayType="success">
+										{Liferay.Language.get('done')}
+									</ClayLabel>
+								)}
+
+								{active && (
+									<ClayLabel displayType="info">
+										{Liferay.Language.get('in-progress')}
+									</ClayLabel>
+								)}
+							</div>
+
+							{(completed || active) && (
+								<div className="content-site-generator__stage-progress">
+									<div className="progress">
+										<div
+											className={
+												completed
+													? 'progress-bar bg-success'
+													: 'progress-bar progress-bar-animated progress-bar-striped'
+											}
+											style={{width: '100%'}}
+										/>
+									</div>
+
+									{completed && (
+										<ClayIcon
+											className="content-site-generator__stage-progress-check text-success"
+											spritemap={Liferay.Icons.spritemap}
+											symbol="check-circle"
+										/>
+									)}
+								</div>
+							)}
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/steps/ReviewStep.tsx
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/src/main/resources/META-INF/resources/js/steps/ReviewStep.tsx
@@ -1,0 +1,584 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
+import {ClayCheckbox, ClayInput, ClaySelect} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
+import ClayTable from '@clayui/table';
+import React, {useEffect, useMemo, useState} from 'react';
+
+import GenerateProgress from '../components/GenerateProgress';
+import StepActions from '../components/StepActions';
+import SummaryStats from '../components/SummaryStats';
+import {getGenerationPages} from '../services/generations';
+import {getSiteByExternalReferenceCode} from '../services/sites';
+import {buildDetectedConfig, getLanguageLabel} from '../util/contentModel';
+
+import type {SummaryStat} from '../types/ContentModel';
+import type {GeneratedPage} from '../types/GeneratedPage';
+import type {Generation} from '../types/Generation';
+import type {GenerationItem} from '../types/GenerationItem';
+
+interface IProps {
+	error?: string;
+	generation: Generation;
+	items: GenerationItem[];
+	onBack: () => void;
+	onCancel: () => void;
+	onPublish: () => void;
+	publishing: boolean;
+}
+
+export default function ReviewStep({
+	error,
+	generation,
+	items,
+	onBack,
+	onCancel,
+	onPublish,
+	publishing,
+}: IProps) {
+	const [filterType, setFilterType] = useState('');
+	const [loadError, setLoadError] = useState(false);
+	const [order, setOrder] = useState('title-asc');
+	const [page, setPage] = useState(1);
+	const [pages, setPages] = useState<GeneratedPage[]>([]);
+	const [pageSize, setPageSize] = useState(20);
+	const [search, setSearch] = useState('');
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [siteFriendlyURL, setSiteFriendlyURL] = useState<string | null>(null);
+	const [urlColumnVisible, setUrlColumnVisible] = useState(true);
+
+	const committed = generation.generationStatus.key === 'committed';
+
+	const generating = generation.generationStatus.key === 'generating';
+
+	useEffect(() => {
+		let cancelled = false;
+
+		getGenerationPages(items)
+			.then((newPages) => {
+				if (!cancelled) {
+					setPages(newPages);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setLoadError(true);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [items]);
+
+	useEffect(() => {
+		if (!committed || !generation.generatedSiteERC) {
+			return;
+		}
+
+		let cancelled = false;
+
+		getSiteByExternalReferenceCode(generation.generatedSiteERC)
+			.then((site) => {
+				if (!cancelled && site && site.friendlyUrlPath) {
+					setSiteFriendlyURL(site.friendlyUrlPath);
+				}
+			})
+			.catch(() => {});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [committed, generation.generatedSiteERC]);
+
+	const reviewStats = useMemo<SummaryStat[]>(() => {
+		const detectedConfig = buildDetectedConfig(generation, items);
+
+		return [
+			{
+				icon: 'list',
+				label: Liferay.Language.get('total-items'),
+				value: items.reduce(
+					(sum, item) => sum + (item.itemCount ?? 0),
+					0
+				),
+			},
+			{
+				icon: 'automatic-translate',
+				label: Liferay.Language.get('languages'),
+				value: detectedConfig.languageLabels.length,
+			},
+			{
+				icon: 'flag-full',
+				label: Liferay.Language.get('status'),
+				value: committed
+					? generation.generationStatus.name ||
+						Liferay.Language.get('published')
+					: Liferay.Language.get('draft'),
+			},
+		];
+	}, [committed, generation, items]);
+
+	const templateLabels = useMemo(
+		() => [
+			...new Set(
+				pages.map((generatedPage) => generatedPage.templateLabel)
+			),
+		],
+		[pages]
+	);
+
+	const visiblePages = useMemo(() => {
+		const searchText = search.trim().toLowerCase();
+
+		const filtered = pages.filter((generatedPage) => {
+			if (filterType && generatedPage.templateLabel !== filterType) {
+				return false;
+			}
+
+			if (
+				searchText &&
+				!generatedPage.title.toLowerCase().includes(searchText) &&
+				!(generatedPage.url ?? '').toLowerCase().includes(searchText)
+			) {
+				return false;
+			}
+
+			return true;
+		});
+
+		return [...filtered].sort((a, b) => {
+			const comparison = a.title.localeCompare(b.title);
+
+			return order === 'title-desc' ? -comparison : comparison;
+		});
+	}, [pages, search, filterType, order]);
+
+	const pageItems = visiblePages.slice(
+		(page - 1) * pageSize,
+		page * pageSize
+	);
+
+	const hasURL = pages.some((generatedPage) => generatedPage.url);
+
+	const showURL = hasURL && urlColumnVisible;
+
+	const allSelected =
+		!!visiblePages.length &&
+		visiblePages.every((generatedPage) =>
+			selectedIds.has(generatedPage.id)
+		);
+
+	const getPageHref = (generatedPage: GeneratedPage) =>
+		committed && siteFriendlyURL && generatedPage.url?.startsWith('/')
+			? `/web${siteFriendlyURL}${generatedPage.url}`
+			: null;
+
+	const toggleAll = () => {
+		if (allSelected) {
+			setSelectedIds(new Set());
+		}
+		else {
+			setSelectedIds(
+				new Set(visiblePages.map((generatedPage) => generatedPage.id))
+			);
+		}
+	};
+
+	const toggleOne = (id: string) => {
+		const newSelectedIds = new Set(selectedIds);
+
+		if (newSelectedIds.has(id)) {
+			newSelectedIds.delete(id);
+		}
+		else {
+			newSelectedIds.add(id);
+		}
+
+		setSelectedIds(newSelectedIds);
+	};
+
+	const openSelected = () => {
+		for (const generatedPage of visiblePages) {
+			if (!selectedIds.has(generatedPage.id)) {
+				continue;
+			}
+
+			const href = getPageHref(generatedPage);
+
+			if (href) {
+				window.open(href, '_blank');
+			}
+		}
+	};
+
+	return (
+		<div className="content-site-generator__review">
+			{generating ? (
+				<GenerateProgress generation={generation} items={items} />
+			) : (
+				<>
+					<div className="content-site-generator__refine-header">
+						<h3>{Liferay.Language.get('review-and-publish')}</h3>
+
+						<p className="text-secondary">
+							{Liferay.Language.get(
+								'review-the-generated-content-before-publishing-it-to-your-site'
+							)}
+						</p>
+					</div>
+
+					{error && (
+						<ClayAlert
+							displayType="danger"
+							title={Liferay.Language.get('error')}
+						>
+							{error}
+						</ClayAlert>
+					)}
+
+					{committed && (
+						<ClayAlert
+							displayType="success"
+							title={Liferay.Language.get('success')}
+						>
+							{Liferay.Language.get(
+								'the-generated-content-was-published'
+							)}
+						</ClayAlert>
+					)}
+
+					<SummaryStats stats={reviewStats} />
+
+					<div className="content-site-generator__review-toolbar">
+						<ClaySelect
+							aria-label={Liferay.Language.get('filter')}
+							className="content-site-generator__review-filter"
+							onChange={(event) => {
+								setPage(1);
+								setFilterType(event.target.value);
+							}}
+							value={filterType}
+						>
+							<ClaySelect.Option
+								label={Liferay.Language.get('all-types')}
+								value=""
+							/>
+
+							{templateLabels.map((label) => (
+								<ClaySelect.Option
+									key={label}
+									label={label}
+									value={label}
+								/>
+							))}
+						</ClaySelect>
+
+						<ClaySelect
+							aria-label={Liferay.Language.get('order')}
+							className="content-site-generator__review-order"
+							onChange={(event) => setOrder(event.target.value)}
+							value={order}
+						>
+							<ClaySelect.Option
+								label={Liferay.Language.get('ascending')}
+								value="title-asc"
+							/>
+
+							<ClaySelect.Option
+								label={Liferay.Language.get('descending')}
+								value="title-desc"
+							/>
+						</ClaySelect>
+
+						<ClayInput.Group className="content-site-generator__review-search">
+							<ClayInput.GroupItem>
+								<ClayInput
+									aria-label={Liferay.Language.get('search')}
+									insetBefore
+									onChange={(event) => {
+										setPage(1);
+										setSearch(event.target.value);
+									}}
+									placeholder={Liferay.Language.get('search')}
+									type="text"
+									value={search}
+								/>
+
+								<ClayInput.GroupInsetItem before tag="span">
+									<ClayIcon
+										spritemap={Liferay.Icons.spritemap}
+										symbol="search"
+									/>
+								</ClayInput.GroupInsetItem>
+							</ClayInput.GroupItem>
+						</ClayInput.Group>
+					</div>
+
+					{!!selectedIds.size && (
+						<div className="content-site-generator__review-selection">
+							<span>
+								{Liferay.Util.sub(
+									Liferay.Language.get('x-selected'),
+									String(selectedIds.size)
+								)}
+							</span>
+
+							<ClayButton
+								disabled={!committed || !siteFriendlyURL}
+								displayType="secondary"
+								onClick={openSelected}
+								small
+							>
+								{Liferay.Language.get('open-selected')}
+							</ClayButton>
+
+							<ClayButton
+								displayType="unstyled"
+								onClick={() => setSelectedIds(new Set())}
+								small
+							>
+								{Liferay.Language.get('clear')}
+							</ClayButton>
+						</div>
+					)}
+
+					{!visiblePages.length ? (
+						<p className="text-secondary">
+							{loadError
+								? Liferay.Language.get('unable-to-load-content')
+								: search.trim() || filterType
+									? Liferay.Language.get(
+											'no-results-were-found'
+										)
+									: Liferay.Language.get('no-results-found')}
+						</p>
+					) : (
+						<>
+							<ClayTable className="content-site-generator__review-table">
+								<ClayTable.Head>
+									<ClayTable.Row>
+										<ClayTable.Cell headingCell>
+											<ClayCheckbox
+												aria-label={Liferay.Language.get(
+													'select-all'
+												)}
+												checked={allSelected}
+												onChange={toggleAll}
+											/>
+										</ClayTable.Cell>
+
+										<ClayTable.Cell expanded headingCell>
+											{Liferay.Language.get('title')}
+										</ClayTable.Cell>
+
+										<ClayTable.Cell headingCell>
+											{Liferay.Language.get('language')}
+										</ClayTable.Cell>
+
+										<ClayTable.Cell headingCell>
+											{Liferay.Language.get('items')}
+										</ClayTable.Cell>
+
+										{showURL && (
+											<ClayTable.Cell headingCell>
+												{Liferay.Language.get('url')}
+											</ClayTable.Cell>
+										)}
+
+										<ClayTable.Cell headingCell>
+											<ClayDropDown
+												trigger={
+													<ClayButtonWithIcon
+														aria-label={Liferay.Language.get(
+															'columns'
+														)}
+														displayType="unstyled"
+														size="sm"
+														spritemap={
+															Liferay.Icons
+																.spritemap
+														}
+														symbol="caret-bottom"
+													/>
+												}
+											>
+												<ClayDropDown.ItemList>
+													<ClayDropDown.Item
+														active={
+															urlColumnVisible
+														}
+														disabled={!hasURL}
+														onClick={() =>
+															setUrlColumnVisible(
+																(visible) =>
+																	!visible
+															)
+														}
+													>
+														{Liferay.Language.get(
+															'url'
+														)}
+													</ClayDropDown.Item>
+												</ClayDropDown.ItemList>
+											</ClayDropDown>
+										</ClayTable.Cell>
+									</ClayTable.Row>
+								</ClayTable.Head>
+
+								<ClayTable.Body>
+									{pageItems.map((generatedPage) => {
+										const href = getPageHref(generatedPage);
+
+										return (
+											<ClayTable.Row
+												key={generatedPage.id}
+											>
+												<ClayTable.Cell>
+													<ClayCheckbox
+														aria-label={Liferay.Util.sub(
+															Liferay.Language.get(
+																'select-x'
+															),
+															generatedPage.title
+														)}
+														checked={selectedIds.has(
+															generatedPage.id
+														)}
+														onChange={() =>
+															toggleOne(
+																generatedPage.id
+															)
+														}
+													/>
+												</ClayTable.Cell>
+
+												<ClayTable.Cell expanded>
+													<span className="content-site-generator__review-title">
+														<ClayIcon
+															className="mr-2 text-secondary"
+															spritemap={
+																Liferay.Icons
+																	.spritemap
+															}
+															symbol={
+																generatedPage.icon
+															}
+														/>
+
+														{generatedPage.title}
+													</span>
+												</ClayTable.Cell>
+
+												<ClayTable.Cell>
+													{generatedPage.languages
+														.map(getLanguageLabel)
+														.join(', ')}
+												</ClayTable.Cell>
+
+												<ClayTable.Cell>
+													{generatedPage.itemCount}
+												</ClayTable.Cell>
+
+												{showURL && (
+													<ClayTable.Cell>
+														<span className="content-site-generator__review-url">
+															{generatedPage.url ??
+																''}
+														</span>
+													</ClayTable.Cell>
+												)}
+
+												<ClayTable.Cell>
+													<ClayDropDown
+														trigger={
+															<ClayButtonWithIcon
+																aria-label={Liferay.Util.sub(
+																	Liferay.Language.get(
+																		'actions-for-x'
+																	),
+																	generatedPage.title
+																)}
+																displayType="unstyled"
+																size="sm"
+																spritemap={
+																	Liferay
+																		.Icons
+																		.spritemap
+																}
+																symbol="ellipsis-v"
+															/>
+														}
+													>
+														<ClayDropDown.ItemList>
+															<ClayDropDown.Item
+																disabled={!href}
+																onClick={() => {
+																	if (href) {
+																		window.open(
+																			href,
+																			'_blank'
+																		);
+																	}
+																}}
+															>
+																{Liferay.Language.get(
+																	'open-page'
+																)}
+															</ClayDropDown.Item>
+														</ClayDropDown.ItemList>
+													</ClayDropDown>
+												</ClayTable.Cell>
+											</ClayTable.Row>
+										);
+									})}
+								</ClayTable.Body>
+							</ClayTable>
+
+							<ClayPaginationBarWithBasicItems
+								active={page}
+								activeDelta={pageSize}
+								ellipsisBuffer={3}
+								onActiveChange={setPage}
+								onDeltaChange={(delta) => {
+									setPage(1);
+									setPageSize(delta);
+								}}
+								spritemap={Liferay.Icons.spritemap}
+								totalItems={visiblePages.length}
+							/>
+						</>
+					)}
+				</>
+			)}
+
+			<StepActions
+				backLabel={Liferay.Language.get('back')}
+				continueDisabled={committed || generating}
+				continueLabel={Liferay.Language.get('publish')}
+				continueLoading={publishing}
+				onBack={onBack}
+				onCancel={onCancel}
+				onContinue={onPublish}
+			>
+				{committed && siteFriendlyURL && (
+					<ClayButton
+						displayType="secondary"
+						onClick={() =>
+							window.open(`/web${siteFriendlyURL}`, '_blank')
+						}
+					>
+						{Liferay.Language.get('view-site')}
+					</ClayButton>
+				)}
+			</StepActions>
+		</div>
+	);
+}

--- a/modules/dxp/apps/content-site-generator/content-site-generator-web/test/js/steps/ReviewStep.test.tsx
+++ b/modules/dxp/apps/content-site-generator/content-site-generator-web/test/js/steps/ReviewStep.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import {getGenerationPages} from '../../../src/main/resources/META-INF/resources/js/services/generations';
+import {getSiteByExternalReferenceCode} from '../../../src/main/resources/META-INF/resources/js/services/sites';
+import ReviewStep from '../../../src/main/resources/META-INF/resources/js/steps/ReviewStep';
+
+import type {GeneratedPage} from '../../../src/main/resources/META-INF/resources/js/types/GeneratedPage';
+import type {Generation} from '../../../src/main/resources/META-INF/resources/js/types/Generation';
+import type {GenerationItem} from '../../../src/main/resources/META-INF/resources/js/types/GenerationItem';
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/services/generations',
+	() => ({getGenerationPages: jest.fn()})
+);
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/services/sites',
+	() => ({getSiteByExternalReferenceCode: jest.fn()})
+);
+
+beforeAll(() => {
+	const liferay = Liferay as unknown as Record<string, unknown>;
+
+	liferay.Icons = liferay.Icons ?? {spritemap: 'spritemap.svg'};
+	liferay.Util = {
+		...((liferay.Util as object) ?? {}),
+		sub: (template: string, ...args: string[]) =>
+			args.reduce(
+				(result, value, index) =>
+					result.replace(`{${index}}`, String(value)),
+				template
+			),
+	};
+});
+
+const generation: Generation = {
+	externalReferenceCode: 'erc',
+	generationStatus: {key: 'ready'},
+	id: 1,
+	prompt: 'Build a landing page',
+	targetLanguages: 'en,es',
+	title: 'Landing page',
+};
+
+const items: GenerationItem[] = [
+	{
+		externalReferenceCode: 'i1',
+		fileName: '06-pages.batch-engine-data.json',
+		id: 1,
+		itemCount: 1,
+		languages: 'en,es',
+	},
+	{
+		externalReferenceCode: 'i2',
+		fileName: '07-blogs.batch-engine-data.json',
+		id: 2,
+		itemCount: 2,
+		languages: 'en',
+	},
+];
+
+const pages: GeneratedPage[] = [
+	{
+		icon: 'page',
+		id: '1-0',
+		itemCount: 1,
+		languages: ['en', 'es'],
+		templateLabel: 'page',
+		title: 'Home Page',
+		url: '/home',
+	},
+	{
+		icon: 'document-text',
+		id: '2-0',
+		itemCount: 1,
+		languages: ['en'],
+		templateLabel: 'blog-article',
+		title: 'First Blog',
+		url: '/first-blog',
+	},
+	{
+		icon: 'document-text',
+		id: '2-1',
+		itemCount: 1,
+		languages: ['en'],
+		templateLabel: 'blog-article',
+		title: 'Second Blog',
+		url: '/second-blog',
+	},
+];
+
+const noop = () => {};
+
+beforeEach(() => {
+	(getGenerationPages as jest.Mock).mockResolvedValue(pages);
+	(getSiteByExternalReferenceCode as jest.Mock).mockResolvedValue(null);
+});
+
+describe('ReviewStep', () => {
+	it('filters the pages by content type', async () => {
+		render(
+			<ReviewStep
+				generation={generation}
+				items={items}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		await screen.findByText('Home Page');
+
+		fireEvent.change(screen.getByLabelText('filter'), {
+			target: {value: 'blog-article'},
+		});
+
+		expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
+		expect(screen.getByText('First Blog')).toBeInTheDocument();
+		expect(screen.getByText('Second Blog')).toBeInTheDocument();
+	});
+
+	it('lists the individual generated pages with their URLs', async () => {
+		render(
+			<ReviewStep
+				generation={generation}
+				items={items}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		expect(await screen.findByText('Home Page')).toBeInTheDocument();
+		expect(screen.getByText('First Blog')).toBeInTheDocument();
+		expect(screen.getByText('Second Blog')).toBeInTheDocument();
+
+		expect(screen.getByText('/home')).toBeInTheDocument();
+		expect(screen.getByText('/first-blog')).toBeInTheDocument();
+		expect(screen.getAllByText('url').length).toBeGreaterThan(0);
+
+		expect(screen.getByText('total-items')).toBeInTheDocument();
+		expect(screen.getByText('draft')).toBeInTheDocument();
+	});
+
+	it('omits the localizing phase for single-language generations', () => {
+		render(
+			<ReviewStep
+				generation={{
+					...generation,
+					generationStatus: {key: 'generating'},
+				}}
+				items={[
+					{
+						externalReferenceCode: 'i1',
+						fileName: '07-blogs.batch-engine-data.json',
+						id: 1,
+						itemCount: 2,
+						languages: 'en',
+					},
+				]}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		expect(
+			screen.queryByText('localizing-to-target-languages')
+		).not.toBeInTheDocument();
+	});
+
+	it('reveals the selection bar when pages are selected', async () => {
+		render(
+			<ReviewStep
+				generation={generation}
+				items={items}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		await screen.findByText('Home Page');
+
+		fireEvent.click(screen.getByLabelText('select-all'));
+
+		expect(screen.getByText('x-selected')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', {name: 'open-selected'})
+		).toBeInTheDocument();
+	});
+
+	it('shows the generate progress while the status is generating', () => {
+		render(
+			<ReviewStep
+				generation={{
+					...generation,
+					generationStatus: {key: 'generating'},
+				}}
+				items={[]}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		expect(screen.getByText('generate')).toBeInTheDocument();
+		expect(screen.getByText('analyzing-your-prompt')).toBeInTheDocument();
+		expect(
+			screen.getByText('extracting-key-topics-and-features')
+		).toBeInTheDocument();
+		expect(screen.getByText('generating-content')).toBeInTheDocument();
+		expect(
+			screen.getByText('generating-content-pages')
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryByText('review-and-publish')
+		).not.toBeInTheDocument();
+	});
+
+	it('shows the localizing phase for multi-language generations', () => {
+		render(
+			<ReviewStep
+				generation={{
+					...generation,
+					generationStatus: {key: 'generating'},
+				}}
+				items={[
+					{
+						externalReferenceCode: 'i1',
+						fileName: '07-blogs.batch-engine-data.json',
+						id: 1,
+						itemCount: 2,
+						languages: 'en,es',
+					},
+				]}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		expect(
+			screen.getByText('localizing-to-target-languages')
+		).toBeInTheDocument();
+	});
+
+	it('shows the success alert, View Site, and disables publish once committed', async () => {
+		(getSiteByExternalReferenceCode as jest.Mock).mockResolvedValue({
+			friendlyUrlPath: '/freshwater',
+		});
+
+		render(
+			<ReviewStep
+				generation={{
+					...generation,
+					generatedSiteERC: 'site-erc',
+					generationStatus: {key: 'committed'},
+				}}
+				items={items}
+				onBack={noop}
+				onCancel={noop}
+				onPublish={noop}
+				publishing={false}
+			/>
+		);
+
+		expect(
+			await screen.findByRole('button', {name: 'view-site'})
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText('the-generated-content-was-published')
+		).toBeInTheDocument();
+		expect(screen.getByText('published')).toBeInTheDocument();
+		expect(screen.getByRole('button', {name: 'publish'})).toBeDisabled();
+	});
+});


### PR DESCRIPTION
Part of the stacked Content Site Generator series (after #575 wizard).

Splits the oversized wizard PR by moving the generation progress into the Review step, matching the Figma design:

- Adds `ReviewStep` and the `GenerateProgress` component.
- The Review step shows the generation progress bars while generating, then the results table once ready.
- Wizard routes a `generating` status to the Review step; publish is disabled while generating.
- Tests for the review-step progress states.

Stacked on `LPD-87447-4-wizard`; `LPD-89663-chat` is rebased on top of this branch.