### PR TITLE
LPD-96617 Handle empty RAG content and surface workflow errors

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultKaleoSignaler.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultKaleoSignaler.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -35,6 +37,7 @@ import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.model.KaleoNode;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 import com.liferay.portal.workflow.kaleo.runtime.KaleoSignaler;
+import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
 import com.liferay.portal.workflow.kaleo.runtime.graph.GraphWalker;
 import com.liferay.portal.workflow.kaleo.runtime.graph.PathElement;
 import com.liferay.portal.workflow.kaleo.runtime.internal.node.util.NodeExecutorRegistryUtil;
@@ -43,6 +46,7 @@ import com.liferay.portal.workflow.kaleo.runtime.util.ExecutionContextHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -282,6 +286,20 @@ public class DefaultKaleoSignaler
 				kaleoLogLocalService.addInstanceFailKaleoLog(
 					executionContextKaleoInstanceToken, throwable.getMessage(),
 					executionContext.getServiceContext());
+
+				Message message = new Message();
+
+				message.put("companyId", kaleoInstance.getCompanyId());
+
+				message.put("createDate", new Date());
+				message.put("exception", throwable);
+				message.put("userId", kaleoInstance.getUserId());
+				message.put(
+					"workflowInstanceId", kaleoInstance.getKaleoInstanceId());
+
+				_messageBus.sendMessage(
+					WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE,
+					message);
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -305,6 +323,9 @@ public class DefaultKaleoSignaler
 
 	@Reference
 	private GraphWalker _graphWalker;
+
+	@Reference
+	private MessageBus _messageBus;
 
 	private NoticeableExecutorService _noticeableExecutorService;
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -7,6 +7,7 @@ package com.liferay.ai.hub.internal.agent;
 
 import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.agent.SupervisorAgent;
+import com.liferay.ai.hub.internal.exception.ContentInjectorException;
 import com.liferay.ai.hub.internal.memory.ChatMemoryProviderUtil;
 import com.liferay.ai.hub.internal.model.VertexAiGeminiUtil;
 import com.liferay.ai.hub.quota.QuotaManager;
@@ -209,6 +210,18 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 				"Chat Message Sent", null, agentContext.getSseEventSinkKey());
 
 			return;
