### PR TITLE
LPD-94145 Add expand toggle to the AI Assistant chat

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -492,7 +492,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 
 	if (embedded) {
 		return (
-			<div className="ai-assistant ai-assistant-chat__embedded d-flex flex-column pt-3">
+			<div className="ai-assistant ai-assistant-chat__embedded">
 				{chatSurface}
 			</div>
 		);
@@ -535,15 +535,15 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 				</ClayButton>
 			}
 		>
-			<div className="ai-assistant ai-assistant-chat__dropdown-container d-flex flex-column">
-				<div className="flex-shrink-0 mb-3 pt-2 px-4">
-					<ClayLayout.ContentRow className="align-items-center border-bottom justify-content-between pb-2">
+			<div className="ai-assistant ai-assistant-chat__dropdown-container">
+				<div className="ai-assistant-chat__dropdown-header">
+					<ClayLayout.ContentRow className="ai-assistant-chat__dropdown-header-row">
 						<ClayLayout.ContentCol className="ai-assistant-chat__dropdown-title">
 							{Liferay.Language.get('ai-assistant')}
 						</ClayLayout.ContentCol>
 
 						<ClayLayout.ContentCol>
-							<div className="align-items-center d-flex">
+							<div className="ai-assistant-chat__dropdown-actions">
 								<ClayButton
 									aria-expanded={expanded}
 									aria-label={
@@ -568,7 +568,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 									/>
 								</ClayButton>
 
-								<div className="ai-assistant-chat__separator align-self-center" />
+								<div className="ai-assistant-chat__separator" />
 
 								<ClayButton
 									aria-label={Liferay.Language.get('close')}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -64,6 +64,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	quickActions,
 }) => {
 	const [active, setActive] = useState<boolean>(false);
+	const [expanded, setExpanded] = useState<boolean>(false);
 	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
 		{}
 	);
@@ -504,16 +505,16 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 			className="d-flex p-0"
 			hasRightSymbols={false}
 			menuElementAttrs={{
-				className: 'cadmin',
-				style: {
-					height: 552,
-					maxHeight: 'none',
-					maxWidth: 'none',
-					overflow: 'hidden',
-					width: 448,
-				},
+				'aria-expanded': expanded,
+				'className': 'cadmin ai-assistant-chat__panel',
 			}}
-			onActiveChange={setActive}
+			onActiveChange={(nextActive) => {
+				setActive(nextActive);
+
+				if (!nextActive) {
+					setExpanded(false);
+				}
+			}}
 			trigger={
 				<ClayButton
 					aria-label={Liferay.Language.get('ai-assistant')}
@@ -535,25 +536,53 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 			}
 		>
 			<div className="ai-assistant ai-assistant-chat__dropdown-container d-flex flex-column">
-				<div className="flex-shrink-0 p-3">
-					<ClayLayout.ContentRow className="align-items-center border-bottom justify-content-between mb-3 pb-2">
-						<ClayLayout.ContentCol className="ai-assistant-chat__dropdown-title font-weight-semi-bold">
+				<div className="flex-shrink-0 mb-3 pt-2 px-4">
+					<ClayLayout.ContentRow className="align-items-center border-bottom justify-content-between pb-2">
+						<ClayLayout.ContentCol className="ai-assistant-chat__dropdown-title">
 							{Liferay.Language.get('ai-assistant')}
 						</ClayLayout.ContentCol>
 
 						<ClayLayout.ContentCol>
