### PR TITLE
LPD-97347 HTTP Request Node is retrieving 401 due to a missing prefix in the Authorization Header

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/HTTPRequestNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/HTTPRequestNodeExecutor.java
@@ -75,11 +75,11 @@ public class HTTPRequestNodeExecutor extends BaseNodeExecutor {
 			Company company = _companyLocalService.getCompany(
 				kaleoInstanceToken.getCompanyId());
 
-			options.addHeader(
-				HttpHeaders.AUTHORIZATION,
-				EncryptorUtil.decrypt(
-					company.getKeyObj(),
-					GetterUtil.getString(workflowContext.get("userToken"))));
+			String userToken = EncryptorUtil.decrypt(
+				company.getKeyObj(),
+				GetterUtil.getString(workflowContext.get("userToken")));
+
+			options.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + userToken);
 
 			String requestBody = VariablesUtil.applyInputVariables(
 				executionContext, "requestBody", kaleoNodeSettingValues);
@@ -126,31 +126,22 @@ public class HTTPRequestNodeExecutor extends BaseNodeExecutor {
 
 			throw new PortalException(exception);
 		}
+
+		KaleoTransition kaleoTransition =
+			currentKaleoNode.getDefaultKaleoTransition();
+
+		remainingPathElements.add(
+			new PathElement(
+				currentKaleoNode, kaleoTransition.getTargetKaleoNode(),
+				new ExecutionContext(
+					executionContext.getKaleoInstanceToken(), workflowContext,
+					executionContext.getServiceContext())));
 	}
 
 	@Override
 	protected void doExit(
-			KaleoNode currentKaleoNode, ExecutionContext executionContext,
-			List<PathElement> remainingPathElements)
-		throws PortalException {
-
-		KaleoTransition kaleoTransition = null;
-
-		if (Validator.isNull(executionContext.getTransitionName())) {
-			kaleoTransition = currentKaleoNode.getDefaultKaleoTransition();
-		}
-		else {
-			kaleoTransition = currentKaleoNode.getKaleoTransition(
-				executionContext.getTransitionName());
-		}
-
-		remainingPathElements.add(
-			new PathElement(
-				null, kaleoTransition.getTargetKaleoNode(),
-				new ExecutionContext(
-					executionContext.getKaleoInstanceToken(),
-					executionContext.getWorkflowContext(),
-					executionContext.getServiceContext())));
+		KaleoNode currentKaleoNode, ExecutionContext executionContext,
+		List<PathElement> remainingPathElements) {
 	}
 
 	@Reference

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -246,6 +246,10 @@ public class AgentInstanceResourceTest
 			"ai-decision-node-with-tool-workflow-definition.json",
 			"AI Decision Node With Tool Workflow Definition");
 		_addAgentDefinitionObjectEntry(
+			"L_HTTP_REQUEST_NODE_WITH_LLM_NODE_WORKFLOW_DEFINITION", "text",
+			"http-request-node-with-llm-node-workflow-definition.json",
+			"HTTP Request Node With LLM Node Workflow Definition");
+		_addAgentDefinitionObjectEntry(
 			"L_LLM_NODE_WITH_RAG_WORKFLOW_DEFINITION", "userMessage",
 			"llm-node-with-rag-workflow-definition.json",
 			"LLM Node With RAG Workflow Definition");
@@ -314,6 +318,7 @@ public class AgentInstanceResourceTest
 			_testPostAgentInstanceWithTypeAutoCategorize();
 			_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction();
 			_testPostAgentInstanceWithTypeGenerateTags();
+			_testPostAgentInstanceWithTypeHTTPRequestNodeWithLLMNodeWorkflowDefinition();
 			_testPostAgentInstanceWithTypeLLMNodeWithRAGWorkflowDefinition();
 			_testPostAgentInstanceWithTypeLLMNodeWithRAGWorkflowDefinitionWithRestrictedUser();
 			_testPostAgentInstanceWithTypeLLMNodeWithToolWorkflowDefinition();
@@ -365,7 +370,9 @@ public class AgentInstanceResourceTest
 	}
 
 	private static byte[] _getContentBytes(String fileName) throws Exception {
-		String content = _read(fileName);
+		String content = StringUtil.replace(
+			_read(fileName), "${portal.port}",
+			String.valueOf(PortalUtil.getPortalServerPort(false)));
 
 		return content.getBytes();
 	}
