### PR TITLE
LPD-96751 Give each AI Hub agent its own workflow via a draft lifecycle (backend)

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/AgentDefinitionManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/AgentDefinitionManager.java
@@ -44,4 +44,8 @@ public interface AgentDefinitionManager {
 			String externalReferenceCode)
 		throws Exception;
 
+	public AgentDefinition postAgentDefinitionDraft(
+			long companyId, DTOConverterContext dtoConverterContext)
+		throws Exception;
+
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/AgentDefinitionResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/AgentDefinitionResource.java
@@ -66,6 +66,8 @@ public interface AgentDefinitionResource {
 			String externalReferenceCode)
 		throws Exception;
 
+	public AgentDefinition postAgentDefinitionDraft() throws Exception;
+
 	public Response postAgentDefinitionsPageExportBatch(
 			String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,
@@ -169,4 +171,4 @@ public interface AgentDefinitionResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:909710946
+// LIFERAY-REST-BUILDER-HASH:-2115452187

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/AgentDefinitionResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/AgentDefinitionResource.java
@@ -72,6 +72,11 @@ public interface AgentDefinitionResource {
 				String externalReferenceCode)
 		throws Exception;
 
+	public AgentDefinition postAgentDefinitionDraft() throws Exception;
+
+	public HttpInvoker.HttpResponse postAgentDefinitionDraftHttpResponse()
+		throws Exception;
+
 	public void postAgentDefinitionsPageExportBatch(
 			String search, String filterString, String sortString,
 			String callbackURL, String contentType, String fieldNames)
@@ -651,6 +656,108 @@ public interface AgentDefinitionResource {
 			return httpInvoker.invoke();
 		}
 
+		public AgentDefinition postAgentDefinitionDraft() throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				postAgentDefinitionDraftHttpResponse();
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return AgentDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postAgentDefinitionDraftHttpResponse()
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/agent-definitions/draft");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void postAgentDefinitionsPageExportBatch(
 				String search, String filterString, String sortString,
 				String callbackURL, String contentType, String fieldNames)
@@ -789,4 +896,4 @@ public interface AgentDefinitionResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:47835231
+// LIFERAY-REST-BUILDER-HASH:-152261706

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -398,6 +398,19 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/AgentDefinition"
             tags: ["AgentDefinition"]
+    "/agent-definitions/draft":
+        post:
+            operationId: postAgentDefinitionDraft
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AgentDefinition"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/AgentDefinition"
+            tags: ["AgentDefinition"]
     "/agent-instances":
         post:
             operationId: postAgentInstance

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -47,6 +48,8 @@ import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
+
+import jakarta.ws.rs.BadRequestException;
 
 import java.util.Locale;
 import java.util.Map;
@@ -186,8 +189,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 			String externalReferenceCode)
 		throws Exception {
 
-		AccountEntry accountEntry = AccountEntryUtil.getUserAccountEntry(
-			dtoConverterContext.getUserId());
+		AccountEntry accountEntry = _getUserAccountEntry(dtoConverterContext);
 
 		ObjectDefinition objectDefinition = _getObjectDefinition(companyId);
 
@@ -207,14 +209,15 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 		String workflowDefinitionName = PortalUUIDUtil.generate();
 
-		_workflowDefinitionManager.deployWorkflowDefinition(
-			content.getBytes(), companyId, null,
-			accountEntry.getAccountEntryGroupId(), workflowDefinitionName,
-			WorkflowDefinitionConstants.SCOPE_AI,
-			LanguageUtil.format(
-				locale, "copy-of-x",
-				workflowDefinition.getTitle(locale.getDisplayLanguage())),
-			dtoConverterContext.getUserId());
+		WorkflowDefinition copiedWorkflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				content.getBytes(), companyId, null,
+				accountEntry.getAccountEntryGroupId(), workflowDefinitionName,
+				WorkflowDefinitionConstants.SCOPE_AI,
+				LanguageUtil.format(
+					locale, "copy-of-x",
+					workflowDefinition.getTitle(locale.getDisplayLanguage())),
+				dtoConverterContext.getUserId());
 
 		Map<String, String> title =
 			(Map<String, String>)objectEntry.getPropertyValue("title_i18n");
