### PR TITLE
LPD-97534 Prevent supervisor agent failure when the LLM wraps its plan JSON in a markdown code fence

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/GoogleGenAiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/GoogleGenAiUtil.java
@@ -16,6 +16,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.service.ServiceContext;
 
+import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.google.genai.GoogleGenAiChatModel;
 import dev.langchain4j.model.google.genai.GoogleGenAiStreamingChatModel;
 
@@ -47,6 +48,8 @@ public class GoogleGenAiUtil {
 			vertexAIConfiguration.modelName()
 		).projectId(
 			vertexAIConfiguration.projectId()
+		).responseFormat(
+			ResponseFormat.JSON
 		).safetySettings(
 			_safetySettings
 		).build();

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/GoogleGenAiUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/model/GoogleGenAiUtilTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.google.genai.GoogleGenAiChatModel;
 import dev.langchain4j.model.google.genai.GoogleGenAiStreamingChatModel;
 
@@ -104,6 +105,8 @@ public class GoogleGenAiUtilTest {
 			googleGenAiChatModel.defaultRequestParameters();
 
 		Assert.assertEquals(_MODEL_NAME, defaultRequestParameters.modelName());
+		Assert.assertEquals(
+			ResponseFormat.JSON, defaultRequestParameters.responseFormat());
 
 		_assertSafetySettings(
 			ReflectionTestUtil.getFieldValue(
@@ -121,6 +124,7 @@ public class GoogleGenAiUtilTest {
 			googleGenAiStreamingChatModel.defaultRequestParameters();
 
 		Assert.assertEquals(_MODEL_NAME, defaultRequestParameters.modelName());
+		Assert.assertNull(defaultRequestParameters.responseFormat());
 
 		_assertSafetySettings(
 			ReflectionTestUtil.getFieldValue(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97534

## What Is Being Fixed

The AI Hub supervisor asks Gemini for a JSON `AgentInvocation` plan each turn, which langchain4j's `PojoOutputParser` parses by feeding the raw model text straight to Jackson. When the model wraps that plan in a ` ```json ... ``` ` markdown fence and/or leaves a quote inside a value unescaped, Jackson throws and langchain4j rethrows it as `OutputParsingException`, which propagates through `SupervisorPlanner.nextSubagent` to `SupervisorAgentImpl._handleException` — so the chat shows a generic error even though the model produced a complete, correct answer. The ticket framed this as fence-only, but the logged payload also had unescaped quotes: the JSON was invalid independent of the fence, and langchain4j 1.17.1 does not recover from it.

## How It Is Being Fixed

Request `responseMimeType: application/json` from the supervisor's model by setting `.responseFormat(ResponseFormat.JSON)` on the non-streaming `GoogleGenAiChatModel` built in `GoogleGenAiUtil`. In this mode Gemini's API returns syntactically valid, unfenced, properly-escaped JSON, eliminating both failure modes at the source instead of trying to repair malformed text afterward. The capability-flip alternative (advertising `RESPONSE_FORMAT_JSON_SCHEMA`) was rejected: `AgentInvocation.arguments` is an open `Map`, so its generated schema has empty `properties` and would make Gemini return empty arguments. The change is scoped to the supervisor's non-streaming model; the streaming model used by the sub-agent LLM nodes stays in text mode, since their responses are prose. As a side effect, the supervisor's summarization and scoring calls (which share this model) also run in JSON mode — both are internal and tolerated it in testing.

### How the failure was reproduced

The bug depends on the model emitting malformed JSON, which is intermittent and cannot be forced by prompting. To reproduce it deterministically, a temporary hook in `GoogleGenAiChatModel.chat()` un-escaped quotes (`\"` becomes `"`) in the planner's response, turning Gemini's fenced-but-valid output into the ticket's exact fence + unescaped-quote payload. With the fix off, a quote-heavy prompt then produced the ticket's `OutputParsingException` live (`Unexpected character ('`' code 96) ... line 1, column 1` at `SupervisorAgentImpl._handleException`), matching the ticket. With the fix on and the hook removed, the same prompt returned unfenced, escaped JSON that parsed cleanly (`done` plus response scores), no error. The reproduction hook, temporary logging, and a local web-search bypass used during validation were all reverted; only the one-line fix and its test remain.

## Why the Test Coverage Is a Unit Test

`GoogleGenAiUtilTest` asserts the effective request config of the built models: the supervisor's non-streaming model requests JSON mode, and the streaming sub-agent model does not — guarding the two regressions we control (the fix being removed, or JSON mode leaking to the sub-agent model).

An end-to-end "the crash never recurs" test is intentionally omitted. The failure originates in a stochastic external model, and the fix is preventive (it constrains the request; that valid JSON comes back is Gemini's API contract). That outcome can only be exercised against real Vertex AI — nondeterministic and costly — so it belongs in the AI Hub daily-routine Vertex suite, not a per-PR check. The live before/after above is the manual end-to-end evidence.

## PR Check

**pr-check: PASS** — tested on `8f24c7a938103ed780c7e8e24b059f13e367b363`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8f24c7a938103ed780c7e8e24b059f13e367b363"} -->
