### PR TITLE
LPD-97619 Extract workflow node Tools into a top-level class

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/tool/WorkflowNodeTools.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/tool/WorkflowNodeTools.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -11,11 +11,13 @@ import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCall
 import com.liferay.portal.kernel.workflow.WorkflowNodeManager;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.invocation.InvocationParameters;
 
 import java.io.Serializable;
+
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -49,16 +51,12 @@ public class WorkflowNodeTools {
 				});
 	}
 
-	@Tool(
-		"Complete the workflow node by proceeding to the chosen transition"
-	)
+	@Tool("Complete the workflow node by proceeding to the chosen transition")
 	public void completeWorkflowNode(
-		InvocationParameters invocationParameters,
-		@P(
-			"A brief, one-sentence justification for the chosen transition."
-		)
-		String reason,
-		@P("Transition name") String transitionName)
+			InvocationParameters invocationParameters,
+			@P("A brief, one-sentence justification for the chosen transition.")
+				String reason,
+			@P("Transition name") String transitionName)
 		throws PortalException {
 
 		_invocationParameters = invocationParameters;
@@ -77,4 +75,5 @@ public class WorkflowNodeTools {
 	private InvocationParameters _invocationParameters;
 	private String _reason;
 	private String _transitionName;
+
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/tool/WorkflowNodeTools.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/tool/WorkflowNodeTools.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.tool;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
+import com.liferay.portal.kernel.workflow.WorkflowNodeManager;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.invocation.InvocationParameters;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class WorkflowNodeTools {
+
+	public WorkflowNodeTools(WorkflowNodeManager workflowNodeManager) {
+		_completeWorkflowNodeCallable =
+			new CompanyInheritableThreadLocalCallable<>(
+				() -> {
+					ExecutionContext executionContext =
+						_invocationParameters.get("executionContext");
+
+					KaleoInstanceToken kaleoInstanceToken =
+						executionContext.getKaleoInstanceToken();
+
+					Map<String, Serializable> workflowContext =
+						executionContext.getWorkflowContext();
+
+					workflowContext.put("reason", _reason);
+
+					workflowNodeManager.completeWorkflowNode(
+						kaleoInstanceToken.getCompanyId(),
+						kaleoInstanceToken.getUserId(),
+						kaleoInstanceToken.getKaleoInstanceTokenId(),
+						_transitionName, workflowContext, false);
+
+					return null;
+				});
+	}
+
+	@Tool(
+		"Complete the workflow node by proceeding to the chosen transition"
+	)
+	public void completeWorkflowNode(
+		InvocationParameters invocationParameters,
+		@P(
+			"A brief, one-sentence justification for the chosen transition."
+		)
+		String reason,
+		@P("Transition name") String transitionName)
+		throws PortalException {
+
+		_invocationParameters = invocationParameters;
+		_reason = reason;
+		_transitionName = transitionName;
+
+		try {
+			_completeWorkflowNodeCallable.call();
+		}
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
+		}
+	}
+
+	private final Callable<Void> _completeWorkflowNodeCallable;
+	private InvocationParameters _invocationParameters;
+	private String _reason;
+	private String _transitionName;
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -28,10 +28,8 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.petra.concurrent.NoticeableExecutorService;
 import com.liferay.petra.executor.PortalExecutorManager;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -49,8 +47,6 @@ import com.liferay.portal.workflow.kaleo.runtime.graph.PathElement;
 import com.liferay.portal.workflow.kaleo.runtime.node.BaseNodeExecutor;
 import com.liferay.portal.workflow.kaleo.runtime.node.NodeExecutor;
 
-import dev.langchain4j.agent.tool.P;
-import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.invocation.InvocationParameters;
@@ -60,7 +56,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Activate;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -13,6 +13,7 @@ import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.InputG
 import com.liferay.ai.hub.internal.langchain4j.observability.api.listener.OutputGuardrailExecutedListenerImpl;
 import com.liferay.ai.hub.internal.mcp.tool.provider.MCPToolProviderUtil;
 import com.liferay.ai.hub.internal.model.GoogleGenAiUtil;
+import com.liferay.ai.hub.internal.tool.WorkflowNodeTools;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.GuardrailsUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoNodeSettingUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.MessageUtil;
@@ -77,64 +78,6 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 	@Override
 	public NodeType getNodeType() {
 		return NodeType.AI_DECISION;
-	}
-
-	public class Tools {
-
-		public Tools() {
-			_completeWorkflowNodeCallable =
-				new CompanyInheritableThreadLocalCallable<>(
-					() -> {
-						ExecutionContext executionContext =
-							_invocationParameters.get("executionContext");
-
-						KaleoInstanceToken kaleoInstanceToken =
-							executionContext.getKaleoInstanceToken();
-
-						Map<String, Serializable> workflowContext =
-							executionContext.getWorkflowContext();
-
-						workflowContext.put("reason", _reason);
-
-						_workflowNodeManager.completeWorkflowNode(
-							kaleoInstanceToken.getCompanyId(),
-							kaleoInstanceToken.getUserId(),
-							kaleoInstanceToken.getKaleoInstanceTokenId(),
-							_transitionName, workflowContext, false);
-
-						return null;
-					});
-		}
-
-		@Tool(
-			"Complete the workflow node by proceeding to the chosen transition"
-		)
-		public void completeWorkflowNode(
-				InvocationParameters invocationParameters,
-				@P(
-					"A brief, one-sentence justification for the chosen transition."
-				)
-				String reason,
-				@P("Transition name") String transitionName)
-			throws PortalException {
-
-			_invocationParameters = invocationParameters;
-			_reason = reason;
-			_transitionName = transitionName;
-
-			try {
-				_completeWorkflowNodeCallable.call();
-			}
-			catch (Exception exception) {
-				ReflectionUtil.throwException(exception);
-			}
-		}
-
-		private final Callable<Void> _completeWorkflowNodeCallable;
-		private InvocationParameters _invocationParameters;
-		private String _reason;
-		private String _transitionName;
-
 	}
 
 	@Activate
@@ -241,7 +184,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			).systemMessageProviderFunction(
 				memoryId -> prompt
 			).tools(
-				new Tools()
+				new WorkflowNodeTools(_workflowNodeManager)
 			).toolProvider(
 				MCPToolProviderUtil.create(
 					kaleoInstanceToken.getCompanyId(), _dtoConverterRegistry,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97619

## What Is Being Fixed

The workflow-node completion tool used by the AI Decision node executor lived as a public inner class (`Tools`) on `AIDecisionNodeExecutor`. Nesting it inside the executor tied the tool's `WorkflowNodeManager` dependency to the enclosing instance's field and made the tool harder to reuse and reason about in isolation.

## How It Is Being Fixed

The inner `Tools` class was extracted into a standalone top-level class, `WorkflowNodeTools`, under `com.liferay.ai.hub.internal.tool`. The `WorkflowNodeManager` it needs is now passed through the constructor rather than read from the enclosing executor's field, and `AIDecisionNodeExecutor` instantiates it with `new WorkflowNodeTools(_workflowNodeManager)`. The tool's behavior — completing the workflow node on the chosen transition and recording the reason in the workflow context — is unchanged.

## Why Are There No Tests?

This is a pure refactor with no behavior change: the inner `Tools` class was extracted into a top-level `WorkflowNodeTools` class. Existing coverage of `AIDecisionNodeExecutor` applies unchanged.

## PR Check

**pr-check: PASS** — tested on `ce7ed203f02641feefdd34c1d1d3cebff513f6a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ce7ed203f02641feefdd34c1d1d3cebff513f6a4"} -->