@@ -222,31 +225,39 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 		title.replaceAll(
 			(key, value) -> LanguageUtil.format(locale, "copy-of-x", value));
 
-		ObjectEntry copiedObjectEntry = _objectEntryManager.addObjectEntry(
-			dtoConverterContext, _getObjectDefinition(companyId),
-			new ObjectEntry() {
-				{
-					setProperties(
-						() -> Map.of(
-							"active",
-							GetterUtil.getBoolean(
-								objectEntry.getPropertyValue("active")),
-							"description",
-							GetterUtil.getString(
-								objectEntry.getPropertyValue("description")),
-							"inputVariables",
-							GetterUtil.getString(
-								objectEntry.getPropertyValue("inputVariables")),
-							"outputVariable",
-							GetterUtil.getString(
-								objectEntry.getPropertyValue("outputVariable")),
-							"r_accountToAIHubAgentDefinitions_accountEntryId",
-							accountEntry.getAccountEntryId(), "title_i18n",
-							title, "workflowDefinitionName",
-							workflowDefinitionName));
-				}
-			},
-			null);
+		ObjectEntry copiedObjectEntry = new ObjectEntry() {
+			{
+				setProperties(
+					() -> Map.of(
+						"active",
+						GetterUtil.getBoolean(
+							objectEntry.getPropertyValue("active")),
+						"description",
+						GetterUtil.getString(
+							objectEntry.getPropertyValue("description")),
+						"inputVariables",
+						GetterUtil.getString(
+							objectEntry.getPropertyValue("inputVariables")),
+						"outputVariable",
+						GetterUtil.getString(
+							objectEntry.getPropertyValue("outputVariable")),
+						"r_accountToAIHubAgentDefinitions_accountEntryId",
+						accountEntry.getAccountEntryId(), "title_i18n", title,
+						"workflowDefinitionName", workflowDefinitionName));
+			}
+		};
+
+		try {
+			copiedObjectEntry = _objectEntryManager.addObjectEntry(
+				dtoConverterContext, _getObjectDefinition(companyId),
+				copiedObjectEntry, null);
+		}
+		catch (Exception exception) {
+			_undeployWorkflowDefinition(
+				dtoConverterContext, copiedWorkflowDefinition);
+
+			throw exception;
+		}
 
 		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.getObjectRelationship(
@@ -275,6 +286,58 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 		return _toAgentDefinition(
 			companyId, dtoConverterContext, copiedObjectEntry);
+	}
+
+	@Override
+	public AgentDefinition postAgentDefinitionDraft(
+			long companyId, DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		AccountEntry accountEntry = _getUserAccountEntry(dtoConverterContext);
+
+		String workflowDefinitionContent = _getWorkflowDefinitionContent();
+
+		String workflowDefinitionName = PortalUUIDUtil.generate();
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				workflowDefinitionContent.getBytes(), companyId, null,
+				accountEntry.getAccountEntryGroupId(), workflowDefinitionName,
+				WorkflowDefinitionConstants.SCOPE_AI,
+				_language.get(
+					dtoConverterContext.getLocale(), "untitled-workflow"),
+				dtoConverterContext.getUserId());
+
+		ObjectEntry objectEntry = new ObjectEntry() {
+			{
+				setProperties(
+					() -> Map.of(
+						"active", false,
+						"r_accountToAIHubAgentDefinitions_accountEntryId",
+						accountEntry.getAccountEntryId(),
+						"workflowDefinitionName", workflowDefinitionName));
+				setStatus(
+					() -> new com.liferay.object.rest.dto.v1_0.Status() {
+						{
+							setCode(() -> WorkflowConstants.STATUS_DRAFT);
+						}
+					});
+			}
+		};
+
+		try {
+			objectEntry = _objectEntryManager.addObjectEntry(
+				dtoConverterContext, _getObjectDefinition(companyId),
+				objectEntry, null);
+		}
+		catch (Exception exception) {
+			_undeployWorkflowDefinition(
+				dtoConverterContext, workflowDefinition);
+
+			throw exception;
+		}
+
+		return _toAgentDefinition(companyId, dtoConverterContext, objectEntry);
 	}
 
 	private Map<String, String> _addAction(
@@ -342,7 +405,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 	}
 
 	private Status _getStatus(
-		DTOConverterContext dtoConverterContext,
+		DTOConverterContext dtoConverterContext, ObjectEntry objectEntry,
 		WorkflowDefinition workflowDefinition) {
 
 		if (dtoConverterContext == null) {
@@ -351,11 +414,42 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 		Locale locale = dtoConverterContext.getLocale();
 
+		com.liferay.object.rest.dto.v1_0.Status status =
+			objectEntry.getStatus();
+
+		if ((status != null) &&
+			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
+
+			return _toStatus("draft", locale);
+		}
+
 		if ((workflowDefinition != null) && workflowDefinition.isActive()) {
 			return _toStatus("active", locale);
 		}
 
 		return _toStatus("inactive", locale);
+	}
+
+	private AccountEntry _getUserAccountEntry(
+			DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		AccountEntry accountEntry = AccountEntryUtil.getUserAccountEntry(
+			dtoConverterContext.getUserId());
+
+		if (accountEntry == null) {
+			throw new BadRequestException(
+				"The current user is not associated with an AI Hub account");
+		}
+
+		return accountEntry;
+	}
+
+	private String _getWorkflowDefinitionContent() throws Exception {
+		return StringUtil.read(
+			AgentDefinitionManagerImpl.class.getClassLoader(),
+			"com/liferay/ai/hub/rest/internal/manager/v1_0/dependencies" +
+				"/workflow-definition.xml");
 	}
 
 	private boolean _hasAgentDefinitionWithWorkflowDefinitionName(
@@ -483,7 +577,8 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 						GetterUtil.getString(
 							objectEntry.getPropertyValue("outputVariable"))));
 				setStatus(
-					() -> _getStatus(dtoConverterContext, workflowDefinition));
+					() -> _getStatus(
+						dtoConverterContext, objectEntry, workflowDefinition));
 				setSystem(
 					() -> GetterUtil.getBoolean(
 						objectEntry.getPropertyValue("system")));
