### PR TITLE
LPD-96951 Update an agent definition using its original reference code

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
@@ -72,7 +72,10 @@ export function useAgentDefinitionForm({
 		onSubmit: async (formValues) => {
 			try {
 				const response = externalReferenceCode
-					? await putAgentDefinition(formValues)
+					? await putAgentDefinition(
+							formValues,
+							externalReferenceCode
+						)
 					: await postAgentDefinition(formValues);
 
 				if (formValues.externalReferenceCode) {

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -77,9 +77,12 @@ async function postAgentDefinition(agentDefinition: AgentDefinition) {
 	return response.json();
 }
 
-async function putAgentDefinition(agentDefinition: AgentDefinition) {
+async function putAgentDefinition(
+	agentDefinition: AgentDefinition,
+	externalReferenceCode: string
+) {
 	const response = await fetch(
-		`${AGENT_DEFINITION_BY_ERC_URI}${agentDefinition.externalReferenceCode}`,
+		`${AGENT_DEFINITION_BY_ERC_URI}${externalReferenceCode}`,
 		{
 			body: JSON.stringify(agentDefinition),
 			headers: {

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {getAgentDefinitions} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService';
+import {
+	getAgentDefinitions,
+	putAgentDefinition,
+} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService';
+import {AgentDefinition} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/types/AgentDefinition';
 
 const mockFetch = jest.fn();
 
@@ -58,6 +62,35 @@ describe('AgentDefinitionService', () => {
 			expect(mockFetch).toHaveBeenCalledWith(
 				BASE_URI,
 				expect.objectContaining({method: 'GET'})
+			);
+		});
+	});
+
+	describe('putAgentDefinition', () => {
+		it('uses the ERC argument as the URL path, not the one in the body', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({}),
+			});
+
+			const agentDefinition = {
+				active: true,
+				description: 'Description',
+				externalReferenceCode: 'NEW-AGENT-DEFINITION-ERC',
+				inputVariables: 'input',
+				outputVariable: 'output',
+				r_accountToAIHubAgentDefinitions_accountEntryERC: 'ACCOUNT-ERC',
+				title_i18n: {en_US: 'Title'},
+				workflowDefinitionName: 'workflow',
+			} as AgentDefinition;
+
+			await putAgentDefinition(agentDefinition, 'AGENT-DEFINITION-ERC');
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/o/ai-hub/agent-definitions/by-external-reference-code/AGENT-DEFINITION-ERC`,
+				expect.objectContaining({
+					body: JSON.stringify(agentDefinition),
+					method: 'PUT',
+				})
 			);
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96951

## What Is Being Fixed

Editing an agent definition failed to target the correct entity when its external reference code was changed in the form. The update request built its URL from the external reference code in the request body, so renaming the code pointed the request at a nonexistent resource instead of the agent being edited.

## How It Is Being Fixed

putAgentDefinition now takes the original external reference code as an explicit argument and uses it to build the request URL, while the request body still carries the possibly-changed values. The form hook passes the external reference code it loaded the agent with, so the update always targets the original entity regardless of edits to the code field. A Jest unit test asserts the request URL uses the original external reference code even when the body carries a new one.

## PR Check

**pr-check: PASS** — tested on `dd742fa8d9362027de6ead81eb50dee501230c15`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "dd742fa8d9362027de6ead81eb50dee501230c15"} -->
