### PR TITLE
LPD-97506 Grant the User role View permission on Guardrail picklists

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -384,7 +385,7 @@ public class AIHubSiteInitializerTest {
 		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
 			TestPropsValues.getGroupId(), false, friendlyURL);
 
-		Assert.assertEquals(name, layout.getName());
+		Assert.assertEquals(name, layout.getName(LocaleUtil.getSiteDefault()));
 	}
 
 	private void _assertLayoutUtilityPageEntryExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/resource-permissions.json
@@ -125,34 +125,34 @@
 		"actionIds": [
 			"VIEW"
 		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Guardrail Confidence Levels$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Guardrail Responsible AI Levels$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Guardrail Types$]",
+		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
+		"roleName": "User",
+		"scope": "4"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
 		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Instruction Definition Scopes$]",
-		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
-		"roleName": "User",
-		"scope": "4"
-	},
-	{
-		"actionIds": [
-			"VIEW"
-		],
-		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Confidence Levels$]",
-		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
-		"roleName": "User",
-		"scope": "4"
-	},
-	{
-		"actionIds": [
-			"VIEW"
-		],
-		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Guardrail Types$]",
-		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
-		"roleName": "User",
-		"scope": "4"
-	},
-	{
-		"actionIds": [
-			"VIEW"
-		],
-		"primKey": "[$LIST_TYPE_DEFINITION_ID:AI Hub Model Armor Template Responsible AI Levels$]",
 		"resourceName": "com.liferay.list.type.model.ListTypeDefinition",
 		"roleName": "User",
 		"scope": "4"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97506

## What Is Being Fixed

The AI Hub site initializer grants the User role VIEW on the three guardrail picklists, but the permission entries referenced the old picklist names "AI Hub Model Armor Template *". The picklists were renamed to "AI Hub Guardrail *", so the grants no longer matched any picklist and the User role never received VIEW on the AI Hub Guardrail Confidence Levels, Guardrail Types, and Guardrail Responsible AI Levels picklists.

## How It Is Being Fixed

Update the three primKey references in resource-permissions.json from the stale "AI Hub Model Armor Template *" names to the current "AI Hub Guardrail *" names, so the User role's VIEW grant lands on the actual picklists, and sort the User-role ListTypeDefinition permission entries alphabetically by primKey. A second commit fixes an unrelated pre-existing assertion in AIHubSiteInitializerTest that compared the raw i18n layout name instead of the site-default locale name.

## Why Are There No Tests?

The fix is covered by the existing AIHubSiteInitializerTest._assertListTypeDefinitionUserRoleViewPermission assertion (added by LPD-92709), which asserts the User role has VIEW on the AI Hub Guardrail picklists. That assertion was failing because the initializer granted VIEW against the stale picklist names; this change makes the existing test pass. No new test is required.

## PR Check

**pr-check: PASS** — tested on `e6664ea5bd5b05dabc0214c10c0da770cb03c1b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e6664ea5bd5b05dabc0214c10c0da770cb03c1b6"} -->
