### PR TITLE
LPD-97446 Fix positive rating always showing 0% on the feedback cards

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewIssueReportsDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewIssueReportsDisplayContext.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.web.internal.display.context;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -72,7 +73,8 @@ public class ViewIssueReportsDisplayContext {
 				new DefaultDTOConverterContext(
 					false, null, null, _httpServletRequest, null,
 					_themeDisplay.getLocale(), null, _themeDisplay.getUser()),
-				null, Pagination.of(1, 1), null, null);
+				null, Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null,
+				null);
 
 			criticalCount = _getFacetCount(page, "level", "critical");
 			negativeCount = _getFacetCount(page, "feedback", "negative");

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/ViewIssueReportsDisplayContextTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/ViewIssueReportsDisplayContextTest.java
@@ -8,12 +8,14 @@ package com.liferay.ai.hub.web.internal.display.context;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.aggregation.Facet;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -87,34 +89,45 @@ public class ViewIssueReportsDisplayContextTest {
 			Mockito.mock(ObjectDefinition.class)
 		);
 
-		Page<?> page = Mockito.mock(Page.class);
-
-		Mockito.when(
-			page.getTotalCount()
-		).thenReturn(
-			10L
-		);
-
-		Mockito.when(
-			page.getFacets()
-		).thenReturn(
-			List.of(
-				new Facet(
-					"level", List.of(new Facet.FacetValue(2, "critical"))),
-				new Facet(
-					"feedback",
-					List.of(
-						new Facet.FacetValue(3, "negative"),
-						new Facet.FacetValue(6, "positive"))))
-		);
-
 		Mockito.when(
 			_objectEntryManager.getObjectEntries(
 				Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.any(),
 				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
 				Mockito.any())
-		).thenReturn(
-			(Page)page
+		).thenAnswer(
+			invocation -> {
+				Pagination pagination = invocation.getArgument(6);
+
+				int pageSize = pagination.getPageSize();
+
+				Page<?> page = Mockito.mock(Page.class);
+
+				Mockito.when(
+					page.getTotalCount()
+				).thenReturn(
+					10L
+				);
+
+				Mockito.when(
+					page.getFacets()
+				).thenReturn(
+					List.of(
+						new Facet(
+							"level",
+							_limitFacetValues(
+								List.of(new Facet.FacetValue(2, "critical")),
+								pageSize)),
+						new Facet(
+							"feedback",
+							_limitFacetValues(
+								List.of(
+									new Facet.FacetValue(3, "negative"),
+									new Facet.FacetValue(6, "positive")),
+								pageSize)))
+				);
+
+				return page;
+			}
 		);
 
 		Map<String, Object> cardsReactData =
@@ -143,6 +156,16 @@ public class ViewIssueReportsDisplayContextTest {
 		Assert.assertEquals(0L, cardsReactData.get("criticalIssuesCount"));
 		Assert.assertEquals(0, cardsReactData.get("dislikeRatingPercent"));
 		Assert.assertEquals(0, cardsReactData.get("positiveRatingPercent"));
+	}
+
+	private List<Facet.FacetValue> _limitFacetValues(
+		List<Facet.FacetValue> facetValues, int pageSize) {
+
+		if (pageSize == QueryUtil.ALL_POS) {
+			return facetValues;
+		}
+
+		return facetValues.subList(0, Math.min(pageSize, facetValues.size()));
 	}
 
 	@Mock


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97446

## What Is Being Fixed

On the Monitor AI Agent Feedback admin page, when both positive and negative feedback have been reported, the positive rating card always showed 0%, while the dislike and critical issue cards were correct.

## How It Is Being Fixed

The card counts come from ViewIssueReportsDisplayContext.getCardsReactData(), which aggregates the AIHubReport entries by feedback and level. It requested the aggregation with Pagination.of(1, 1), and that pagination window is applied to the aggregation GROUP BY itself (getAggregationCounts appends LIMIT start, end with no ORDER BY), so only the first bucket per term was returned. Databases return the grouped rows in ascending key order, so the negative bucket won the single slot and positive was dropped, leaving positiveCount always 0; criticalIssuesCount survived only because critical sorts first among the level values. The fix requests a page size large enough to return every feedback and level bucket. The unit test is updated to make the mocked page pagination-aware, truncating the facet buckets to the requested page size, so it reproduces the 0% behavior on the old value and passes on the fix.

## PR Check

**pr-check: PASS** — tested on `8394174d11387e1a6c0e2105debd8bb9638e1953`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8394174d11387e1a6c0e2105debd8bb9638e1953"} -->