@@ -548,6 +643,31 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 				setType(() -> "string");
 			}
 		};
+	}
+
+	private void _undeployWorkflowDefinition(
+		DTOConverterContext dtoConverterContext,
+		WorkflowDefinition workflowDefinition) {
+
+		try {
+			_workflowDefinitionManager.updateActive(
+				false, workflowDefinition.getCompanyId(),
+				workflowDefinition.getName(), dtoConverterContext.getUserId(),
+				workflowDefinition.getVersion());
+
+			_workflowDefinitionManager.undeployWorkflowDefinition(
+				workflowDefinition.getCompanyId(), workflowDefinition.getName(),
+				dtoConverterContext.getUserId(),
+				workflowDefinition.getVersion());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to undeploy orphaned workflow definition " +
+						workflowDefinition.getName(),
+					exception);
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
@@ -27,6 +27,8 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -70,16 +72,26 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 			companyId, dtoConverterContext, externalReferenceCode,
 			_getObjectDefinition(companyId), null);
 
+		String workflowDefinitionName = GetterUtil.getString(
+			objectEntry.getPropertyValue("workflowDefinitionName"));
+
 		_objectEntryManager.deleteObjectEntry(
 			companyId, dtoConverterContext,
 			objectEntry.getExternalReferenceCode(),
 			_getObjectDefinition(companyId), null);
 
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.getLatestWorkflowDefinition(
-				companyId,
-				GetterUtil.getString(
-					objectEntry.getPropertyValue("workflowDefinitionName")));
+		if (_hasAgentDefinitionWithWorkflowDefinitionName(
+				companyId, dtoConverterContext, workflowDefinitionName)) {
+
+			return;
+		}
+
+		WorkflowDefinition workflowDefinition = _fetchLatestWorkflowDefinition(
+			companyId, workflowDefinitionName);
+
+		if (workflowDefinition == null) {
+			return;
+		}
 
 		_workflowDefinitionManager.updateActive(
 			false, workflowDefinition.getCompanyId(),
@@ -290,6 +302,29 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 			dtoConverterContext.getUriInfo());
 	}
 
