### PR TITLE
LPD-94223 Add the Find Matching Assets agent

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -34,6 +34,10 @@ public class SearchResultEntityModel implements EntityModel {
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(
 				new IntegerEntityField(
+					"internalTaxonomyCategoryIds",
+					locale -> Field.ASSET_INTERNAL_CATEGORY_IDS)),
+			new CollectionEntityField(
+				new IntegerEntityField(
 					"taxonomyCategoryIds", locale -> "assetCategoryIds")),
 			new CollectionEntityField(
 				new StringEntityField(

--- a/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow API
 Bundle-SymbolicName: com.liferay.portal.workflow.api
-Bundle-Version: 16.2.1
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.portal.workflow.comparator,\
 	com.liferay.portal.workflow.configuration,\

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -13,6 +13,9 @@ public class WorkflowDefinitionConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_CHANGE_TONE =
 		"L_CHANGE_TONE";
 
+	public static final String EXTERNAL_REFERENCE_CODE_FIND_MATCHING_ASSETS =
+		"L_FIND_MATCHING_ASSETS";
+
 	public static final String
 		EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR =
 			"L_FIX_SPELLING_AND_GRAMMAR";
@@ -42,6 +45,9 @@ public class WorkflowDefinitionConstants {
 
 	public static final String NAME_CHANGE_TONE = "Change Tone";
 
+	public static final String NAME_FIND_MATCHING_ASSETS =
+		"Find Matching Assets";
+
 	public static final String NAME_FIX_SPELLING_AND_GRAMMAR =
 		"Fix Spelling and Grammar";
 
@@ -68,7 +74,8 @@ public class WorkflowDefinitionConstants {
 	public static final String SCOPE_ALL = "all";
 
 	public static final String[] SYSTEM_WORKFLOW_DEFINITION_NAMES = {
-		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
+		NAME_CHANGE_TONE, NAME_FIND_MATCHING_ASSETS,
+		NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
 		NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER, NAME_MAKE_SHORTER,
 		NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -647,7 +647,7 @@ public class AgentDefinitionResourceTest
 	private void _testGetAgentDefinitionsPage() throws Exception {
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), null);
+				null, null, Pagination.of(1, 11), null);
 
 		assertEquals(
 			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
@@ -680,7 +680,7 @@ public class AgentDefinitionResourceTest
 		// Date created
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 11),
 			null);
 
 		assertEquals(
@@ -689,7 +689,7 @@ public class AgentDefinitionResourceTest
 		// Date modified
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 11),
 			null);
 
 		assertEquals(
@@ -938,6 +938,61 @@ public class AgentDefinitionResourceTest
 					version = 1;
 					workflowDefinitionName =
 						WorkflowDefinitionConstants.NAME_CHANGE_TONE;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode =
+						WorkflowDefinitionConstants.
+							EXTERNAL_REFERENCE_CODE_FIND_MATCHING_ASSETS;
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "cmsGroupId";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "funnelStageId";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "keywords";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "personaId";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "portalURL";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "tasks";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "matchingAssets";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName =
+						WorkflowDefinitionConstants.NAME_FIND_MATCHING_ASSETS;
 				}
 			},
 			new AgentDefinition() {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -291,6 +291,11 @@ public class AIHubSiteInitializerTest {
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_FIND_MATCHING_ASSETS,
+			WorkflowDefinitionConstants.NAME_FIND_MATCHING_ASSETS);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
+			WorkflowDefinitionConstants.
 				EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR,
 			WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR);
 		_assertWorkflowDefinitionExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -28,6 +28,19 @@
 		},
 		{
 			"active": true,
+			"description": "This agent searches the broader CMS for existing assets that match a content gap's persona and funnel stage so they can be reused to fill the gap. It never modifies content.",
+			"externalReferenceCode": "L_FIND_MATCHING_ASSETS",
+			"inputVariables": "cmsGroupId,funnelStageId,keywords,personaId,portalURL,tasks",
+			"outputVariable": "matchingAssets",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Find Matching Assets"
+			},
+			"workflowDefinitionName": "Find Matching Assets"
+		},
+		{
+			"active": true,
 			"description": "This writing agent acts as an expert linguistic editor, correcting grammar and spelling errors while strictly preserving your original tone and style.",
 			"externalReferenceCode": "L_FIX_SPELLING_AND_GRAMMAR",
 			"inputVariables": "text",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/find-matching-assets-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/find-matching-assets-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_FIND_MATCHING_ASSETS",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Find Matching Assets",
+	"scope": "ai",
+	"title": "Find Matching Assets",
+	"title_i18n": {
+		"en_US": "Find Matching Assets"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/find-matching-assets-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/find-matching-assets-workflow-definition/workflow-definition.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Find Matching Assets</name>
+	<version>1</version>
+	<http-request>
+		<name>findMatchingAssets</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Find Matching Assets
+			</label>
+		</labels>
+		<http-method>GET</http-method>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "portalURL",
+						"type": "string"
+					},
+					{
+						"name": "cmsGroupId",
+						"type": "string"
+					},
+					{
+						"name": "personaId",
+						"type": "string"
+					},
+					{
+						"name": "funnelStageId",
+						"type": "string"
+					},
+					{
+						"name": "keywords",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "findResults",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<timeout>10000</timeout>
+		<transitions>
+			<transition>
+				<name>narrateMatches</name>
+				<target>narrateMatches</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<url>{{portalURL}}/o/search/v1.0/search?scope={{cmsGroupId}}&amp;emptySearch=true&amp;search={{keywords}}&amp;pageSize=20&amp;filter=%28cmsSection%20eq%20%27contents%27%20or%20cmsSection%20eq%20%27files%27%29%20and%20rootDescendantNode%20eq%20false%20and%20internalTaxonomyCategoryIds%2Fany%28c%3Ac%20eq%20{{personaId}}%29%20and%20internalTaxonomyCategoryIds%2Fany%28c%3Ac%20eq%20{{funnelStageId}}%29</url>
+	</http-request>
+	<llm>
+		<name>narrateMatches</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Narrate Matches
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "findResults",
+						"type": "string"
+					},
+					{
+						"name": "tasks",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "matchingAssets",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[You help a project owner fill a content coverage gap by reusing existing CMS assets. You are given "findResults", the JSON response from a search of the CMS for content that already carries the gap's persona and funnel-stage categories, and "tasks", a JSON array of the project's tasks (each with an id, title, and description). Rank the found assets from most to least relevant to the gap. For each asset, write a single concise sentence explaining why it matches, and choose the single best-fit task id from "tasks" by matching the asset's topic to the task title and description. Output ONLY a raw JSON object, with no markdown fences and no commentary, of the exact shape: {"matches":[{"assetId":"","externalReferenceCode":"","assetType":"","title":"","space":"","relevanceScore":0,"reason":"","taskId":""}],"noMatches":false,"summary":""}. "relevanceScore" is an integer from 0 to 100. "summary" is one sentence such as "N matching assets found." If the search returned no results, return an empty "matches" array, set "noMatches" to true, and set "summary" to a sentence noting that no existing assets match and suggesting generating new content for this gap.]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[These are the CMS search results and the project tasks for the coverage gap. Search results: {{findResults}} Project tasks: {{tasks}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Find Matching Assets
+					</label>
+				</labels>
+				<name>findMatchingAssets</name>
+				<target>findMatchingAssets</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						676
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94223

## What Is Being Fixed

The Content GAP Analysis epic's second story needs to fill a detected content coverage gap by reusing existing CMS assets. Given a gap — a persona and funnel stage with no content — there was no agent to search the broader CMS for assets already categorized for that persona and funnel stage and surface them for reuse, and no search filter to query content by its internal (non public) taxonomy categories, which is how the CMP personas and funnel stages are modeled.

## How It Is Being Fixed

Adds an internalTaxonomyCategoryIds filter field to the /o/search/v1.0/search entity model, mapping to Field.ASSET_INTERNAL_CATEGORY_IDS, so callers can filter content by internal vocabulary categories (the existing taxonomyCategoryIds covers only public vocabularies). Seeds a new out of the box "Find Matching Assets" AI Hub agent through the AI Hub site initializer as an ai scope Kaleo workflow: an http-request node queries /o/search with the gap's persona and funnel stage category ids, and an llm node ranks the matches, explains why each fits, and picks the best fit project task. The agent is registered the same way as the Content Gap Analysis agent — WorkflowDefinitionConstants gains EXTERNAL_REFERENCE_CODE_FIND_MATCHING_ASSETS and NAME_FIND_MATCHING_ASSETS, the name joins SYSTEM_WORKFLOW_DEFINITION_NAMES, with the required portal-workflow-api constants package version bump. AIHubSiteInitializerTest asserts the workflow is seeded at site creation, which also validates the workflow XML parses, and AgentDefinitionResourceTest is updated so its expected agent set includes the new agent.

## PR Check

**pr-check: PASS** — tested on `9d6a789464bb590dd2bcb334821d29f9116dae99`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

Cross-Module Compile: the WorkflowDefinitionConstants change is additive only (new constants plus a new SYSTEM_WORKFLOW_DEFINITION_NAMES entry, nothing removed or changed), so no consumer can fail to compile; its testIntegration consumers exceed the eight module cap and are covered by Integration Test Compile.

<!-- pr-check {"result": "success", "sha": "9d6a789464bb590dd2bcb334821d29f9116dae99"} -->
