### PR TITLE
LPD-97140 Allow sorting agent definitions by date

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/odata/entity/v1_0/AgentDefinitionEntityModel.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/odata/entity/v1_0/AgentDefinitionEntityModel.java
@@ -5,7 +5,9 @@
 
 package com.liferay.ai.hub.rest.internal.odata.entity.v1_0;
 
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.odata.entity.BooleanEntityField;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 
@@ -38,7 +40,13 @@ public class AgentDefinitionEntityModel implements EntityModel {
 	@Activate
 	protected void activate() {
 		_entityFieldMap = EntityModel.toEntityFieldsMap(
-			new BooleanEntityField("active", locale -> "active"));
+			new BooleanEntityField("active", locale -> "active"),
+			new DateTimeEntityField(
+				"dateCreated", locale -> Field.CREATE_DATE,
+				locale -> Field.CREATE_DATE),
+			new DateTimeEntityField(
+				"dateModified", locale -> "modifiedDate",
+				locale -> "modifiedDate"));
 	}
 
 	private Map<String, EntityField> _entityFieldMap;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -69,6 +69,8 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -196,10 +198,26 @@ public class AgentDefinitionResourceTest
 		_testGetAgentDefinitionsPageWithPermissions();
 	}
 
+	@Override
+	@Test
+	public void testGetAgentDefinitionsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		_assertGetAgentDefinitionsPageFilteredByDateTime("dateCreated");
+		_assertGetAgentDefinitionsPageFilteredByDateTime("dateModified");
+	}
+
 	@Ignore
 	@Override
 	@Test
 	public void testGetAgentDefinitionsPageWithPagination() {
+	}
+
+	@Override
+	@Test
+	public void testGetAgentDefinitionsPageWithSortDateTime() throws Exception {
+		_assertGetAgentDefinitionsPageSortedByDateTime("dateCreated");
+		_assertGetAgentDefinitionsPageSortedByDateTime("dateModified");
 	}
 
 	@Override
@@ -452,6 +470,50 @@ public class AgentDefinitionResourceTest
 		Assert.assertEquals(expectedLabel, model.getLabel());
 		Assert.assertEquals(expectedName, model.getName());
 		Assert.assertEquals(expectedProviderLabel, model.getProviderLabel());
+	}
+
+	private void _assertGetAgentDefinitionsPageFilteredByDateTime(
+			String filterField)
+		throws Exception {
+
+		long totalCount = agentDefinitionResource.getAgentDefinitionsPage(
+			null, null, Pagination.of(1, 1), null
+		).getTotalCount();
+
+		Page<AgentDefinition> pastPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, filterField + " gt 2000-01-01T00:00:00Z",
+				Pagination.of(1, 1), null);
+
+		Assert.assertEquals(totalCount, pastPage.getTotalCount());
+
+		Page<AgentDefinition> futurePage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, filterField + " gt 3000-01-01T00:00:00Z",
+				Pagination.of(1, 1), null);
+
+		Assert.assertEquals(0, futurePage.getTotalCount());
+	}
+
+	private void _assertGetAgentDefinitionsPageSortedByDateTime(
+			String sortField)
+		throws Exception {
+
+		Page<AgentDefinition> ascPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":asc");
+
+		Page<AgentDefinition> descPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":desc");
+
+		List<AgentDefinition> agentDefinitions = new ArrayList<>(
+			(List<AgentDefinition>)descPage.getItems());
+
+		Collections.reverse(agentDefinitions);
+
+		assertEquals(
+			(List<AgentDefinition>)ascPage.getItems(), agentDefinitions);
 	}
 
 	private Page<AgentDefinition> _getAgentDefinitionsPageWithModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -70,7 +70,6 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -201,28 +200,13 @@ public class AgentDefinitionResourceTest
 		_testGetAgentDefinitionsPageWithFilter();
 		_testGetAgentDefinitionsPageWithModel();
 		_testGetAgentDefinitionsPageWithPermissions();