+	private WorkflowDefinition _fetchLatestWorkflowDefinition(
+		long companyId, String workflowDefinitionName) {
+
+		if (Validator.isNull(workflowDefinitionName)) {
+			return null;
+		}
+
+		try {
+			return _workflowDefinitionManager.getLatestWorkflowDefinition(
+				companyId, workflowDefinitionName);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get the latest workflow definition with name " +
+						workflowDefinitionName,
+					exception);
+			}
+
+			return null;
+		}
+	}
+
 	private String _getFilterString(String filterString) {
 		if (Validator.isNull(filterString)) {
 			return "externalReferenceCode ne 'L_PAGE_BUILDER'";
@@ -316,11 +351,36 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 		Locale locale = dtoConverterContext.getLocale();
 
-		if (workflowDefinition.isActive()) {
+		if ((workflowDefinition != null) && workflowDefinition.isActive()) {
 			return _toStatus("active", locale);
 		}
 
 		return _toStatus("inactive", locale);
+	}
+
+	private boolean _hasAgentDefinitionWithWorkflowDefinitionName(
+			long companyId, DTOConverterContext dtoConverterContext,
+			String workflowDefinitionName)
+		throws Exception {
+
+		if (Validator.isNull(workflowDefinitionName)) {
+			return false;
+		}
+
+		Page<ObjectEntry> objectEntriesPage =
+			_objectEntryManager.getObjectEntries(
+				companyId, _getObjectDefinition(companyId), null, null,
+				dtoConverterContext,
+				"workflowDefinitionName eq '" +
+					StringUtil.replace(workflowDefinitionName, '\'', "''") +
+						"'",
+				Pagination.of(1, 1), null, null);
+
+		if (objectEntriesPage.getTotalCount() > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private AgentDefinition _toAgentDefinition(
@@ -328,17 +388,19 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 			ObjectEntry objectEntry)
 		throws PortalException {
 
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.getLatestWorkflowDefinition(
-				companyId,
-				GetterUtil.getString(
-					objectEntry.getPropertyValue("workflowDefinitionName")));
+		String workflowDefinitionName = GetterUtil.getString(
+			objectEntry.getPropertyValue("workflowDefinitionName"));
+
+		WorkflowDefinition workflowDefinition = _fetchLatestWorkflowDefinition(
+			companyId, workflowDefinitionName);
 
 		return new AgentDefinition() {
 			{
 				setActions(
 					() -> {
-						if (dtoConverterContext == null) {
+						if ((dtoConverterContext == null) ||
+							(workflowDefinition == null)) {
+
 							return null;
 						}
 
@@ -428,8 +490,22 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 				setTitle(
 					() -> GetterUtil.getString(
 						objectEntry.getPropertyValue("title")));
-				setVersion(workflowDefinition::getVersion);
-				setWorkflowDefinitionName(workflowDefinition::getName);
+				setVersion(
+					() -> {
+						if (workflowDefinition == null) {
+							return null;
+						}
+
+						return workflowDefinition.getVersion();
+					});
+				setWorkflowDefinitionName(
+					() -> {
+						if (workflowDefinition == null) {
+							return workflowDefinitionName;
+						}
+
+						return workflowDefinition.getName();
+					});
 			}
 		};
 	}
@@ -473,6 +549,9 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 			}
 		};
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AgentDefinitionManagerImpl.class);
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/AgentDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/AgentDefinitionResourceImpl.java
@@ -106,6 +106,18 @@ public class AgentDefinitionResourceImpl
 			externalReferenceCode);
 	}
 
+	@Override
+	public AgentDefinition postAgentDefinitionDraft() throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		return _agentDefinitionManager.postAgentDefinitionDraft(
+			contextCompany.getCompanyId(), _createDTOConverterContext());
+	}
+
 	private DTOConverterContext _createDTOConverterContext() {
 		return new DefaultDTOConverterContext(
 			contextAcceptLanguage.isAcceptAllLanguages(), null,

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseAgentDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseAgentDefinitionResourceImpl.java
@@ -231,6 +231,24 @@ public abstract class BaseAgentDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/agent-definitions/draft'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "AgentDefinition")
+		}
+	)
+	@jakarta.ws.rs.Path("/agent-definitions/draft")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public AgentDefinition postAgentDefinitionDraft() throws Exception {
+		return new AgentDefinition();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/agent-definitions/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -994,4 +1012,4 @@ public abstract class BaseAgentDefinitionResourceImpl
 		LogFactoryUtil.getLog(BaseAgentDefinitionResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1557361672
+// LIFERAY-REST-BUILDER-HASH:1504049273

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/com/liferay/ai/hub/rest/internal/manager/v1_0/dependencies/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/com/liferay/ai/hub/rest/internal/manager/v1_0/dependencies/workflow-definition.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Untitled Workflow</name>
+	<version>1</version>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						100
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						273,
+						300
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.ai.hub.configuration.VertexAIConfiguration;
 import com.liferay.ai.hub.rest.client.dto.v1_0.AgentDefinition;
 import com.liferay.ai.hub.rest.client.dto.v1_0.Model;
+import com.liferay.ai.hub.rest.client.dto.v1_0.Status;
 import com.liferay.ai.hub.rest.client.dto.v1_0.Variable;
 import com.liferay.ai.hub.rest.client.pagination.Page;
 import com.liferay.ai.hub.rest.client.pagination.Pagination;
@@ -23,7 +24,6 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -372,6 +372,85 @@ public class AgentDefinitionResourceTest
 			NestedFieldsContextThreadLocal.setNestedFieldsContext(
 				nestedFieldsContext);
 		}
+	}
+
+	@Override
+	@Test
+	public void testPostAgentDefinitionDraft() throws Exception {
+		AgentDefinition agentDefinition =
+			agentDefinitionResource.postAgentDefinitionDraft();
+
+		Assert.assertFalse(agentDefinition.getActive());
+
+		Status status = agentDefinition.getStatus();
+
+		Assert.assertEquals("draft", status.getLabel());
+
+		String workflowDefinitionName =
+			agentDefinition.getWorkflowDefinitionName();
+
+		Assert.assertNotNull(workflowDefinitionName);
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(
+				TestPropsValues.getCompanyId(), workflowDefinitionName, 1);
+
+		Assert.assertEquals(
+			_accountEntry.getAccountEntryGroupId(),
+			workflowDefinition.getGroupId());
+
+		ObjectEntry objectEntry = _objectEntryManager.getObjectEntry(
+			TestPropsValues.getCompanyId(), _dtoConverterContext,
+			agentDefinition.getExternalReferenceCode(), _getObjectDefinition(),
+			null);
+
+		com.liferay.object.rest.dto.v1_0.Status objectEntryStatus =
+			objectEntry.getStatus();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, (int)objectEntryStatus.getCode());
+
+		_objectEntryManager.updateObjectEntry(
+			TestPropsValues.getCompanyId(), _dtoConverterContext,
+			agentDefinition.getExternalReferenceCode(), _getObjectDefinition(),
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"active", true
+					).put(
+						"description", RandomTestUtil.randomString()
+					).put(
+						"inputVariables", "text"
+					).put(
+						"outputVariable", "result"
+					).put(
+						"r_accountToAIHubAgentDefinitions_accountEntryId",
+						_accountEntry.getAccountEntryId()
+					).put(
+						"title_i18n",
+						HashMapBuilder.put(
+							"en_US", RandomTestUtil.randomString()
+						).build()
+					).put(
+						"workflowDefinitionName", workflowDefinitionName
+					).build();
+				}
+			},
+			null);
+
+		objectEntry = _objectEntryManager.getObjectEntry(
+			TestPropsValues.getCompanyId(), _dtoConverterContext,
+			agentDefinition.getExternalReferenceCode(), _getObjectDefinition(),
+			null);
+
+		objectEntryStatus = objectEntry.getStatus();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED,
+			(int)objectEntryStatus.getCode());
+
+		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
+			agentDefinition.getExternalReferenceCode());
 	}
 
 	@Override
