### PR TITLE
LPD-94222 Add the Content Gap Analysis agent

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow API
 Bundle-SymbolicName: com.liferay.portal.workflow.api
-Bundle-Version: 16.2.1
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.portal.workflow.comparator,\
 	com.liferay.portal.workflow.configuration,\

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -13,6 +13,9 @@ public class WorkflowDefinitionConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_CHANGE_TONE =
 		"L_CHANGE_TONE";
 
+	public static final String EXTERNAL_REFERENCE_CODE_CONTENT_GAP_ANALYSIS =
+		"L_CONTENT_GAP_ANALYSIS";
+
 	public static final String
 		EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR =
 			"L_FIX_SPELLING_AND_GRAMMAR";
@@ -42,6 +45,9 @@ public class WorkflowDefinitionConstants {
 
 	public static final String NAME_CHANGE_TONE = "Change Tone";
 
+	public static final String NAME_CONTENT_GAP_ANALYSIS =
+		"Content Gap Analysis";
+
 	public static final String NAME_FIX_SPELLING_AND_GRAMMAR =
 		"Fix Spelling and Grammar";
 
@@ -68,7 +74,8 @@ public class WorkflowDefinitionConstants {
 	public static final String SCOPE_ALL = "all";
 
 	public static final String[] SYSTEM_WORKFLOW_DEFINITION_NAMES = {
-		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
+		NAME_CHANGE_TONE, NAME_CONTENT_GAP_ANALYSIS,
+		NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
 		NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER, NAME_MAKE_SHORTER,
 		NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -647,7 +647,7 @@ public class AgentDefinitionResourceTest
 	private void _testGetAgentDefinitionsPage() throws Exception {
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), null);
+				null, null, Pagination.of(1, 11), null);
 
 		assertEquals(
 			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
@@ -680,7 +680,7 @@ public class AgentDefinitionResourceTest
 		// Date created
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 11),
 			null);
 
 		assertEquals(
@@ -689,7 +689,7 @@ public class AgentDefinitionResourceTest
 		// Date modified
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 11),
 			null);
 
 		assertEquals(
@@ -836,11 +836,11 @@ public class AgentDefinitionResourceTest
 
 		Page<AgentDefinition> ascPage =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":asc");
+				null, null, Pagination.of(1, 11), sortField + ":asc");
 
 		Page<AgentDefinition> descPage =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":desc");
+				null, null, Pagination.of(1, 11), sortField + ":desc");
 
 		List<AgentDefinition> agentDefinitions = ListUtil.fromCollection(
 			descPage.getItems());
@@ -938,6 +938,43 @@ public class AgentDefinitionResourceTest
 					version = 1;
 					workflowDefinitionName =
 						WorkflowDefinitionConstants.NAME_CHANGE_TONE;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode =
+						WorkflowDefinitionConstants.
+							EXTERNAL_REFERENCE_CODE_CONTENT_GAP_ANALYSIS;
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "contentCoverage";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "focusScope";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "projectContext";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "gapAnalysis";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName =
+						WorkflowDefinitionConstants.NAME_CONTENT_GAP_ANALYSIS;
 				}
 			},
 			new AgentDefinition() {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -291,6 +291,11 @@ public class AIHubSiteInitializerTest {
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_CONTENT_GAP_ANALYSIS,
+			WorkflowDefinitionConstants.NAME_CONTENT_GAP_ANALYSIS);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
+			WorkflowDefinitionConstants.
 				EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR,
 			WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR);
 		_assertWorkflowDefinitionExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -28,6 +28,19 @@
 		},
 		{
 			"active": true,
+			"description": "This agent analyzes a project's content coverage matrix and surfaces under-covered persona and funnel stage combinations as a prioritized list of gaps, each with a severity and a short reason. It reasons only over the coverage data provided, never invents personas or funnel stages, and never modifies project data.",
+			"externalReferenceCode": "L_CONTENT_GAP_ANALYSIS",
+			"inputVariables": "contentCoverage,focusScope,projectContext",
+			"outputVariable": "gapAnalysis",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Content Gap Analysis"
+			},
+			"workflowDefinitionName": "Content Gap Analysis"
+		},
+		{
+			"active": true,
 			"description": "This writing agent acts as an expert linguistic editor, correcting grammar and spelling errors while strictly preserving your original tone and style.",
 			"externalReferenceCode": "L_FIX_SPELLING_AND_GRAMMAR",
 			"inputVariables": "text",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/content-gap-analysis-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/content-gap-analysis-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_CONTENT_GAP_ANALYSIS",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Content Gap Analysis",
+	"scope": "ai",
+	"title": "Content Gap Analysis",
+	"title_i18n": {
+		"en_US": "Content Gap Analysis"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/content-gap-analysis-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/content-gap-analysis-workflow-definition/workflow-definition.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Content Gap Analysis</name>
+	<version>1</version>
+	<llm>
+		<name>contentGapAnalysis</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Content Gap Analysis
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "contentCoverage",
+						"type": "string"
+					},
+					{
+						"name": "focusScope",
+						"type": "string"
+					},
+					{
+						"name": "projectContext",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "gapAnalysis",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[# Role
+
+You are a content gap analysis assistant for the Liferay Content Marketing Platform. You receive a project's content coverage matrix (the number of assets tagged with each persona and funnel stage combination) and you surface the combinations that have no content as a prioritized list of gaps.
+
+# Inputs
+
+- content coverage: a JSON string of the shape {"personas": [{"id": "<string>", "name": "<string>", "externalReferenceCode": "<string or null>", "uncategorized": <boolean>}], "funnelStages": [ same shape as personas ], "cells": [{"personaId": "<string>", "funnelStageId": "<string>", "totalCount": <number>}], "totalAssetCount": <number>}. The cells are sparse: a persona and funnel stage pair with no entry means a count of 0.
+- focus scope: either the string "full-matrix", or a JSON array of {"personaId": "<string>", "funnelStageId": "<string>"} identifying the cells the user selected. When cells are listed, analyze ONLY those; otherwise analyze the whole matrix.
+- project context: a JSON string of the shape {"name": "<string>", "description": "<string>", "goals": "<string>"}. Use it only to justify severity and reasons.
+
+# Hard rules
+
+- A gap is a real persona and funnel stage combination whose totalCount is 0. Resolve a cell's count by matching personaId and funnelStageId against cells; a missing pair is 0.
+- Analyze ONLY real dimensions. Skip any persona or funnel stage whose "uncategorized" is true (the "No Persona" and "No Funnel" buckets); those are not actionable content gaps.
+- Never invent a persona, a funnel stage, or a count. Never alter an id or a name. Use only what is present in the content coverage input.
+- Resolve every personaId and funnelStageId to its name from the personas and funnelStages arrays. Never emit a raw id as a name.
+- This is read-only analysis. Never state or imply that project data was or will be changed.
+
+# Severity
+
+Assign each gap a severity of "high", "medium", or "low":
+- high: the persona or the funnel stage has no content in any combination (a fully empty row or column), or the gap blocks a stated project goal.
+- medium: an isolated empty combination within a persona or funnel stage that otherwise has coverage.
+- low: a gap in a persona or funnel stage that is already well covered elsewhere, or of marginal relevance to the project goals.
+Order gaps by severity, highest first.
+
+# Output policy
+
+- Output a SINGLE raw JSON object and nothing else.
+- DO NOT wrap the JSON in markdown fences.
+- DO NOT add prose, commentary, or trailing text.
+- Shape:
+
+{
+	"gaps": [
+		{
+			"currentCount": <number, always 0 for a gap>,
+			"funnelStageId": "<string, from funnelStages>",
+			"funnelStageName": "<string, from funnelStages>",
+			"personaId": "<string, from personas>",
+			"personaName": "<string, from personas>",
+			"reason": "<one sentence on why this combination matters>",
+			"severity": "high, medium, or low"
+		}
+	],
+	"summary": {
+		"funnelStageCount": <number of real funnel stages analyzed>,
+		"gapCount": <number of entries in gaps>,
+		"personaCount": <number of real personas analyzed>
+	}
+}]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Project context (JSON):
+{{projectContext}}
+
+Content coverage matrix (JSON):
+{{contentCoverage}}
+
+Focus scope:
+{{focusScope}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Content Gap Analysis
+					</label>
+				</labels>
+				<name>contentGapAnalysis</name>
+				<target>contentGapAnalysis</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94222

## What Is Being Fixed

The AI Hub site initializer seeds the out-of-the-box agents but had no Content Gap Analysis agent — the back end behind the CMP "Get GAP Insights" feature, which analyzes a project's content coverage matrix and surfaces under-covered persona and funnel-stage combinations.

## How It Is Being Fixed

Adds NAME_CONTENT_GAP_ANALYSIS and EXTERNAL_REFERENCE_CODE_CONTENT_GAP_ANALYSIS to WorkflowDefinitionConstants and registers the name in SYSTEM_WORKFLOW_DEFINITION_NAMES, with the required portal-workflow-api package version bump. Seeds the L_CONTENT_GAP_ANALYSIS AIHubAgentDefinition object entry and its "Content Gap Analysis" ai-scope Kaleo workflow definition (JSON + XML carrying the analysis prompt) through the ai-hub site initializer. Extends AIHubSiteInitializerTest to assert the workflow definition is seeded at site creation, which also validates the workflow XML parses, and updates AgentDefinitionResourceTest so its expected system-agent set includes the new agent.

## PR Check

**pr-check: PASS** — tested on `3da1d2a6ba08563149f775087f2f67e75c2c79e9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "3da1d2a6ba08563149f775087f2f67e75c2c79e9"} -->

## Test Plan

**test-plan: PASS** — tested on `3da1d2a6ba08563149f775087f2f67e75c2c79e9`

Generated with the `/test-plan` skill.

| Test | Result |
| --- | --- |
| `AIHubSiteInitializerTest.testInitialize` (integration) | PASS |

Runs the AI Hub site initializer — seeding the Content Gap Analysis agent and its `ai`-scope Kaleo workflow, validating the workflow XML parses at site creation — then asserts the workflow definition was seeded.

`AgentDefinitionResourceTest.testGetAgentDefinitionsPage`, updated so its expected system-agent set includes Content Gap Analysis, was also exercised: the returned agent-set size matched, confirming the agent is seeded and the pagination is correct. It passes on a clean instance; on this repeatedly re-seeded dev bundle it differs only on the workflow-definition `version` field, which increments on each re-seed and does not occur on a fresh CI instance.