+		}
+
+		if ((invocationTargetException.getCause() instanceof
+				RuntimeException runtimeException) &&
+			(runtimeException.getCause() instanceof
+				ContentInjectorException contentInjectorException)) {
+
+			SseUtil.send(
+				_language.get(
+					dtoConverterContext.getLocale(),
+					contentInjectorException.getMessageKey()),
+				"Chat Message Sent", null, agentContext.getSseEventSinkKey());
 		}
 
 		if (invocationTargetException.getCause() instanceof

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/exception/ContentInjectorException.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/exception/ContentInjectorException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.exception;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class ContentInjectorException extends RuntimeException {
+
+	public ContentInjectorException(String message) {
+		super(message);
+	}
+
+	public ContentInjectorException(String message, String messageKey) {
+		super(message);
+
+		_messageKey = messageKey;
+	}
+
+	public String getMessageKey() {
+		return _messageKey;
+	}
+
+	private String _messageKey;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/observability/api/listener/AiServiceErrorListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/observability/api/listener/AiServiceErrorListenerImpl.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.langchain4j.observability.api.listener;
+
+import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
+import dev.langchain4j.observability.api.listener.AiServiceErrorListener;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class AiServiceErrorListenerImpl implements AiServiceErrorListener {
+
+	public AiServiceErrorListenerImpl(Consumer<Throwable> onErrorConsumer) {
+		_onErrorConsumer = onErrorConsumer;
+	}
+
+	@Override
+	public void onEvent(AiServiceErrorEvent aiServiceErrorEvent) {
+		_onErrorConsumer.accept(aiServiceErrorEvent.error());
+	}
+
+	private final Consumer<Throwable> _onErrorConsumer;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/injector/DefaultContentInjector.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/injector/DefaultContentInjector.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.langchain4j.rag.content.injector;
+
+import com.liferay.ai.hub.internal.exception.ContentInjectorException;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.rag.content.Content;
+
+import java.util.List;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class DefaultContentInjector
+	extends dev.langchain4j.rag.content.injector.DefaultContentInjector {
+
+	public DefaultContentInjector(List<String> metadataKeysToInclude) {
+		super(metadataKeysToInclude);
+	}
+
+	@Override
+	public ChatMessage inject(List<Content> contents, ChatMessage chatMessage) {
+		if (contents.isEmpty()) {
+			throw new ContentInjectorException(
+				"No content to be injected", "there-is-no-content");
+		}
+
+		return super.inject(contents, chatMessage);
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowInstanceMessageListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowInstanceMessageListener.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
@@ -103,7 +103,7 @@ public class WorkflowInstanceMessageListener extends BaseMessageListener {
 				AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE_EXCEPTIONALLY :
 					AIHubEventTypes.AI_HUB_AGENT_INSTANCE_COMPLETE);
 
-		MessageBusUtil.sendMessage(
+		_messageBus.sendMessage(
 			AIHubDestinationNames.AI_HUB_AGENT_INSTANCE, message);
 	}
 
@@ -111,6 +111,9 @@ public class WorkflowInstanceMessageListener extends BaseMessageListener {
 	private DestinationFactory _destinationFactory;
 
 	private ServiceRegistration<Destination> _destinationServiceRegistration;
+
+	@Reference
+	private MessageBus _messageBus;
 
 	@Reference
 	private WorkflowInstanceManager _workflowInstanceManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node;
 import com.liferay.ai.hub.guardrail.ModelArmorHandler;
 import com.liferay.ai.hub.internal.assistant.handler.AssistantHandlerContext;
 import com.liferay.ai.hub.internal.assistant.handler.AssistantHandlerUtil;
+import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.AiServiceErrorListenerImpl;
 import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.InputGuardrailExecutedListenerImpl;
 import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.OutputGuardrailExecutedListenerImpl;
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
@@ -15,6 +16,7 @@ import com.liferay.ai.hub.internal.model.VertexAiGeminiUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.GuardrailsUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoNodeSettingUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.MessageUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.OnErrorConsumerUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.PromptUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.QuotaUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.RetrievalAugmentorUtil;
@@ -59,6 +61,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -188,10 +191,15 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			_objectEntryManager, outputGuardrails, _quotaManager,
 			serviceContext, workflowContext);
 
+		Consumer<Throwable> onErrorConsumer = OnErrorConsumerUtil.create(
+			kaleoInstanceToken, sseEventSinkKey,
+			vertexAiGeminiStreamingChatModel);
+
 		AssistantHandlerUtil.handle(
 			AssistantHandlerContext.builder(
 			).aiServiceListeners(
 				List.of(
+					new AiServiceErrorListenerImpl(onErrorConsumer),
 					new InputGuardrailExecutedListenerImpl(executionContext),
 					new OutputGuardrailExecutedListenerImpl(executionContext))
 			).inputGuardrails(
@@ -212,13 +220,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 						executionContext.getServiceContext(), userMessage);
 				}
 			).onErrorConsumer(
-				throwable -> {
-					MCPToolProviderUtil.close(sseEventSinkKey);
-
-					vertexAiGeminiStreamingChatModel.close();
-
-					_log.error(throwable);
-				}
+				onErrorConsumer
 			).outputGuardrails(
 				outputGuardrails
 			).retrievalAugmentor(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -28,8 +28,6 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -192,8 +190,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			serviceContext, workflowContext);
 
 		Consumer<Throwable> onErrorConsumer = OnErrorConsumerUtil.create(
-			kaleoInstanceToken, sseEventSinkKey,
-			vertexAiGeminiStreamingChatModel);
+			sseEventSinkKey, vertexAiGeminiStreamingChatModel);
 
 		AssistantHandlerUtil.handle(
 			AssistantHandlerContext.builder(
@@ -274,9 +271,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 					executionContext.getWorkflowContext(),
 					executionContext.getServiceContext())));
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		AIDecisionNodeExecutor.class);
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node;
 import com.liferay.ai.hub.guardrail.ModelArmorHandler;
 import com.liferay.ai.hub.internal.assistant.handler.AssistantHandlerContext;
 import com.liferay.ai.hub.internal.assistant.handler.AssistantHandlerUtil;
+import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.AiServiceErrorListenerImpl;
 import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.InputGuardrailExecutedListenerImpl;
 import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.OutputGuardrailExecutedListenerImpl;
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
@@ -15,6 +16,7 @@ import com.liferay.ai.hub.internal.model.VertexAiGeminiUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.GuardrailsUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoNodeSettingUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.MessageUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.OnErrorConsumerUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.PromptUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.QuotaUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.RetrievalAugmentorUtil;
@@ -26,8 +28,6 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -155,10 +156,15 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 			_objectEntryManager, outputGuardrails, _quotaManager,
 			serviceContext, workflowContext);
 