@@ -890,9 +969,6 @@ public class AgentDefinitionResourceTest
 
 	@Inject(filter = "object.entry.manager.storage.type=default")
 	private ObjectEntryManager _objectEntryManager;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -71,6 +71,7 @@ import java.time.format.DateTimeFormatter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -150,41 +151,8 @@ public class AgentDefinitionResourceTest
 	public void testDeleteAgentDefinitionByExternalReferenceCode()
 		throws Exception {
 
-		AgentDefinition agentDefinition = _addAgentDefinition();
-
-		ObjectDefinition objectDefinition = _getObjectDefinition();
-
-		ObjectEntry objectEntry = _objectEntryManager.getObjectEntry(
-			TestPropsValues.getCompanyId(), _dtoConverterContext,
-			agentDefinition.getExternalReferenceCode(), objectDefinition, null);
-
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.getWorkflowDefinition(
-				TestPropsValues.getCompanyId(),
-				agentDefinition.getWorkflowDefinitionName(), 1);
-
-		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
-			agentDefinition.getExternalReferenceCode());
-
-		AssertUtils.assertFailure(
-			NoSuchObjectEntryException.class,
-			StringBundler.concat(
-				"No ObjectEntry exists with the key {externalReferenceCode=",
-				objectEntry.getExternalReferenceCode(),
-				", groupId=0, companyId=", TestPropsValues.getCompanyId(),
-				", objectDefinitionId=",
-				objectDefinition.getObjectDefinitionId(), "}"),
-			() -> _objectEntryManager.getObjectEntry(
-				TestPropsValues.getCompanyId(), _dtoConverterContext,
-				agentDefinition.getExternalReferenceCode(), objectDefinition,
-				null));
-		AssertUtils.assertFailure(
-			NoSuchWorkflowDefinitionException.class,
-			NoSuchDefinitionException.class.getName() +
-				": No KaleoDefinition exists with the primary key " +
-					workflowDefinition.getWorkflowDefinitionId(),
-			() -> _workflowDefinitionManager.getWorkflowDefinition(
-				workflowDefinition.getWorkflowDefinitionId()));
+		_testDeleteAgentDefinitionByExternalReferenceCode();
+		_testDeleteAgentDefinitionByExternalReferenceCodeWithSharedWorkflowDefinition();
 	}
 
 	@Override