-	}
-
-	@Override
-	@Test
-	public void testGetAgentDefinitionsPageWithFilterDateTimeEquals()
-		throws Exception {
-
-		_assertGetAgentDefinitionsPageFilteredByDateTime("dateCreated");
-		_assertGetAgentDefinitionsPageFilteredByDateTime("dateModified");
+		_testGetAgentDefinitionsPageWithSort();
 	}
 
 	@Ignore
 	@Override
 	@Test
 	public void testGetAgentDefinitionsPageWithPagination() {
-	}
-
-	@Override
-	@Test
-	public void testGetAgentDefinitionsPageWithSortDateTime() throws Exception {
-		_assertGetAgentDefinitionsPageSortedByDateTime("dateCreated");
-		_assertGetAgentDefinitionsPageSortedByDateTime("dateModified");
 	}
 
 	@Override
@@ -436,6 +420,10 @@ public class AgentDefinitionResourceTest
 		};
 	}
 
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[] {"dateCreated", "dateModified"};
+	}
+
 	@Override
 	protected AgentDefinition
 			testBatchEngineDeleteImportTask_addAgentDefinition()
@@ -475,50 +463,6 @@ public class AgentDefinitionResourceTest
 		Assert.assertEquals(expectedLabel, model.getLabel());
 		Assert.assertEquals(expectedName, model.getName());
 		Assert.assertEquals(expectedProviderLabel, model.getProviderLabel());
-	}
-
-	private void _assertGetAgentDefinitionsPageFilteredByDateTime(
-			String filterField)
-		throws Exception {
-
-		long totalCount = agentDefinitionResource.getAgentDefinitionsPage(
-			null, null, Pagination.of(1, 1), null
-		).getTotalCount();
-
-		Page<AgentDefinition> pastPage =
-			agentDefinitionResource.getAgentDefinitionsPage(
-				null, filterField + " gt 2000-01-01T00:00:00Z",
-				Pagination.of(1, 1), null);
-
-		Assert.assertEquals(totalCount, pastPage.getTotalCount());
-
-		Page<AgentDefinition> futurePage =
-			agentDefinitionResource.getAgentDefinitionsPage(
-				null, filterField + " gt 3000-01-01T00:00:00Z",
-				Pagination.of(1, 1), null);
-
-		Assert.assertEquals(0, futurePage.getTotalCount());
-	}
-
-	private void _assertGetAgentDefinitionsPageSortedByDateTime(
-			String sortField)
-		throws Exception {
-
-		Page<AgentDefinition> ascPage =
-			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":asc");
-
-		Page<AgentDefinition> descPage =
-			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":desc");
-
-		List<AgentDefinition> agentDefinitions = new ArrayList<>(
-			(List<AgentDefinition>)descPage.getItems());
-
-		Collections.reverse(agentDefinitions);
-
-		assertEquals(
-			(List<AgentDefinition>)ascPage.getItems(), agentDefinitions);
 	}
 
 	private Page<AgentDefinition> _getAgentDefinitionsPageWithModel(
@@ -576,6 +520,24 @@ public class AgentDefinitionResourceTest
 			ListUtil.filter(
 				_systemAgentDefinitions, AgentDefinition::getActive),
 			(List<AgentDefinition>)page.getItems());
+
+		// Date created
+
+		page = agentDefinitionResource.getAgentDefinitionsPage(
+			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null);
+
+		assertEquals(
+			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
+
+		// Date modified
+
+		page = agentDefinitionResource.getAgentDefinitionsPage(
+			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null);
+
+		assertEquals(
+			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
 	}
 
 	private void _testGetAgentDefinitionsPageWithModel() throws Exception {
@@ -670,6 +632,37 @@ public class AgentDefinitionResourceTest
 
 			Assert.assertTrue(actions.containsKey("permissions"));
 		}
+	}
+
+	private void _testGetAgentDefinitionsPageWithSort() throws Exception {
+
+		// Date created
+
+		_testGetAgentDefinitionsPageWithSort("dateCreated");
+
+		// Date modified
+
+		_testGetAgentDefinitionsPageWithSort("dateModified");
+	}
+
+	private void _testGetAgentDefinitionsPageWithSort(String sortField)
+		throws Exception {
+
+		Page<AgentDefinition> ascPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":asc");
+
+		Page<AgentDefinition> descPage =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 10), sortField + ":desc");
+
+		List<AgentDefinition> agentDefinitions = ListUtil.fromCollection(
+			descPage.getItems());
+
+		Collections.reverse(agentDefinitions);
+
+		assertEquals(
+			(List<AgentDefinition>)ascPage.getItems(), agentDefinitions);
 	}
 
 	private static AccountEntry _accountEntry;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -136,6 +137,10 @@ public class AgentDefinitionResourceTest
 		_accountEntryUserRelLocalService.addAccountEntryUserRel(
 			_aiHubAccountEntry.getAccountEntryId(),
 			TestPropsValues.getUserId());
