### PR TITLE
LPD-96938 Fix Site Builder workflow definition failing XSD validation

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/site-builder-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/site-builder-workflow-definition/workflow-definition.xml
@@ -522,11 +522,6 @@ Output:
 	</llm>
 	<service>
 		<name>repairSitePlan</name>
-		<labels>
-			<label language-id="en_US">
-				Repair Site Plan
-			</label>
-		</labels>
 		<input-variables>
 			<![CDATA[
 				[
@@ -538,6 +533,11 @@ Output:
 			]]>
 		</input-variables>
 		<java-delegate>javaDelegate#jsonRepair</java-delegate>
+		<labels>
+			<label language-id="en_US">
+				Repair Site Plan
+			</label>
+		</labels>
 		<output-variables>
 			<![CDATA[
 				[
@@ -557,12 +557,12 @@ Output:
 	</service>
 	<service>
 		<name>acknowledgeAgent</name>
+		<java-delegate>javaDelegate#acknowledgeAgent</java-delegate>
 		<labels>
 			<label language-id="en_US">
 				Acknowledge Agent
 			</label>
 		</labels>
-		<java-delegate>javaDelegate#acknowledgeAgent</java-delegate>
 		<output-variables>
 			<![CDATA[
 				[
@@ -582,11 +582,6 @@ Output:
 	</service>
 	<service>
 		<name>repairEnrichedSitePlan</name>
-		<labels>
-			<label language-id="en_US">
-				Repair Enriched Site Plan
-			</label>
-		</labels>
 		<input-variables>
 			<![CDATA[
 				[
@@ -598,6 +593,11 @@ Output:
 			]]>
 		</input-variables>
 		<java-delegate>javaDelegate#jsonRepair</java-delegate>
+		<labels>
+			<label language-id="en_US">
+				Repair Enriched Site Plan
+			</label>
+		</labels>
 		<output-variables>
 			<![CDATA[
 				[
@@ -617,11 +617,6 @@ Output:
 	</service>
 	<service>
 		<name>writeGenerationItems</name>
-		<labels>
-			<label language-id="en_US">
-				Write Generation Items
-			</label>
-		</labels>
 		<input-variables>
 			<![CDATA[
 				[
@@ -641,6 +636,11 @@ Output:
 			]]>
 		</input-variables>
 		<java-delegate>javaDelegate#writeCSGGenerationItems</java-delegate>
+		<labels>
+			<label language-id="en_US">
+				Write Generation Items
+			</label>
+		</labels>
 		<output-variables>
 			<![CDATA[
 				[


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96938

## What Is Being Fixed

Creating an AI Hub site failed during site initialization with "WorkflowDefinitionFileException: Unable to parse definition". The Site Builder workflow definition never deployed because its XML did not validate against the workflow schema.

## How It Is Being Fixed

The workflow schema (liferay-workflow-definition_7_4_0.xsd) defines the children of a service node as an ordered sequence in which labels must follow java-delegate. The four service nodes in site-builder-workflow-definition/workflow-definition.xml placed labels immediately after name, so Xerces rejected the document (cvc-complex-type.2.4.a on the labels element). Each service node now lists labels after java-delegate, matching the schema sequence, and the definition validates against the XSD.

## Why Are There No Tests?

The change only reorders elements in a static workflow-definition XML resource to satisfy the workflow XSD; there is no unit-testable logic, and correctness is verified by validating the resource against the schema.

## PR Check

**pr-check: PASS** — tested on `dbdbeb09d7e81061228293d0ff52b375a0f011ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "dbdbeb09d7e81061228293d0ff52b375a0f011ed"} -->