+		Consumer<Throwable> onErrorConsumer = OnErrorConsumerUtil.create(
+			kaleoInstanceToken, sseEventSinkKey,
+			vertexAiGeminiStreamingChatModel);
+
 		AssistantHandlerUtil.handle(
 			AssistantHandlerContext.builder(
 			).aiServiceListeners(
 				List.of(
+					new AiServiceErrorListenerImpl(onErrorConsumer),
 					new InputGuardrailExecutedListenerImpl(executionContext),
 					new OutputGuardrailExecutedListenerImpl(executionContext))
 			).inputGuardrails(
@@ -185,13 +191,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 					}
 				}
 			).onErrorConsumer(
-				throwable -> {
-					MCPToolProviderUtil.close(sseEventSinkKey);
-
-					vertexAiGeminiStreamingChatModel.close();
-
-					_log.error(throwable);
-				}
+				onErrorConsumer
 			).outputGuardrails(
 				outputGuardrails
 			).retrievalAugmentor(
@@ -287,9 +287,6 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 			throw new RuntimeException(portalException);
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		LLMNodeExecutor.class);
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -157,8 +157,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 			serviceContext, workflowContext);
 
 		Consumer<Throwable> onErrorConsumer = OnErrorConsumerUtil.create(
-			kaleoInstanceToken, sseEventSinkKey,
-			vertexAiGeminiStreamingChatModel);
+			sseEventSinkKey, vertexAiGeminiStreamingChatModel);
 
 		AssistantHandlerUtil.handle(
 			AssistantHandlerContext.builder(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OnErrorConsumerUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OnErrorConsumerUtil.java
@@ -8,14 +8,9 @@ package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.messaging.MessageBusUtil;
-import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
-import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
 
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 
-import java.util.Date;
 import java.util.function.Consumer;
 
 /**
@@ -24,26 +19,13 @@ import java.util.function.Consumer;
 public class OnErrorConsumerUtil {
 
 	public static Consumer<Throwable> create(
-		KaleoInstanceToken kaleoInstanceToken, String sseEventSinkKey,
+		String sseEventSinkKey,
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
 
 		return throwable -> {
 			MCPToolProviderUtil.close(sseEventSinkKey);
 
 			vertexAiGeminiStreamingChatModel.close();
-
-			Message message = new Message();
-
-			message.put("companyId", kaleoInstanceToken.getCompanyId());
-
-			message.put("createDate", new Date());
-			message.put("exception", throwable);
-			message.put("userId", kaleoInstanceToken.getUserId());
-			message.put(
-				"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
-
-			MessageBusUtil.sendMessage(
-				WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
 
 			_log.error(throwable);
 		};

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OnErrorConsumerUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OnErrorConsumerUtil.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
+
+import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
+import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
+
+import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
+
+import java.util.Date;
+import java.util.function.Consumer;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class OnErrorConsumerUtil {
+
+	public static Consumer<Throwable> create(
+		KaleoInstanceToken kaleoInstanceToken, String sseEventSinkKey,
+		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
+
+		return throwable -> {
+			MCPToolProviderUtil.close(sseEventSinkKey);
+
+			vertexAiGeminiStreamingChatModel.close();
+
+			Message message = new Message();
+
+			message.put("companyId", kaleoInstanceToken.getCompanyId());
+
+			message.put("createDate", new Date());
+			message.put("exception", throwable);
+			message.put("userId", kaleoInstanceToken.getUserId());
+			message.put(
+				"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
+
+			MessageBusUtil.sendMessage(
+				WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
+
+			_log.error(throwable);
+		};
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OnErrorConsumerUtil.class);
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/RetrievalAugmentorUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/RetrievalAugmentorUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
 
+import com.liferay.ai.hub.internal.langchain4j.rag.content.injector.DefaultContentInjector;
 import com.liferay.ai.hub.internal.langchain4j.rag.content.retriever.ElasticsearchContentRetriever;
 import com.liferay.ai.hub.internal.langchain4j.rag.content.retriever.LiferayWebSearchContentRetriever;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -32,7 +33,6 @@ import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
-import dev.langchain4j.rag.content.injector.DefaultContentInjector;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.router.DefaultQueryRouter;
 
@@ -85,10 +85,7 @@ public class RetrievalAugmentorUtil {
 
 		return DefaultRetrievalAugmentor.builder(
 		).contentInjector(
-			DefaultContentInjector.builder(
-			).metadataKeysToInclude(
-				List.of("url")
-			).build()
+			new DefaultContentInjector(List.of("url"))
 		).queryRouter(
 			new DefaultQueryRouter(contentRetrievers)
 		).build();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96617

## What Is Being Fixed

When a retrieval-augmented generation query returned no content, the LLM was still invoked with an empty context, producing ungrounded responses instead of telling the user there was nothing to ground an answer on. Separately, when an error occurred while a workflow instance was running, no completion event was emitted, so downstream AI Hub listeners never learned the instance had failed.

## How It Is Being Fixed

A DefaultContentInjector subclass throws a ContentInjectorException when there is no content to inject, short-circuiting inference before the model is called. SupervisorAgentImpl unwraps that exception and streams the localized "there-is-no-content" message to the client instead of a model response. A shared AiServiceErrorListenerImpl and OnErrorConsumerUtil consolidate the streaming error handling (closing the MCP tool provider and the chat model, logging) so both the AI service error listener and the onErrorConsumer run the same cleanup across the LLM and AI decision node executors. On the workflow side, DefaultKaleoSignaler now sends a message to the WORKFLOW_INSTANCE destination when an instance fails, and WorkflowInstanceMessageListener maps it to the AI Hub complete-exceptionally event; MessageBusUtil is replaced with an injected MessageBus reference.

## Why Are There No Tests?

The changed error and event paths are exercised by the existing workflow integration tests.

## PR Check

**pr-check: PASS** — tested on `66a8149325bd386beb3de797ff6d10680d2cd727`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "66a8149325bd386beb3de797ff6d10680d2cd727"} -->
