### PR TITLE
LPD-95685 Return the chatbot avatar as an object

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/Chatbot.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/Chatbot.java
@@ -18,6 +18,8 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import jakarta.annotation.Generated;
 
+import jakarta.validation.Valid;
+
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.io.Serializable;
@@ -88,7 +90,8 @@ public class Chatbot implements Serializable {
 	private Supplier<Boolean> _activeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
-	public String getAvatar() {
+	@Valid
+	public Map<String, ?> getAvatar() {
 		if (_avatarSupplier != null) {
 			avatar = _avatarSupplier.get();
 
@@ -98,7 +101,7 @@ public class Chatbot implements Serializable {
 		return avatar;
 	}
 
-	public void setAvatar(String avatar) {
+	public void setAvatar(Map<String, ?> avatar) {
 		this.avatar = avatar;
 
 		_avatarSupplier = null;
@@ -106,7 +109,7 @@ public class Chatbot implements Serializable {
 
 	@JsonIgnore
 	public void setAvatar(
-		UnsafeSupplier<String, Exception> avatarUnsafeSupplier) {
+		UnsafeSupplier<Map<String, ?>, Exception> avatarUnsafeSupplier) {
 
 		_avatarSupplier = () -> {
 			try {
@@ -123,10 +126,10 @@ public class Chatbot implements Serializable {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
-	protected String avatar;
+	protected Map<String, ?> avatar;
 
 	@JsonIgnore
-	private Supplier<String> _avatarSupplier;
+	private Supplier<Map<String, ?>> _avatarSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public String getDisclaimerMessage() {
@@ -413,7 +416,7 @@ public class Chatbot implements Serializable {
 			sb.append(active);
 		}
 
-		String avatar = getAvatar();
+		Map<String, ?> avatar = getAvatar();
 
 		if (avatar != null) {
 			if (sb.length() > 1) {
@@ -422,11 +425,7 @@ public class Chatbot implements Serializable {
 
 			sb.append("\"avatar\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(avatar));
-
-			sb.append("\"");
+			sb.append(_toJSON(avatar));
 		}
 
 		String disclaimerMessage = getDisclaimerMessage();
@@ -626,4 +625,4 @@ public class Chatbot implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1626177627
+// LIFERAY-REST-BUILDER-HASH:2078847285

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/Chatbot.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/Chatbot.java
@@ -12,6 +12,7 @@ import jakarta.annotation.Generated;
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -46,16 +47,16 @@ public class Chatbot implements Cloneable, Serializable {
 
 	protected Boolean active;
 
-	public String getAvatar() {
+	public Map<String, ?> getAvatar() {
 		return avatar;
 	}
 
-	public void setAvatar(String avatar) {
+	public void setAvatar(Map<String, ?> avatar) {
 		this.avatar = avatar;
 	}
 
 	public void setAvatar(
-		UnsafeSupplier<String, Exception> avatarUnsafeSupplier) {
+		UnsafeSupplier<Map<String, ?>, Exception> avatarUnsafeSupplier) {
 
 		try {
 			avatar = avatarUnsafeSupplier.get();
@@ -65,7 +66,7 @@ public class Chatbot implements Cloneable, Serializable {
 		}
 	}
 
-	protected String avatar;
+	protected Map<String, ?> avatar;
 
 	public String getDisclaimerMessage() {
 		return disclaimerMessage;
@@ -225,4 +226,4 @@ public class Chatbot implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-387793772
+// LIFERAY-REST-BUILDER-HASH:-1342302770

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ChatbotSerDes.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/ChatbotSerDes.java
@@ -61,11 +61,7 @@ public class ChatbotSerDes {
 
 			sb.append("\"avatar\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(chatbot.getAvatar()));
-
-			sb.append("\"");
+			sb.append(_toJSON(chatbot.getAvatar()));
 		}
 
 		if (chatbot.getDisclaimerMessage() != null) {
@@ -255,7 +251,7 @@ public class ChatbotSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "avatar")) {
-				return false;
+				return true;
 			}
 			else if (Objects.equals(jsonParserFieldName, "disclaimerMessage")) {
 				return false;
@@ -297,7 +293,7 @@ public class ChatbotSerDes {
 			}
 			else if (Objects.equals(jsonParserFieldName, "avatar")) {
 				if (jsonParserFieldValue != null) {
-					chatbot.setAvatar((String)jsonParserFieldValue);
+					chatbot.setAvatar((Map<String, ?>)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "disclaimerMessage")) {
@@ -419,4 +415,4 @@ public class ChatbotSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1527032100
+// LIFERAY-REST-BUILDER-HASH:-1593085211

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -73,8 +73,9 @@ components:
                 active:
                     type: boolean
                 avatar:
+                    additionalProperties: true
                     readOnly: true
-                    type: string
+                    type: object
                 disclaimerMessage:
                     readOnly: true
                     type: string

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ChatbotResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ChatbotResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.rest.internal.resource.v1_0;
 import com.liferay.ai.hub.rest.dto.v1_0.Chatbot;
 import com.liferay.ai.hub.rest.resource.v1_0.ChatbotResource;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
+import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import java.util.Map;
 
@@ -59,11 +61,12 @@ public class ChatbotResourceImpl extends BaseChatbotResourceImpl {
 				() -> {
 					Object avatar = objectEntry.getPropertyValue("avatar");
 
-					if (avatar instanceof Map avatarMap) {
-						return GetterUtil.getString(avatarMap.get("fileURL"));
+					if (avatar instanceof FileEntry fileEntry) {
+						return ObjectMapperUtil.readValue(
+							Map.class, fileEntry.toString());
 					}
 
-					return GetterUtil.getString(avatar);
+					return null;
 				});
 			chatbot.setDisclaimerMessage(
 				() -> GetterUtil.getString(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/build.gradle
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:ai-hub-cell:ai-hub-cell-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-api")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseChatbotResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseChatbotResourceTestCase.java
@@ -167,7 +167,6 @@ public abstract class BaseChatbotResourceTestCase {
 
 		Chatbot chatbot = randomChatbot();
 
-		chatbot.setAvatar(regex);
 		chatbot.setDisclaimerMessage(regex);
 		chatbot.setExternalReferenceCode(regex);
 		chatbot.setIntroMessage(regex);
@@ -181,7 +180,6 @@ public abstract class BaseChatbotResourceTestCase {
 
 		chatbot = ChatbotSerDes.toDTO(json);
 
-		Assert.assertEquals(regex, chatbot.getAvatar());
 		Assert.assertEquals(regex, chatbot.getDisclaimerMessage());
 		Assert.assertEquals(regex, chatbot.getExternalReferenceCode());
 		Assert.assertEquals(regex, chatbot.getIntroMessage());
@@ -477,8 +475,8 @@ public abstract class BaseChatbotResourceTestCase {
 			}
 
 			if (Objects.equals("avatar", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						chatbot1.getAvatar(), chatbot2.getAvatar())) {
+				if (!equals(
+						(Map)chatbot1.getAvatar(), (Map)chatbot2.getAvatar())) {
 
 					return false;
 				}
@@ -672,49 +670,8 @@ public abstract class BaseChatbotResourceTestCase {
 		}
 
 		if (entityFieldName.equals("avatar")) {
-			Object object = chatbot.getAvatar();
-
-			String value = String.valueOf(object);
-
-			if (operator.equals("contains")) {
-				sb = new StringBundler();
-
-				sb.append("contains(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 2)) {
-					sb.append(value.substring(1, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else if (operator.equals("startswith")) {
-				sb = new StringBundler();
-
-				sb.append("startswith(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 1)) {
-					sb.append(value.substring(0, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else {
-				sb.append("'");
-				sb.append(value);
-				sb.append("'");
-			}
-
-			return sb.toString();
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("disclaimerMessage")) {
@@ -1041,7 +998,6 @@ public abstract class BaseChatbotResourceTestCase {
 		return new Chatbot() {
 			{
 				active = RandomTestUtil.randomBoolean();
-				avatar = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				disclaimerMessage = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				externalReferenceCode = StringUtil.toLowerCase(
@@ -1277,4 +1233,4 @@ public abstract class BaseChatbotResourceTestCase {
 		_chatbotResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-741125367
+// LIFERAY-REST-BUILDER-HASH:705595240

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ChatbotResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ChatbotResourceTest.java
@@ -12,9 +12,11 @@ import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.ai.hub.rest.client.dto.v1_0.Chatbot;
 import com.liferay.ai.hub.rest.client.resource.v1_0.ChatbotResource;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
@@ -23,9 +25,14 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -115,6 +122,20 @@ public class ChatbotResourceTest extends BaseChatbotResourceTestCase {
 			HashMapBuilder.<String, Serializable>put(
 				"active", true
 			).put(
+				"avatar",
+				() -> {
+					FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
+						TestPropsValues.getGroupId(),
+						TestPropsValues.getUserId(), StringUtil.randomString(),
+						TempFileEntryUtil.getTempFileName(
+							StringUtil.randomString() + ".png"),
+						FileUtil.createTempFile(
+							DLTestUtil.randomTextFileBytes()),
+						ContentTypes.IMAGE_PNG);
+
+					return fileEntry.getFileEntryId();
+				}
+			).put(
 				"externalReferenceCode", chatbotExternalReferenceCode
 			).put(
 				"r_accountToAIHubChatbots_accountEntryId",
@@ -145,6 +166,8 @@ public class ChatbotResourceTest extends BaseChatbotResourceTestCase {
 			postChatbot.getExternalReferenceCode());
 
 		Assert.assertTrue(getChatbot.getActive());
+		Assert.assertNotNull(
+			MapUtil.getString(getChatbot.getAvatar(), "fileURL"));
 		Assert.assertEquals(postChatbot.getTitle(), getChatbot.getTitle());
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/ChatbotForm.tsx
@@ -135,7 +135,6 @@ export default function ChatbotForm({
 		originalSelectedAgentDefinitions,
 		setOriginalSelectedAgentDefinitions,
 	] = useState<AgentDefinitionOption[]>([]);
-	const [avatarChanged, setAvatarChanged] = useState(false);
 	const [avatarLoading, setAvatarLoading] = useState(false);
 	const avatarInputRef = useRef<HTMLInputElement>(null);
 
@@ -214,8 +213,6 @@ export default function ChatbotForm({
 				},
 				avatarFileName: file.name,
 			}));
-
-			setAvatarChanged(true);
 		}
 		catch (error) {
 			openToast({
@@ -238,8 +235,6 @@ export default function ChatbotForm({
 			avatar: null,
 			avatarFileName: undefined,
 		}));
-
-		setAvatarChanged(true);
 	};
 
 	const handleCopyEmbedCode = () => {
@@ -258,17 +253,14 @@ export default function ChatbotForm({
 
 	const handleSubmit = async () => {
 		try {
-			const {avatar, ...rest} = formData;
-
 			const payload = {
-				...rest,
+				...formData,
 				r_accountToAIHubChatbots_accountEntryERC:
 					accountEntryExternalReferenceCode,
 				title:
 					formData.title_i18n?.['en_US'] ||
 					Object.values(formData.title_i18n ?? {})[0] ||
 					'',
-				...(avatarChanged && {avatar}),
 			};
 
 			let chatbotExternalReferenceCode =
@@ -328,8 +320,6 @@ export default function ChatbotForm({
 
 			setOriginalSelectedAgentDefinitions(selectedAgentDefinitions);
 
-			setAvatarChanged(false);
-
 			openToast({
 				message: Liferay.Language.get('chatbot-was-saved-successfully'),
 				type: 'success',
@@ -364,7 +354,6 @@ export default function ChatbotForm({
 
 				setSelectedAgentDefinitions([]);
 				setOriginalSelectedAgentDefinitions([]);
-				setAvatarChanged(false);
 
 				return;
 			}
@@ -383,7 +372,10 @@ export default function ChatbotForm({
 				setFormData({
 					active: chatbotDefinition.active ?? false,
 					avatar: avatarAttachment
-						? avatarAttachment.id
+						? {
+								externalReferenceCode:
+									avatarAttachment.externalReferenceCode,
+							}
 						: chatbotDefinition.avatar,
 					avatarFileName: avatarAttachment?.name,
 					description: chatbotDefinition.description,
@@ -410,7 +402,6 @@ export default function ChatbotForm({
 
 				setSelectedAgentDefinitions(agentDefinitions);
 				setOriginalSelectedAgentDefinitions(agentDefinitions);
-				setAvatarChanged(false);
 			}
 			catch (error) {
 				openToast({

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/types/Chatbot.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/types/Chatbot.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export type AvatarReference = {
+	externalReferenceCode: string;
+};
+
 export type AvatarUpload = {
 	fileBase64: string;
 	mimeType?: string;
@@ -11,7 +15,7 @@ export type AvatarUpload = {
 
 export type Chatbot = {
 	active: boolean;
-	avatar?: number | AvatarUpload | null;
+	avatar?: AvatarReference | AvatarUpload | null | number;
 	avatarFileName?: string;
 	description: string;
 	disclaimerMessage_i18n?: {[key: string]: string};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95685

## What Is Being Fixed

An avatar assigned to a chatbot did not appear when the chatbot was read through the AI Hub REST endpoint, making it look like the avatar was never saved. `ChatbotResourceImpl.getChatbotByExternalReferenceCode` exposed `avatar` as a plain string and tried to pull `fileURL` out of a `Map`, but the object entry's attachment value is a `FileEntry` DTO, not a `Map`, so the check never matched and the avatar came back empty. The custom element frontend reads `avatar.fileURL`, so nothing rendered.

## How It Is Being Fixed

The `Chatbot.avatar` schema field was changed from a string to an object in `rest-openapi.yaml`, and REST Builder regenerated the API and client DTOs, the serdes, and the test base. `ChatbotResourceImpl` now detects the `FileEntry` returned for the attachment field and converts it to a map, so the endpoint returns the full avatar object including `fileURL` — mirroring what the default object definition endpoint returns and matching what the frontend consumes. This is a breaking change to the exported `com.liferay.ai.hub.rest.dto.v1_0` package, which is already covered by its 2.0.0 package version. An integration test asserts the endpoint returns the avatar as an object carrying a `fileURL`.

## PR Check

**pr-check: PASS** — tested on `da3aaf8f8d3280aa9600d429940868372c393d81`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "da3aaf8f8d3280aa9600d429940868372c393d81"} -->