@@ -192,6 +160,7 @@ public class AgentDefinitionResourceTest
 	public void testGetAgentDefinitionsPage() throws Exception {
 		_testGetAgentDefinitionsPage();
 		_testGetAgentDefinitionsPageWithFilter();
+		_testGetAgentDefinitionsPageWithMissingWorkflowDefinition();
 		_testGetAgentDefinitionsPageWithModel();
 		_testGetAgentDefinitionsPageWithPermissions();
 	}
@@ -443,6 +412,38 @@ public class AgentDefinitionResourceTest
 					EXTERNAL_REFERENCE_CODE_CHANGE_TONE);
 	}
 
+	private ObjectEntry _addAgentDefinitionObjectEntry(
+			String workflowDefinitionName)
+		throws Exception {
+
+		return _objectEntryManager.addObjectEntry(
+			_dtoConverterContext, _getObjectDefinition(),
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"active", true
+					).put(
+						"description", RandomTestUtil.randomString()
+					).put(
+						"inputVariables", "text"
+					).put(
+						"outputVariable", "rewrittenText"
+					).put(
+						"r_accountToAIHubAgentDefinitions_accountEntryId",
+						_aiHubAccountEntry.getAccountEntryId()
+					).put(
+						"title_i18n",
+						HashMapBuilder.put(
+							"en_US", RandomTestUtil.randomString()
+						).build()
+					).put(
+						"workflowDefinitionName", workflowDefinitionName
+					).build();
+				}
+			},
+			null);
+	}
+
 	private void _assertAgentDefinitionModel(
 		String expectedLabel, String expectedName, String expectedProviderLabel,
 		AgentDefinition agentDefinition) {
@@ -477,6 +478,82 @@ public class AgentDefinitionResourceTest
 			TestPropsValues.getCompanyId(), "AIHubAgentDefinition");
 	}
 
