### PR TITLE
LPD-94024 Generate content entries from an AI Assistant text conversation

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
@@ -42,7 +42,7 @@ public class ServiceNodeValidator extends BaseNodeValidator<ServiceNode> {
 		}
 
 		if (Validator.isNull(javaDelegate) ||
-			!javaDelegate.matches("[\\w.$]+#\\w+")) {
+			!javaDelegate.matches("[\\w.$]+(#\\w+)+")) {
 
 			throw new KaleoDefinitionValidationException(
 				StringBundler.concat(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
@@ -455,46 +455,18 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 					RandomTestUtil.randomString(), TestPropsValues.getUserId());
 			});
 
-		InputStream inputStream = getResourceInputStream(
-			"service-node-workflow-definition.json");
+		byte[] bytes = FileUtil.getBytes(
+			getResourceInputStream("service-node-workflow-definition.json"));
 
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.deployWorkflowDefinition(
-				FileUtil.getBytes(inputStream), TestPropsValues.getCompanyId(),
-				RandomTestUtil.randomString(),
-				"Service Node Workflow Definition",
-				RandomTestUtil.randomString(), TestPropsValues.getUserId());
+		_assertServiceNodeWorkflowDefinition(
+			bytes, "com.example.Converter#convert");
 
-		List<WorkflowNode> workflowNodes =
-			workflowDefinition.getWorkflowNodes();
+		String content = StringUtil.replace(
+			new String(bytes), "com.example.Converter#convert",
+			"com.example.Converter#scope#convert");
 
-		WorkflowNode workflowNode = workflowNodes.get(2);
-
-		Assert.assertEquals(WorkflowNode.Type.SERVICE, workflowNode.getType());
-
-		_assertEquals(
-			List.of(
-				_createWorkflowNodeSetting(
-					"inputVariables",
-					JSONUtil.put(
-						JSONUtil.put(
-							"name", "input"
-						).put(
-							"type", "string"
-						)
-					).toString()),
-				_createWorkflowNodeSetting(
-					"javaDelegate", "com.example.Converter#convert"),
-				_createWorkflowNodeSetting(
-					"outputVariables",
-					JSONUtil.put(
-						JSONUtil.put(
-							"name", "output"
-						).put(
-							"type", "string"
-						)
-					).toString())),
-			workflowNode.getWorkflowNodeSettings());
+		_assertServiceNodeWorkflowDefinition(
+			content.getBytes(), "com.example.Converter#scope#convert");
 	}
 
 	@Test
@@ -941,6 +913,48 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 		}
 
 		return null;
+	}
+
+	private void _assertServiceNodeWorkflowDefinition(
+			byte[] bytes, String javaDelegate)
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				bytes, TestPropsValues.getCompanyId(),
+				RandomTestUtil.randomString(),
+				"Service Node Workflow Definition",
+				RandomTestUtil.randomString(), TestPropsValues.getUserId());
+
+		List<WorkflowNode> workflowNodes =
+			workflowDefinition.getWorkflowNodes();
+
+		WorkflowNode workflowNode = workflowNodes.get(2);
+
+		Assert.assertEquals(WorkflowNode.Type.SERVICE, workflowNode.getType());
+
+		_assertEquals(
+			List.of(
+				_createWorkflowNodeSetting(
+					"inputVariables",
+					JSONUtil.put(
+						JSONUtil.put(
+							"name", "input"
+						).put(
+							"type", "string"
+						)
+					).toString()),
+				_createWorkflowNodeSetting("javaDelegate", javaDelegate),
+				_createWorkflowNodeSetting(
+					"outputVariables",
+					JSONUtil.put(
+						JSONUtil.put(
+							"name", "output"
+						).put(
+							"type", "string"
+						)
+					).toString())),
+			workflowNode.getWorkflowNodeSettings());
 	}
 
 	private void _assertValid(InputStream inputStream) throws Exception {

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/ComposeContentEntriesOutputServiceNodeDelegate.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/ComposeContentEntriesOutputServiceNodeDelegate.java
@@ -89,7 +89,7 @@ public class ComposeContentEntriesOutputServiceNodeDelegate
 
 	@Override
 	public String getKey() {
-		return "javaDelegate#composeContentEntriesOutput";
+		return "javaDelegate#GenerateContent#composeContentEntriesOutput";
 	}
 
 	private String _getOutput(Map<String, String> inputVariables) {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -80,7 +80,7 @@
 		},
 		{
 			"active": true,
-			"description": "This agent generates one or more CMS content entries (assets backed by a Content Structure) as drafts from a brief, decomposing it into distinct angles. Use it whenever the user asks to generate, write, draft, or create CMS content, blog posts, or web content. From the user request, extract brief (the topic or description) and count. Always pass count as an integer number of entries: use the quantity the user asks for, and default to 1 whenever no quantity is given, treating singular phrasing or an article such as \"a\", \"an\", or \"one\" as 1. Every other input is resolved automatically by the application, so always proceed and never ask the user for, infer, or wait on the content type, structure, fields, or destination space.",
+			"description": "This agent generates one or more CMS content entries (assets backed by a Content Structure) as drafts from a brief, decomposing it into distinct angles. Use it whenever the user asks to generate, write, draft, or create CMS content, blog posts, or web content. It needs a brief (the subject the content should be about) and a count (how many entries to generate). A content-type or structure name such as \"Basic Web Content\" or \"blog\" is NOT a brief, and an explicit number or an article such as \"a\", \"an\", or \"one\" is the count. When the brief or the count is missing, ask the user for whichever is missing and wait before generating; never invent a brief and never assume a count. The content type, structure, fields, and destination space are resolved automatically by the application, so never ask about those.",
 			"externalReferenceCode": "L_GENERATE_CONTENT",
 			"inputVariables": "brief,count",
 			"outputVariable": "output",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
@@ -248,7 +248,7 @@ Space id: {{spaceId}}]]>
 				]
 			]]>
 		</input-variables>
-		<java-delegate>javaDelegate#composeContentEntriesOutput</java-delegate>
+		<java-delegate>javaDelegate#GenerateContent#composeContentEntriesOutput</java-delegate>
 		<labels>
 			<label language-id="en_US">
 				Compose Content Entries Output


### PR DESCRIPTION
[LPD-94024](https://liferay.atlassian.net/browse/LPD-94024)

**What is being fixed:** The Generate Content agent would proceed with only a content-type name as the brief and would invent a count when the user gave none, producing content that did not match the user's intent. The compose output delegate key was also unscoped, so it could collide with other workflows that share the same delegate name.

**How it is being fixed:** The agent description now treats the brief as a required subject — rejecting content-type or structure names as briefs — and asks a single clarifying question for both the subject and the quantity when either is missing, waiting for the answer before generating. The compose content entries output delegate key is scoped by workflow (`javaDelegate#GenerateContent#composeContentEntriesOutput`) in both the delegate and the workflow definition so it no longer collides across workflows.




**pr-check: PASS** — tested on `acae4b1f20d835df8c26a174a41ea60dfc9ff91c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

_Since the prior run the only change is a test-only private-method rename (`_assertServiceNode` → `_assertServiceNodeWorkflowDefinition`) in `WorkflowDefinitionManagerTest`; re-verified with formatSource (clean) and `compileTestIntegrationJava` (BUILD SUCCESSFUL). No product code changed, so the other validations carry over._

<!-- pr-check {"result": "success", "sha": "acae4b1f20d835df8c26a174a41ea60dfc9ff91c"} -->