### PR TITLE
LPD-96015 Stop storing Vertex AI properties in TestPropsValues

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -301,11 +302,13 @@ public class AgentInstanceResourceTest
 						TestPropsValues.getCompanyId(),
 						VertexAIConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
-							"location", TestPropsValues.VERTEX_AI_LOCATION
+							"location", TestPropsUtil.get("vertex.ai.location")
 						).put(
-							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
+							"modelName",
+							TestPropsUtil.get("vertex.ai.model.name")
 						).put(
-							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+							"projectId",
+							TestPropsUtil.get("vertex.ai.project.id")
 						).build())) {
 
 			_testPostAgentInstance();

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/MessageResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/MessageResourceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -138,11 +139,13 @@ public class MessageResourceTest extends BaseMessageResourceTestCase {
 						TestPropsValues.getCompanyId(),
 						VertexAIConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
-							"location", TestPropsValues.VERTEX_AI_LOCATION
+							"location", TestPropsUtil.get("vertex.ai.location")
 						).put(
-							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
+							"modelName",
+							TestPropsUtil.get("vertex.ai.model.name")
 						).put(
-							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+							"projectId",
+							TestPropsUtil.get("vertex.ai.project.id")
 						).build())) {
 
 			CountDownLatch countDownLatch1 = new CountDownLatch(4);
@@ -253,11 +256,13 @@ public class MessageResourceTest extends BaseMessageResourceTestCase {
 						TestPropsValues.getCompanyId(),
 						VertexAIConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
-							"location", TestPropsValues.VERTEX_AI_LOCATION
+							"location", TestPropsUtil.get("vertex.ai.location")
 						).put(
-							"modelName", TestPropsValues.VERTEX_AI_MODEL_NAME
+							"modelName",
+							TestPropsUtil.get("vertex.ai.model.name")
 						).put(
-							"projectId", TestPropsValues.VERTEX_AI_PROJECT_ID
+							"projectId",
+							TestPropsUtil.get("vertex.ai.project.id")
 						).build())) {
 
 			CountDownLatch countDownLatch1 = new CountDownLatch(4);

--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
@@ -58,15 +58,6 @@ public class TestPropsValues {
 	public static final String USER_PASSWORD = TestPropsUtil.get(
 		"user.password");
 
-	public static final String VERTEX_AI_LOCATION = TestPropsUtil.get(
-		"vertex.ai.location");
-
-	public static final String VERTEX_AI_MODEL_NAME = TestPropsUtil.get(
-		"vertex.ai.model.name");
-
-	public static final String VERTEX_AI_PROJECT_ID = TestPropsUtil.get(
-		"vertex.ai.project.id");
-
 	static {
 		String companyWebId = TestPropsUtil.get("company.web.id");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96015

## What Is Being Fixed

The Vertex AI location, model name, and project ID were added as constants in the shared portal-test TestPropsValues. CI injects these values into the test properties (keyed to the AI Hub daily routine), so dedicated portal-core constants are unnecessary and put app-specific configuration in a shared location.

## How It Is Being Fixed

Remove VERTEX_AI_LOCATION, VERTEX_AI_MODEL_NAME, and VERTEX_AI_PROJECT_ID from TestPropsValues. The AI Hub tests that configure VertexAIConfiguration (AgentInstanceResourceTest, MessageResourceTest) now read the values inline with TestPropsUtil.get("vertex.ai.*"), matching how SalesforceObjectEntryManagerImplTest reads its CI-injected object-storage properties.

## PR Check

**pr-check: PASS** — tested on `7666f3a3ab4254e8a4e2b40ce3faee1f67b89a19`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portal Core Compile (ant compile) | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7666f3a3ab4254e8a4e2b40ce3faee1f67b89a19"} -->