+	private void _testDeleteAgentDefinitionByExternalReferenceCode()
+		throws Exception {
+
+		AgentDefinition agentDefinition = _addAgentDefinition();
+
+		ObjectDefinition objectDefinition = _getObjectDefinition();
+
+		ObjectEntry objectEntry = _objectEntryManager.getObjectEntry(
+			TestPropsValues.getCompanyId(), _dtoConverterContext,
+			agentDefinition.getExternalReferenceCode(), objectDefinition, null);
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(
+				TestPropsValues.getCompanyId(),
+				agentDefinition.getWorkflowDefinitionName(), 1);
+
+		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
+			agentDefinition.getExternalReferenceCode());
+
+		AssertUtils.assertFailure(
+			NoSuchObjectEntryException.class,
+			StringBundler.concat(
+				"No ObjectEntry exists with the key {externalReferenceCode=",
+				objectEntry.getExternalReferenceCode(),
+				", groupId=0, companyId=", TestPropsValues.getCompanyId(),
+				", objectDefinitionId=",
+				objectDefinition.getObjectDefinitionId(), "}"),
+			() -> _objectEntryManager.getObjectEntry(
+				TestPropsValues.getCompanyId(), _dtoConverterContext,
+				agentDefinition.getExternalReferenceCode(), objectDefinition,
+				null));
+		AssertUtils.assertFailure(
+			NoSuchWorkflowDefinitionException.class,
+			NoSuchDefinitionException.class.getName() +
+				": No KaleoDefinition exists with the primary key " +
+					workflowDefinition.getWorkflowDefinitionId(),
+			() -> _workflowDefinitionManager.getWorkflowDefinition(
+				workflowDefinition.getWorkflowDefinitionId()));
+	}
+
+	private void _testDeleteAgentDefinitionByExternalReferenceCodeWithSharedWorkflowDefinition()
+		throws Exception {
+
+		AgentDefinition agentDefinition = _addAgentDefinition();
+
+		String workflowDefinitionName =
+			agentDefinition.getWorkflowDefinitionName();
+
+		ObjectEntry objectEntry = _addAgentDefinitionObjectEntry(
+			workflowDefinitionName);
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(
+				TestPropsValues.getCompanyId(), workflowDefinitionName, 1);
+
+		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
+			agentDefinition.getExternalReferenceCode());
+
+		WorkflowDefinition latestWorkflowDefinition =
+			_workflowDefinitionManager.getLatestWorkflowDefinition(
+				TestPropsValues.getCompanyId(), workflowDefinitionName);
+
+		Assert.assertTrue(latestWorkflowDefinition.isActive());
+
+		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
+			objectEntry.getExternalReferenceCode());
+
+		AssertUtils.assertFailure(
+			NoSuchWorkflowDefinitionException.class,
+			NoSuchDefinitionException.class.getName() +
+				": No KaleoDefinition exists with the primary key " +
+					workflowDefinition.getWorkflowDefinitionId(),
+			() -> _workflowDefinitionManager.getWorkflowDefinition(
+				workflowDefinition.getWorkflowDefinitionId()));
+	}
+
 	private void _testGetAgentDefinitionsPage() throws Exception {
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
@@ -503,6 +580,36 @@ public class AgentDefinitionResourceTest
 
 		assertEquals(
 			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
+	}
+
+	private void _testGetAgentDefinitionsPageWithMissingWorkflowDefinition()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addAgentDefinitionObjectEntry(
+			RandomTestUtil.randomString());
+
+		Page<AgentDefinition> page =
+			agentDefinitionResource.getAgentDefinitionsPage(
+				null, null, Pagination.of(1, 20), null);
+
+		AgentDefinition agentDefinition = null;
+
+		for (AgentDefinition curAgentDefinition : page.getItems()) {
+			if (Objects.equals(
+					curAgentDefinition.getExternalReferenceCode(),
+					objectEntry.getExternalReferenceCode())) {
+
+				agentDefinition = curAgentDefinition;
+
+				break;
+			}
+		}
+
+		Assert.assertNotNull(agentDefinition);
+		Assert.assertNull(agentDefinition.getVersion());
+
+		agentDefinitionResource.deleteAgentDefinitionByExternalReferenceCode(
+			objectEntry.getExternalReferenceCode());
 	}
 
 	private void _testGetAgentDefinitionsPageWithModel() throws Exception {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseAgentDefinitionResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseAgentDefinitionResourceTestCase.java
@@ -631,6 +631,26 @@ public abstract class BaseAgentDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testPostAgentDefinitionDraft() throws Exception {
+		AgentDefinition randomAgentDefinition = randomAgentDefinition();
+
+		AgentDefinition postAgentDefinition =
+			testPostAgentDefinitionDraft_addAgentDefinition(
+				randomAgentDefinition);
+
+		assertEquals(randomAgentDefinition, postAgentDefinition);
+		assertValid(postAgentDefinition);
+	}
+
+	protected AgentDefinition testPostAgentDefinitionDraft_addAgentDefinition(
+			AgentDefinition agentDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		AgentDefinition agentDefinition1 =
 			testBatchEngineDeleteImportTask_addAgentDefinition();
@@ -1782,4 +1802,4 @@ public abstract class BaseAgentDefinitionResourceTestCase {
 		_agentDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-357511421
+// LIFERAY-REST-BUILDER-HASH:-1610169972

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/agent-definition-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/agent-definition-object-definition.json
@@ -4,6 +4,7 @@
 	"className": "com.liferay.object.model.ObjectDefinition#P8M2",
 	"enableFormContainer": false,
 	"enableIndexSearch": true,
+	"enableObjectEntryDraft": true,
 	"enableObjectEntryHistory": true,
 	"externalReferenceCode": "L_AI_HUB_AGENT_DEFINITION",
 	"friendlyURLSeparator": "l",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96745
https://liferay.atlassian.net/browse/LPD-96751

This is the **backend** half of the agent draft lifecycle, split out from #579 per review. The **frontend** changes (Create Agent screen, Save as Draft / Publish actions, the listing Draft badge and "Untitled Agent" fallback) follow in a separate PR that depends on this one.

## What Is Being Fixed

AI Hub agents shared workflow definitions, so an agent's lifecycle was not
self-contained. In particular, deleting an agent cascade-deleted a workflow
that other agents still referenced, which broke the agent listing for those
agents.

## How It Is Being Fixed

Each agent now owns its own workflow. A new `POST /agent-definitions/draft`
endpoint mints a draft agent (status draft, enabled via the object
definition's draft support) together with a freshly deployed per-agent seed
workflow.

Deletion is now reference-counted: an agent's workflow is undeployed only when
the last agent referencing it is removed, which fixes the cascade. The listing
renders agents whose workflow is missing instead of failing. The copy flow
deploys a fresh workflow for the copied agent and rolls it back if the agent
entry cannot be created, matching the draft flow.

All of the above is gated behind the `LPD-62272` feature flag, and the new
endpoint has no caller until the frontend ships, so this half is safe to merge
on its own.

## PR Check

**pr-check: PASS** — tested on `b522c3e506461cdc501c57056b9b6ca79368ad7b`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b522c3e506461cdc501c57056b9b6ca79368ad7b"} -->