-							<ClayButton
-								aria-label={Liferay.Language.get('close')}
-								borderless
-								displayType="unstyled"
-								onClick={() => setActive(false)}
-							>
-								<ClayIcon
-									className="ai-assistant-chat__dropdown-close-button"
-									spritemap={Liferay.Icons.spritemap}
-									symbol="times"
-								/>
-							</ClayButton>
+							<div className="align-items-center d-flex">
+								<ClayButton
+									aria-expanded={expanded}
+									aria-label={
+										expanded
+											? Liferay.Language.get('minimize')
+											: Liferay.Language.get('maximize')
+									}
+									borderless
+									className="ai-assistant-chat__dropdown-minmax-button"
+									displayType="unstyled"
+									onClick={() =>
+										setExpanded(
+											(expandedValue) => !expandedValue
+										)
+									}
+								>
+									<ClayIcon
+										spritemap={Liferay.Icons.spritemap}
+										symbol={
+											expanded ? 'compress' : 'full-size'
+										}
+									/>
+								</ClayButton>
+
+								<div className="ai-assistant-chat__separator align-self-center" />
+
+								<ClayButton
+									aria-label={Liferay.Language.get('close')}
+									borderless
+									displayType="unstyled"
+									onClick={() => setActive(false)}
+								>
+									<ClayIcon
+										className="ai-assistant-chat__dropdown-close-button"
+										spritemap={Liferay.Icons.spritemap}
+										symbol="times"
+									/>
+								</ClayButton>
+							</div>
 						</ClayLayout.ContentCol>
 					</ClayLayout.ContentRow>
 				</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -31,6 +31,7 @@ html#{$cadmin-selector} .cadmin {
 
 	.ai-assistant-chat__embedded {
 		height: 100%;
+		padding-top: 1rem;
 
 		.ai-assistant-chat__messages-container {
 			min-height: 200px;
@@ -44,12 +45,14 @@ html#{$cadmin-selector} .cadmin {
 
 	.ai-assistant-chat__dropdown-container,
 	.ai-assistant-chat__embedded {
+		display: flex;
+		flex-direction: column;
 		height: 100%;
 		width: 100%;
 
-		.ai-assistant-chat__dropdown-title {
-			color: $cadmin-gray-900;
-			font-weight: 600;
+		.ai-assistant-chat__dropdown-actions {
+			align-items: center;
+			display: flex;
 		}
 
 		.ai-assistant-chat__dropdown-close-button,
@@ -57,7 +60,28 @@ html#{$cadmin-selector} .cadmin {
 			color: $cadmin-gray-600;
 		}
 
+		.ai-assistant-chat__dropdown-header {
+			flex-shrink: 0;
+			margin-bottom: 1rem;
+			padding-left: 1.5rem;
+			padding-right: 1.5rem;
+			padding-top: 0.5rem;
+		}
+
+		.ai-assistant-chat__dropdown-header-row {
+			align-items: center;
+			border-bottom: $cadmin-border-width solid $cadmin-border-color;
+			justify-content: space-between;
+			padding-bottom: 0.5rem;
+		}
+
+		.ai-assistant-chat__dropdown-title {
+			color: $cadmin-gray-900;
+			font-weight: 600;
+		}
+
 		.ai-assistant-chat__separator {
+			align-self: center;
 			background-color: $cadmin-gray-500;
 			height: 16px;
 			margin-left: 0.5rem;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -1,6 +1,34 @@
 @import 'cadmin-variables';
 
 html#{$cadmin-selector} .cadmin {
+	&.ai-assistant-chat__panel {
+		height: 552px;
+		max-height: none;
+		max-width: none;
+		overflow: hidden;
+		transition:
+			height 0.3s ease,
+			width 0.3s ease;
+		width: 448px;
+
+		&[aria-expanded='true'] {
+			--ai-assistant-panel-top: calc(
+				var(--control-menu-container-height, 0px) +
+					var(--ai-assistant-panel-top-offset, 0px)
+			);
+
+			border-radius: 0;
+			height: calc(100vh - var(--ai-assistant-panel-top));
+			left: auto !important;
+			margin: 0;
+			position: fixed;
+			right: 0;
+			top: var(--ai-assistant-panel-top) !important;
+			transform: none;
+			width: 480px;
+		}
+	}
+
 	.ai-assistant-chat__embedded {
 		height: 100%;
 
@@ -21,12 +49,20 @@ html#{$cadmin-selector} .cadmin {
 
 		.ai-assistant-chat__dropdown-title {
 			color: $cadmin-gray-900;
+			font-weight: 600;
 		}
 
-		.ai-assistant-chat__dropdown-close-button {
+		.ai-assistant-chat__dropdown-close-button,
+		.ai-assistant-chat__dropdown-minmax-button {
 			color: $cadmin-gray-600;
-			height: 12;
-			width: 12;
+		}
+
+		.ai-assistant-chat__separator {
+			background-color: $cadmin-gray-500;
+			height: 16px;
+			margin-left: 0.5rem;
+			margin-right: 0.5rem;
+			width: 1px;
 		}
 
 		.ai-assistant-chat__footer-disclaimer {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -156,4 +156,29 @@ describe('AIAssistantChat', () => {
 			screen.queryByRole('button', {name: 'report-bad-result'})
 		).not.toBeInTheDocument();
 	});
+
+	it('toggles the expanded state when the maximize button is clicked', async () => {
+		await renderAndOpen();
+
+		const maximizeButton = screen.getByRole('button', {name: 'maximize'});
+
+		expect(maximizeButton).toHaveAttribute('aria-expanded', 'false');
+
+		await act(async () => {
+			fireEvent.click(maximizeButton);
+		});
+
+		const minimizeButton = screen.getByRole('button', {name: 'minimize'});
+
+		expect(minimizeButton).toHaveAttribute('aria-expanded', 'true');
+
+		await act(async () => {
+			fireEvent.click(minimizeButton);
+		});
+
+		expect(screen.getByRole('button', {name: 'maximize'})).toHaveAttribute(
+			'aria-expanded',
+			'false'
+		);
+	});
 });

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_control_menu.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_control_menu.scss
@@ -1,3 +1,8 @@
+body:has(.cms-control-menu) {
+	--ai-assistant-panel-top-offset: var(--top-bar-height);
+	--top-bar-height: 3.5rem;
+}
+
 .cms-control-menu {
 	border-bottom-width: 0.05rem;
 	border-color: $secondary-l0;

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -11,10 +11,6 @@
 	min-height: var(--sidebar-layout-height);
 	transition: 400ms ease-in-out;
 
-	.lfr-layout-structure-item-sidebar:has(.cms-control-menu) & {
-		--top-bar-height: 3.5rem;
-	}
-
 	.c-prefers-reduced-motion & {
 		transition: none;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94145

## What Is Being Fixed

The AI Assistant chat opened only as a fixed-size dropdown, with no way to enlarge it for longer conversations or content generation.

## How It Is Being Fixed

Adds a full-size/expand toggle (with a vertical separator) beside the close button in the AI Assistant chat header. Clicking it expands the chat into a full-height panel anchored to the right of the screen and swaps the Clay full-size/expand icon; the state is driven by aria-expanded on both the toggle button and the panel, and the resize is animated with a CSS transition.

The panel's top offset is generic — the control menu height plus an --ai-assistant-panel-top-offset hook that defaults to zero — so everywhere except the CMS the panel only clears the control menu. To make the CMS top bar height available to the body-level portal the panel renders into, --top-bar-height is hoisted onto body (guarded by :has(.cms-control-menu)) in the CMS page-bar, and the CMS sets the offset hook to that value.

## Why Are There No Tests?

The change is presentational — a CSS-driven expand/collapse toggle and layout offsets on an existing component. Behavior is covered by the existing AIAssistantChat Jest suite (14 suites / 60 tests), which passes; there is no new logic that warrants a dedicated unit test.

## PR Check

**pr-check: PASS** — tested on `f8032994f13ba57dea0652d4bf978b9ba0eed8b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f8032994f13ba57dea0652d4bf978b9ba0eed8b9"} -->
