### PR TITLE
LPD-96016 [BE] Create property to store the service account and apply to use in the chat models

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/configuration/VertexAIConfiguration.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/configuration/VertexAIConfiguration.java
@@ -31,4 +31,9 @@ public interface VertexAIConfiguration {
 	@Meta.AD(name = "project-id")
 	public String projectId();
 
+	@Meta.AD(
+		name = "service-account", required = false, type = Meta.Type.Password
+	)
+	public String serviceAccount();
+
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -5,6 +5,8 @@
 
 package com.liferay.ai.hub.internal.model;
 
+import com.google.auth.oauth2.GoogleCredentials;
+
 import com.liferay.ai.hub.configuration.VertexAIConfiguration;
 import com.liferay.ai.hub.internal.langchain4j.model.chat.listener.AIHubChatModelListenerImpl;
 import com.liferay.ai.hub.quota.QuotaManager;
@@ -18,6 +20,12 @@ import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiStreamingChatModel;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -45,6 +53,8 @@ public class VertexAiGeminiUtil {
 			VertexAiGeminiChatModel.builder();
 
 		_setAPIEndpoint(builder::apiEndpoint, vertexAIConfiguration.location());
+		_setCredentials(
+			builder::credentials, vertexAIConfiguration.serviceAccount());
 
 		return builder.listeners(
 			Collections.singletonList(
@@ -90,6 +100,8 @@ public class VertexAiGeminiUtil {
 			builder = VertexAiGeminiStreamingChatModel.builder();
 
 		_setAPIEndpoint(builder::apiEndpoint, location);
+		_setCredentials(
+			builder::credentials, vertexAIConfiguration.serviceAccount());
 
 		return builder.listeners(
 			Collections.singletonList(
@@ -116,6 +128,44 @@ public class VertexAiGeminiUtil {
 
 			apiEndpointConsumer.accept(
 				"aiplatform." + location + ".rep.googleapis.com");
+		}
+	}
+
+	private static void _setCredentials(
+			Consumer<GoogleCredentials> credentialsConsumer,
+			String serviceAccount)
+		throws ConfigurationException {
+
+		if (Validator.isNull(serviceAccount)) {
+			return;
+		}
+
+		String serviceAccountJSON = serviceAccount.trim();
+
+		try {
+			byte[] bytes = null;
+
+			if (serviceAccountJSON.startsWith("{")) {
+				bytes = serviceAccountJSON.getBytes(StandardCharsets.UTF_8);
+			}
+			else {
+				bytes = Base64.getMimeDecoder(
+				).decode(
+					serviceAccountJSON
+				);
+			}
+
+			credentialsConsumer.accept(
+				GoogleCredentials.fromStream(
+					new ByteArrayInputStream(bytes)
+				).createScoped(
+					Collections.singletonList(
+						"https://www.googleapis.com/auth/cloud-platform")
+				));
+		}
+		catch (IllegalArgumentException | IOException exception) {
+			throw new ConfigurationException(
+				"Unable to read the Vertex AI service account", exception);
 		}
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -306,6 +306,9 @@ public class AgentInstanceResourceTest
 							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
 						).put(
 							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+						).put(
+							"serviceAccount",
+							TestPropsValues.VERTEX_AI_SERVICE_ACCOUNT
 						).build())) {
 
 			_testPostAgentInstance();

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/MessageResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/MessageResourceTest.java
@@ -143,6 +143,9 @@ public class MessageResourceTest extends BaseMessageResourceTestCase {
 							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
 						).put(
 							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+						).put(
+							"serviceAccount",
+							TestPropsValues.VERTEX_AI_SERVICE_ACCOUNT
 						).build())) {
 
 			CountDownLatch countDownLatch1 = new CountDownLatch(4);
@@ -258,6 +261,9 @@ public class MessageResourceTest extends BaseMessageResourceTestCase {
 							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
 						).put(
 							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+						).put(
+							"serviceAccount",
+							TestPropsValues.VERTEX_AI_SERVICE_ACCOUNT
 						).build())) {
 
 			CountDownLatch countDownLatch1 = new CountDownLatch(4);

--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsUtil.java
@@ -110,7 +110,7 @@ public class TestPropsUtil {
 		"object.storage.sugarcrm.base.url", "object.storage.sugarcrm.client.id",
 		"object.storage.sugarcrm.grant.type",
 		"object.storage.sugarcrm.password", "object.storage.sugarcrm.username",
-		"vertex.ai.project.id");
+		"vertex.ai.project.id", "vertex.ai.service.account");
 	private static final TestPropsUtil _testPropsUtil = new TestPropsUtil();
 
 	private final Properties _props = new Properties();

--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
@@ -67,6 +67,9 @@ public class TestPropsValues {
 	public static final String VERTEX_AI_PROJECT_ID = TestPropsUtil.get(
 		"vertex.ai.project.id");
 
+	public static final String VERTEX_AI_SERVICE_ACCOUNT = TestPropsUtil.get(
+		"vertex.ai.service.account");
+
 	static {
 		String companyWebId = TestPropsUtil.get("company.web.id");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96016

## What Is Being Fixed

AI Hub authenticates to Google Vertex AI (Gemini) through Application Default Credentials, which only resolves when a Google service account is available in the environment (for example, an attached service account on Google Cloud). Deployments and CI that run outside such an environment have no way to supply Vertex AI credentials, so the chat models cannot authenticate.

## How It Is Being Fixed

An optional, company-scoped `service-account` property is added to `VertexAIConfiguration` as a `Password` field. When it is set, `VertexAiGeminiUtil` builds a `GoogleCredentials` from its value — accepting either the raw service-account key JSON or a base64 encoding of it, so it can be stored safely in a `.properties` file — scopes it to `cloud-platform`, and passes it to both the chat and streaming model builders via `credentials(...)`. When the property is left empty, credentials are not set and the client falls back to Application Default Credentials, so existing Google Cloud deployments are unaffected. The real-LLM integration tests are wired to read the service account from the new `vertex.ai.service.account` test property.

## Why Are There No Tests?

The service-account handling is credential wiring that only exercises meaningfully against live Google credentials. It is covered by the real-LLM integration tests (`MessageResourceTest`, `AgentInstanceResourceTest`), which are `@Ignore`d because they require Vertex AI credentials and run in the AI Hub daily-routine batch once those credentials are provisioned in CI.

## PR Check

**pr-check: PASS** — tested on `42b3e152c0f1f1139d09419b349f8c76fbe43dac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "42b3e152c0f1f1139d09419b349f8c76fbe43dac"} -->