@@ -864,6 +871,29 @@ public class AgentInstanceResourceTest
 		Assert.assertTrue(data, lowerCaseData.contains("neural networks"));
 
 		Assert.assertTrue(data, StringUtil.count(data, "confidence") <= 5);
+	}
+
+	private void _testPostAgentInstanceWithTypeHTTPRequestNodeWithLLMNodeWorkflowDefinition()
+		throws Exception {
+
+		CountDownLatch countDownLatch = new CountDownLatch(4);
+		List<String> lines = new ArrayList<>();
+
+		String sseEventSinkKey = SseEventSourceTestUtil.open(
+			List.of(countDownLatch), lines, "agent-instances/subscribe");
+
+		_postAgentInstance(
+			"L_HTTP_REQUEST_NODE_WITH_LLM_NODE_WORKFLOW_DEFINITION",
+			RandomTestUtil.randomString(), "text", sseEventSinkKey);
+
+		Assert.assertTrue(countDownLatch.await(60, TimeUnit.SECONDS));
+
+		Assert.assertEquals(lines.toString(), 4, lines.size());
+
+		_assertContains(
+			StringUtil.toLowerCase(lines.get(3)), "\"nodename\":\"llm\"");
+
+		SseUtil.closeAll();
 	}
 
 	private void _testPostAgentInstanceWithTypeLLMNodeWithRAGWorkflowDefinition()

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/util/TokenTestUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/util/TokenTestUtil.java
@@ -53,6 +53,8 @@ public class TokenTestUtil {
 			).put(
 				"clientSecret", oAuth2Application.getClientSecret()
 			).put(
+				"companyId", user.getCompanyId()
+			).put(
 				"serviceURL",
 				"http://localhost:" + PortalUtil.getPortalServerPort(false)
 			).build());

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/resources/com/liferay/ai/hub/rest/resource/v1_0/test/dependencies/http-request-node-with-llm-node-workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/resources/com/liferay/ai/hub/rest/resource/v1_0/test/dependencies/http-request-node-with-llm-node-workflow-definition.json
@@ -1,0 +1,291 @@
+{
+	"#child-nodes": [
+		{
+			"#tag-name": "name",
+			"#value": "HTTP Request Node With LLM Node Workflow Definition"
+		},
+		{
+			"#tag-name": "version",
+			"#value": "1"
+		},
+		{
+			"#child-nodes": [
+				{
+					"#tag-name": "name",
+					"#value": "start"
+				},
+				{
+					"#tag-name": "description",
+					"#value": "Begin a workflow."
+				},
+				{
+					"#cdata-value": [
+						"{",
+						"    \"xy\": [",
+						"        300,",
+						"        100",
+						"    ]",
+						"}"
+					],
+					"#tag-name": "metadata"
+				},
+				{
+					"#tag-name": "initial",
+					"#value": "true"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#tag-name": "label",
+							"#value": "Start",
+							"language-id": "en_US"
+						}
+					],
+					"#tag-name": "labels"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#child-nodes": [
+								{
+									"#child-nodes": [
+										{
+											"#tag-name": "label",
+											"#value": "HTTP Request",
+											"language-id": "en_US"
+										}
+									],
+									"#tag-name": "labels"
+								},
+								{
+									"#tag-name": "name",
+									"#value": "http-request"
+								},
+								{
+									"#tag-name": "target",
+									"#value": "http-request"
+								},
+								{
+									"#tag-name": "default",
+									"#value": "true"
+								}
+							],
+							"#tag-name": "transition"
+						}
+					],
+					"#tag-name": "transitions"
+				}
+			],
+			"#tag-name": "state"
+		},
+		{
+			"#child-nodes": [
+				{
+					"#tag-name": "name",
+					"#value": "http-request"
+				},
+				{
+					"#cdata-value": [
+						"{",
+						"    \"xy\": [",
+						"        300,",
+						"        250",
+						"    ]",
+						"}"
+					],
+					"#tag-name": "metadata"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#tag-name": "label",
+							"#value": "HTTP Request",
+							"language-id": "en_US"
+						}
+					],
+					"#tag-name": "labels"
+				},
+				{
+					"#tag-name": "http-method",
+					"#value": "GET"
+				},
+				{
+					"#cdata-value": [
+						"[",
+						"    {",
+						"        \"name\": \"output\",",
+						"        \"type\": \"json\"",
+						"    }",
+						"]"
+					],
+					"#tag-name": "output-variables"
+				},
+				{
+					"#tag-name": "timeout",
+					"#value": "10000"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#child-nodes": [
+								{
+									"#child-nodes": [
+										{
+											"#tag-name": "label",
+											"#value": "LLM",
+											"language-id": "en_US"
+										}
+									],
+									"#tag-name": "labels"
+								},
+								{
+									"#tag-name": "name",
+									"#value": "llm"
+								},
+								{
+									"#tag-name": "target",
+									"#value": "llm"
+								},
+								{
+									"#tag-name": "default",
+									"#value": "true"
+								}
+							],
+							"#tag-name": "transition"
+						}
+					],
+					"#tag-name": "transitions"
+				},
+				{
+					"#tag-name": "url",
+					"#value": "http://localhost:${portal.port}/o/search/v1.0/search?emptySearch=true"
+				}
+			],
+			"#tag-name": "http-request"
+		},
+		{
+			"#child-nodes": [
+				{
+					"#tag-name": "name",
+					"#value": "llm"
+				},
+				{
+					"#cdata-value": [
+						"{",
+						"    \"xy\": [",
+						"        300,",
+						"        400",
+						"    ]",
+						"}"
+					],
+					"#tag-name": "metadata"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#tag-name": "label",
+							"#value": "LLM",
+							"language-id": "en_US"
+						}
+					],
+					"#tag-name": "labels"
+				},
+				{
+					"#cdata-value": [
+						"[",
+						"    {",
+						"        \"name\": \"output\",",
+						"        \"type\": \"json\"",
+						"    }",
+						"]"
+					],
+					"#tag-name": "input-variables"
+				},
+				{
+					"#cdata-value": [
+						"Fix the spelling and grammar of the following text. Respond only with the corrected text."
+					],
+					"#tag-name": "prompt"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#child-nodes": [
+								{
+									"#child-nodes": [
+										{
+											"#tag-name": "label",
+											"#value": "End",
+											"language-id": "en_US"
+										}
+									],
+									"#tag-name": "labels"
+								},
+								{
+									"#tag-name": "name",
+									"#value": "end"
+								},
+								{
+									"#tag-name": "target",
+									"#value": "end"
+								},
+								{
+									"#tag-name": "default",
+									"#value": "true"
+								}
+							],
+							"#tag-name": "transition"
+						}
+					],
+					"#tag-name": "transitions"
+				},
+				{
+					"#cdata-value": [
+						"{{output}}"
+					],
+					"#tag-name": "user-message"
+				}
+			],
+			"#tag-name": "llm"
+		},
+		{
+			"#child-nodes": [
+				{
+					"#tag-name": "name",
+					"#value": "end"
+				},
+				{
+					"#tag-name": "description",
+					"#value": "Conclude the workflow."
+				},
+				{
+					"#cdata-value": [
+						"{",
+						"    \"terminal\": true,",
+						"    \"xy\": [",
+						"        300,",
+						"        550",
+						"    ]",
+						"}"
+					],
+					"#tag-name": "metadata"
+				},
+				{
+					"#child-nodes": [
+						{
+							"#tag-name": "label",
+							"#value": "End",
+							"language-id": "en_US"
+						}
+					],
+					"#tag-name": "labels"
+				}
+			],
+			"#tag-name": "state"
+		}
+	],
+	"#tag-name": "workflow-definition",
+	"xmlns": "urn:liferay.com:liferay-workflow_7.4.0",
+	"xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+	"xsi:schemaLocation": "urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97347

## What Is Being Fixed

The HTTP Request Node failed with a 401 response because it sent the user token in the Authorization header without the "Bearer " prefix. The node also relied on doExit to transition to the next node, but the HTTP call is synchronous, so the transition belonged in doExecute.

## How It Is Being Fixed

The node now prefixes the decrypted user token with "Bearer " and adds the transition path element from doExecute, forwarding the updated workflow context so the response is available to the next node; doExit becomes a no-op.

Integration coverage is added in AgentInstanceResourceTest: a workflow definition chains an HTTP Request Node into an LLM Node. The HTTP node authenticates against the search endpoint with the cell user token and hands its response to the LLM node, so the test implicitly asserts that the node finishes and transitions. TokenTestUtil now saves the AI Hub Cell configuration with a company ID, without which the configuration model listener skipped provisioning the OAuth2 application and service access policy entry, leaving the cell token flow unusable.

## PR Check

**pr-check: PASS** — tested on `df91d523d5f7ab9b7885d158830c5e07be57c959`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "df91d523d5f7ab9b7885d158830c5e07be57c959"} -->
