### PR TITLE
LPD-97140 Allow sorting agent definitions by date

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/odata/entity/v1_0/AgentDefinitionEntityModel.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/odata/entity/v1_0/AgentDefinitionEntityModel.java
@@ -5,7 +5,9 @@
 
 package com.liferay.ai.hub.rest.internal.odata.entity.v1_0;
 
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.odata.entity.BooleanEntityField;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 
@@ -38,7 +40,13 @@ public class AgentDefinitionEntityModel implements EntityModel {
 	@Activate
 	protected void activate() {
 		_entityFieldMap = EntityModel.toEntityFieldsMap(
-			new BooleanEntityField("active", locale -> "active"));
+			new BooleanEntityField("active", locale -> "active"),
+			new DateTimeEntityField(
+				"dateCreated", locale -> Field.CREATE_DATE,
+				locale -> Field.CREATE_DATE),
+			new DateTimeEntityField(
+				"dateModified", locale -> "modifiedDate",
+				locale -> "modifiedDate"));
 	}
 
 	private Map<String, EntityField> _entityFieldMap;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -69,6 +69,8 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -196,10 +198,26 @@ public class AgentDefinitionResourceTest
 		_testGetAgentDefinitionsPageWithPermissions();
 	}
 
+	@Override
+	@Test
+	public void testGetAgentDefinitionsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		_assertGetAgentDefinitionsPageFilteredByDateTime("dateCreated");
+		_assertGetAgentDefinitionsPageFilteredByDateTime("dateModified");
+	}
+
 	@Ignore
 	@Override
 	@Test
 	public void testGetAgentDefinitionsPageWithPagination() {
+	}
+
+	@Override
+	@Test
+	public void testGetAgentDefinitionsPageWithSortDateTime() throws Exception {
+		_assertGetAgentDefinitionsPageSortedByDateTime("dateCreated");
+		_assertGetAgentDefinitionsPageSortedByDateTime("dateModified");
 	}
 
 	@Override
@@ -452,6 +470,50 @@ public class AgentDefinitionResourceTest
 		Assert.assertEquals(expectedLabel, model.getLabel());
 		Assert.assertEquals(expectedName, model.getName());
 		Assert.assertEquals(expectedProviderLabel, model.getProviderLabel());
+	}
+
+	private void _assertGetAgentDefinitionsPageFilteredByDateTime(
+			String filterField)
+		throws Exception {
+
+		long totalCount = agentDefinitionResource.getAgentDefinitionsPage(
+			null, null, Pagination.of(1, 1), null
+		).getTotalCount();
+
+		Page<AgentDefinition> pastPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, filterField + " gt 2000-01-01T00:00:00Z",
+				Pagination.of(1, 1), null);
+
+		Assert.assertEquals(totalCount, pastPage.getTotalCount());
+
+		Page<AgentDefinition> futurePage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, filterField + " gt 3000-01-01T00:00:00Z",
+				Pagination.of(1, 1), null);
+
+		Assert.assertEquals(0, futurePage.getTotalCount());
+	}
+
+	private void _assertGetAgentDefinitionsPageSortedByDateTime(
+			String sortField)
+		throws Exception {
+
+		Page<AgentDefinition> ascPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":asc");
+
+		Page<AgentDefinition> descPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":desc");
+
+		List<AgentDefinition> agentDefinitions = new ArrayList<>(
+			(List<AgentDefinition>)descPage.getItems());
+
+		Collections.reverse(agentDefinitions);
+
+		assertEquals(
+			(List<AgentDefinition>)ascPage.getItems(), agentDefinitions);
 	}
 
 	private Page<AgentDefinition> _getAgentDefinitionsPageWithModel(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97140

## What Is Being Fixed

The AI Hub home "Latest Agents" widget failed to load. It requests `GET /o/ai-hub/v1.0/agent-definitions?sort=dateModified:desc`, which returned HTTP 400 "Unable to sort by property: dateModified", so newly created or duplicated agents never appeared. The custom `AgentDefinitionEntityModel` backing the `/v1.0/agent-definitions` resource only registered the `active` field, so the OData layer rejected sorting by date. `LPD-94314` switched the agent list from the Object endpoint (which sorts by date natively) to this custom resource, but the entity model was never updated. Chatbots were unaffected because their list still uses the Object endpoint.

## How It Is Being Fixed

Register `dateCreated` and `dateModified` as sortable `DateTimeEntityField`s in `AgentDefinitionEntityModel`, mapped to the `createDate`/`modifiedDate` columns, matching the generic object-entry entity model. An integration test asserts the agent definitions page can be sorted by both fields; `dateCreated`/`dateModified` are added to the ignored entity field names so the generated sort test doesn't try to set them on the DTO.

## PR Check

**pr-check: PASS** — tested on `f3cd8eb278c968bf205889adaaed2eecf63fc049`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f3cd8eb278c968bf205889adaaed2eecf63fc049"} -->
