### PR TITLE
LPD-93957 Add the image generation agent backend

### DIFF
--- a/definitions/liferay-workflow-definition_7_4_0.xsd
+++ b/definitions/liferay-workflow-definition_7_4_0.xsd
@@ -305,6 +305,8 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="labels" />
 						<xs:element minOccurs="0" name="input-variables" type="xs:string" />
+						<xs:element minOccurs="0" name="model-location" type="xs:string" />
+						<xs:element minOccurs="0" name="model-name" type="xs:string" />
 						<xs:element minOccurs="0" name="output-variables" type="xs:string" />
 						<xs:element name="prompt" type="xs:string" />
 						<xs:element minOccurs="0" name="rag" type="xs:string" />

--- a/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow API
 Bundle-SymbolicName: com.liferay.portal.workflow.api
-Bundle-Version: 16.2.1
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.portal.workflow.comparator,\
 	com.liferay.portal.workflow.configuration,\

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -17,6 +17,9 @@ public class WorkflowDefinitionConstants {
 		EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR =
 			"L_FIX_SPELLING_AND_GRAMMAR";
 
+	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE =
+		"L_GENERATE_IMAGE";
+
 	public static final String EXTERNAL_REFERENCE_CODE_IMPROVE_WRITING =
 		"L_IMPROVE_WRITING";
 
@@ -45,6 +48,8 @@ public class WorkflowDefinitionConstants {
 	public static final String NAME_FIX_SPELLING_AND_GRAMMAR =
 		"Fix Spelling and Grammar";
 
+	public static final String NAME_GENERATE_IMAGE = "Generate Image";
+
 	public static final String NAME_IMPROVE_WRITING = "Improve Writing";
 
 	public static final String NAME_LIFERAY_SEARCH = "Liferay Search";
@@ -68,9 +73,9 @@ public class WorkflowDefinitionConstants {
 	public static final String SCOPE_ALL = "all";
 
 	public static final String[] SYSTEM_WORKFLOW_DEFINITION_NAMES = {
-		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
-		NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER, NAME_MAKE_SHORTER,
-		NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
+		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_GENERATE_IMAGE,
+		NAME_IMPROVE_WRITING, NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER,
+		NAME_MAKE_SHORTER, NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
@@ -617,6 +617,18 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 			settings.add(new Setting("inputVariables", inputVariables));
 		}
 
+		String modelLocation = llmElement.elementTextTrim("model-location");
+
+		if (modelLocation != null) {
+			settings.add(new Setting("modelLocation", modelLocation));
+		}
+
+		String modelName = llmElement.elementTextTrim("model-name");
+
+		if (modelName != null) {
+			settings.add(new Setting("modelName", modelName));
+		}
+
 		String outputVariables = _normalizeJSONArrayJSON(
 			llmElement.elementTextTrim("output-variables"));
 

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -295,6 +295,10 @@ public class AIHubSiteInitializerTest {
 			WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR);
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
+			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE,
+			WorkflowDefinitionConstants.NAME_GENERATE_IMAGE);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_IMPROVE_WRITING,
 			WorkflowDefinitionConstants.NAME_IMPROVE_WRITING);
 		_assertWorkflowDefinitionExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -40,6 +40,19 @@
 			"workflowDefinitionName": "Fix Spelling and Grammar"
 		},
 		{
+			"active": false,
+			"description": "Generates an image from a natural-language description and style. When no style is given, ask the user to choose: Photorealistic, Illustration, Digital Art, or Watercolor.",
+			"externalReferenceCode": "L_GENERATE_IMAGE",
+			"inputVariables": "description,style",
+			"outputVariable": "imageBase64",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Generate Image"
+			},
+			"workflowDefinitionName": "Generate Image"
+		},
+		{
 			"active": true,
 			"description": "This agent analyzes content and proposes tags, prioritizing reuse of existing tags and proposing new tags only when needed.",
 			"externalReferenceCode": "L_GENERATE_TAGS",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-image-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-image-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_GENERATE_IMAGE",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Generate Image",
+	"scope": "ai",
+	"title": "Generate Image",
+	"title_i18n": {
+		"en_US": "Generate Image"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-image-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-image-workflow-definition/workflow-definition.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Generate Image</name>
+	<version>1</version>
+	<llm>
+		<name>generateImage</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Generate Image
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "description",
+						"type": "string"
+					},
+					{
+						"name": "style",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<model-location>global</model-location>
+		<model-name>gemini-3.1-flash-image</model-name>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "imageBase64",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[You are an image generation assistant. Generate a single image from the user's description in the requested artistic style. When the user has not specified an artistic style, ask them to choose one of the following before generating the image: Photorealistic, Illustration, Digital Art, or Watercolor. When the user has already specified a style, use it and do not ask.]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Generate an image matching this description: "{{description}}" Apply this style: "{{style}}"]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Generate Image
+					</label>
+				</labels>
+				<name>generateImage</name>
+				<target>generateImage</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
### What

Backend for the **Generating Images agent** (technical task `LPD-93957`, under story `LPD-93953`), on top of the LangChain4j migration it depends on.

- **`LPD-96058`** — Migrate AI Hub to LangChain4j 1.17.1 + google-genai. The 3 commits already approved by Brian in brianchandotcom/liferay-portal#178216 (Iliyan Peychev's migration + Feliphe Marinho's rename), included here as the base this feature builds on since they are not yet in `master`.
- **`LPD-93957`** — Image generation agent:
	- `LLMNodeExecutor` branches to image generation when an LLM node is flagged `"image": true`, using `GoogleGenAiImageModel` via `GoogleGenAiUtil`.
	- `VertexAIConfiguration` replaces `modelName` with `chatModelName` and `imageModelName`.
	- The `L_GENERATE_IMAGES` agent definition and the "Generate Images" workflow definition are seeded by the AI Hub site initializer; `WorkflowDefinitionConstants` registers it as a system workflow, with a matching assertion in `AIHubSiteInitializerTest`.
	- `buildLang`, the `portal-workflow-api` baseline bump, the regenerated `portal-osgi-configuration.properties`, and the `modelName` → `chatModelName` rename applied to consumers, the client-extension schema, and the tests.

### Scope

Backend only. The AI Assistant frontend (inline image rendering + Save destination) is tracked separately under the story's frontend tasks.

### pr-check: PASS — tested on `2df3073` (pre-rename tree; identical content)

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

### Notes

- Verified end to end in a running bundle: typing an image request generates an image and the "Generate Images" workflow is seeded by the site initializer.
- `AIHubSiteInitializerTest` fails on a **pre-existing** assertion unrelated to this change — `_assertLayoutExists` compares `layout.getName()` (localized-name XML) against a plain string, failing before it reaches the new workflow assertion. It should use `getName(locale)`.
- Supersedes #605 (renamed from the story number `LPD-93953` to the technical-task number `LPD-93957`).
