### PR TITLE
LPD-97088 Support keyboard navigation in the Send Feedback modal

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/ReportFeedback/ReportFeedbackModal.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/ReportFeedback/ReportFeedbackModal.tsx
@@ -58,7 +58,10 @@ const ReportFeedbackModal: React.FC<ReportFeedbackModalProps> = ({
 	}
 
 	return (
-		<ClayModal observer={observer}>
+		<ClayModal
+			observer={observer}
+			onKeyDown={(event) => event.stopPropagation()}
+		>
 			<ClayForm onSubmit={handleSubmit}>
 				<ClayModal.Header
 					closeButtonAriaLabel={Liferay.Language.get('close')}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/ReportFeedback/ReportFeedbackModal.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/ReportFeedback/ReportFeedbackModal.test.tsx
@@ -111,4 +111,22 @@ describe('ReportFeedbackModal', () => {
 		expect(await screen.findByText('submit failed')).toBeInTheDocument();
 		expect(openToast).not.toHaveBeenCalled();
 	});
+
+	it('does not propagate key events to surrounding components', async () => {
+		const onAncestorKeyDown = jest.fn();
+
+		render(
+			<div onKeyDown={onAncestorKeyDown}>
+				<ReportFeedbackModal
+					agentDefinitionExternalReferenceCodes={['agent-1']}
+					onClose={jest.fn()}
+					surface="aiAssistant"
+				/>
+			</div>
+		);
+
+		fireEvent.keyDown(await screen.findByRole('combobox'), {key: 'Tab'});
+
+		expect(onAncestorKeyDown).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97088

## What Is Being Fixed

The Send Feedback modal in the AI Assistant chat had no keyboard navigation. Pressing Tab inside the modal closed the entire AI Assistant chat instead of moving focus between the modal's fields, leaving the modal unusable for keyboard-only users.

## How It Is Being Fixed

The modal is rendered as a React child of the chat's ClayDropDown, whose menu closes on Tab. Because React synthetic events bubble up the component tree regardless of the modal's DOM portal, every keystroke inside the modal reached the dropdown's Tab handler and closed the chat. Adding an onKeyDown handler on the ClayModal that stops propagation keeps those events from reaching the dropdown, while ClayModal's own Tab focus-trap and Esc handling — which run on native document listeners — keep working. Focus now cycles through the Reason, Comment, Cancel, and Send controls, and Esc closes only the modal. This mirrors the workaround the chat's text area already uses.

## PR Check

**pr-check: PASS** — tested on `5697d222c28500a52b7fdcb400078d208588040d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5697d222c28500a52b7fdcb400078d208588040d"} -->