+
+		_seoStudioAccountEntry =
+			_accountEntryLocalService.getAccountEntryByExternalReferenceCode(
+				"L_SEO_STUDIO", TestPropsValues.getCompanyId());
 	}
 
 	@AfterClass
@@ -556,7 +561,11 @@ public class AgentDefinitionResourceTest
 			agentDefinitionResource.getAgentDefinitionsPage(
 				null, "(active eq false)", Pagination.of(1, 10), null);
 
-		assertEquals(List.of(), (List<AgentDefinition>)page.getItems());
+		assertEquals(
+			ListUtil.filter(
+				_systemAgentDefinitions,
+				systemAgentDefinition -> !systemAgentDefinition.getActive()),
+			(List<AgentDefinition>)page.getItems());
 
 		// Active as true
 
@@ -564,7 +573,9 @@ public class AgentDefinitionResourceTest
 			null, "(active eq true)", Pagination.of(1, 10), null);
 
 		assertEquals(
-			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
+			ListUtil.filter(
+				_systemAgentDefinitions, AgentDefinition::getActive),
+			(List<AgentDefinition>)page.getItems());
 	}
 
 	private void _testGetAgentDefinitionsPageWithModel() throws Exception {
@@ -607,6 +618,8 @@ public class AgentDefinitionResourceTest
 
 		_accountEntryUserRelLocalService.addAccountEntryUserRel(
 			_aiHubAccountEntry.getAccountEntryId(), user.getUserId());
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			_seoStudioAccountEntry.getAccountEntryId(), user.getUserId());
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -676,12 +689,47 @@ public class AgentDefinitionResourceTest
 
 	private static String _originalName;
 	private static PermissionChecker _originalPermissionChecker;
+	private static AccountEntry _seoStudioAccountEntry;
 
 	@Inject
 	private static SiteInitializerRegistry _siteInitializerRegistry;
 
 	private static final List<AgentDefinition> _systemAgentDefinitions =
 		List.of(
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode = "L_AUTO_CATEGORIZE";
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "candidateCategories";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "content";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "count";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "suggestedCategories";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName = "Auto Categorize";
+				}
+			},
 			new AgentDefinition() {
 				{
 					active = true;
@@ -737,6 +785,40 @@ public class AgentDefinitionResourceTest
 					workflowDefinitionName =
 						WorkflowDefinitionConstants.
 							NAME_FIX_SPELLING_AND_GRAMMAR;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode = "L_GENERATE_TAGS";
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "content";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "count";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "existingTags";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "suggestedTags";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName = "Generate Tags";
 				}
 			},
 			new AgentDefinition() {
@@ -837,6 +919,56 @@ public class AgentDefinitionResourceTest
 					version = 1;
 					workflowDefinitionName =
 						WorkflowDefinitionConstants.NAME_MAKE_SHORTER;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode = "L_SEO_STUDIO_TITLE_GENERATOR";
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "pageContent";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "titleTag";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName = "SEO Studio Title Generator";
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = false;
+					externalReferenceCode = "L_SITE_BUILDER";
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "generationExternalReferenceCode";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "request";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "output";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName = "Site Builder";
 				}
 			});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97140

## What Is Being Fixed

The Latest Agents widget fails because agent definitions cannot be sorted by date. The agent definition REST entity model did not expose dateCreated or dateModified as sortable or filterable fields, so any request that sorted or filtered by them was rejected.

## How It Is Being Fixed

Register dateCreated and dateModified as DateTimeEntityField entries on the agent definition entity model, mapped to the createDate and modifiedDate columns, so the existing object entry query can sort and filter by them.

Exposing those fields caused several existing tests to run against data they no longer matched, so update them: complete the system agent definitions list, assert the active filter against the filtered subsets rather than an empty list, and add the permissions test user to both the AI Hub and SEO Studio accounts, since viewing an agent definition reads the workflow definition behind it and that read is granted through account membership. Finally, add targeted coverage that filters and sorts the definitions by dateCreated and dateModified.

## PR Check

**pr-check: PASS** — tested on `fd28c505bfe36664d636e4072c884e07ce6655a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "fd28c505bfe36664d636e4072c884e07ce6655a3"} -->
