### PR TITLE
LPD-94025 Add the Generate Field Value Agent

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -26,6 +26,9 @@ public class WorkflowDefinitionConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_CONTENT =
 		"L_GENERATE_CONTENT";
 
+	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_FIELD_VALUE =
+		"L_GENERATE_FIELD_VALUE";
+
 	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE =
 		"L_GENERATE_IMAGE";
 
@@ -64,6 +67,9 @@ public class WorkflowDefinitionConstants {
 		"Fix Spelling and Grammar";
 
 	public static final String NAME_GENERATE_CONTENT = "Generate Content";
+
+	public static final String NAME_GENERATE_FIELD_VALUE =
+		"Generate Field Value";
 
 	public static final String NAME_GENERATE_IMAGE = "Generate Image";
 

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -1123,6 +1123,31 @@ public class AgentDefinitionResourceTest
 			new AgentDefinition() {
 				{
 					active = true;
+					externalReferenceCode =
+						WorkflowDefinitionConstants.
+							EXTERNAL_REFERENCE_CODE_GENERATE_FIELD_VALUE;
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "instruction";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "properties";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName =
+						WorkflowDefinitionConstants.NAME_GENERATE_FIELD_VALUE;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
 					externalReferenceCode = "L_GENERATE_TAGS";
 					inputVariables = new Variable[] {
 						new Variable() {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -321,6 +321,7 @@ public class AgentInstanceResourceTest
 			_testPostAgentInstanceWithTypeAutoCategorize();
 			_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction();
 			_testPostAgentInstanceWithTypeGenerateContent();
+			_testPostAgentInstanceWithTypeGenerateFieldValue();
 			_testPostAgentInstanceWithTypeGenerateTags();
 			_testPostAgentInstanceWithTypeHTTPRequestNodeWithLLMNodeWorkflowDefinition();
 			_testPostAgentInstanceWithTypeLLMNodeWithRAGWorkflowDefinition();
@@ -854,6 +855,39 @@ public class AgentInstanceResourceTest
 			));
 
 		_assertContains(data, "AI-generated", "L_CONTENTS", "Liferay");
+	}
+
+	private void _testPostAgentInstanceWithTypeGenerateFieldValue()
+		throws Exception {
+
+		String data = _postAndAwaitAgentInstance(
+			"L_GENERATE_FIELD_VALUE",
+			JSONUtil.put(
+				"instruction", "Generate a title based on the description."
+			).put(
+				"objectFields",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"label", "Description"
+					).put(
+						"name", "description"
+					),
+					JSONUtil.put(
+						"label", "Title"
+					).put(
+						"name", "title"
+					)
+				).toString()
+			).put(
+				"properties",
+				JSONUtil.put(
+					"description",
+					"Liferay DXP is a digital experience platform for " +
+						"building websites, portals, and content."
+				).toString()
+			));
+
+		_assertContains(data, "title");
 	}
 
 	private void _testPostAgentInstanceWithTypeGenerateTags() throws Exception {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -310,6 +310,11 @@ public class AIHubSiteInitializerTest {
 			WorkflowDefinitionConstants.NAME_GENERATE_CONTENT);
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
+			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_GENERATE_FIELD_VALUE,
+			WorkflowDefinitionConstants.NAME_GENERATE_FIELD_VALUE);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE,
 			WorkflowDefinitionConstants.NAME_GENERATE_IMAGE);
 		_assertWorkflowDefinitionExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -93,6 +93,19 @@
 		},
 		{
 			"active": true,
+			"description": "This agent generates the value of a single field of the content entry the user is currently editing, deriving it from the values already filled in the entry's other fields and/or a brief. Use it whenever the user asks to generate, write, or fill one field based on other fields or a description - for example \"generate a title based on the content\", \"write the body from the title\", or \"fill field C from field A and field B\". From the user request, extract instruction. The field definitions and the current field values of the open entry are resolved automatically by the application, so always proceed and never ask the user for them. It returns only the generated value and does not create fields, create content entries, or save anything.",
+			"externalReferenceCode": "L_GENERATE_FIELD_VALUE",
+			"inputVariables": "instruction",
+			"outputVariable": "properties",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Generate Field Value"
+			},
+			"workflowDefinitionName": "Generate Field Value"
+		},
+		{
+			"active": true,
 			"description": "This agent analyzes content and proposes tags, prioritizing reuse of existing tags and proposing new tags only when needed.",
 			"externalReferenceCode": "L_GENERATE_TAGS",
 			"inputVariables": "content,count,existingTags",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-field-value-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-field-value-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_GENERATE_FIELD_VALUE",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Generate Field Value",
+	"scope": "ai",
+	"title": "Generate Field Value",
+	"title_i18n": {
+		"en_US": "Generate Field Value"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-field-value-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-field-value-workflow-definition/workflow-definition.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Generate Field Value</name>
+	<version>1</version>
+	<llm>
+		<name>generateFieldValue</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Generate Field Value
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "instruction",
+						"type": "string"
+					},
+					{
+						"name": "objectFields",
+						"type": "string"
+					},
+					{
+						"name": "properties",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "properties",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[# Role
+
+You generate the value of a SINGLE field of the content entry the user is
+currently editing. You receive the entry's field definitions, its current field
+values, and a natural-language instruction naming which field to produce and
+what to base it on: the values already filled in other fields (for example "a
+title based on the content", "a body based on the title", "field C from field A
+and field B") and/or a brief the user provides.
+
+# Inputs
+
+- instruction: the user's request. It names the target field to generate and the
+source fields and/or brief to derive it from.
+- objectFields: a JSON array of the entry's field definitions. Each element has
+at least `name` and `label`. Match the fields the instruction refers to against
+their `label` or `name`.
+- properties: a JSON object mapping each field `name` to its current value
+(empty or absent when the field is not filled yet). Use these values as the
+source material.
+
+# Rules
+
+- Produce ONLY the value for the single target field named in the instruction.
+- Derive it from the referenced fields' values in `properties` and/or the brief
+in the instruction. Work from whatever context is available.
+- Never generate a value for any other field, and never return more than the
+single target field's value.
+- Write the value in the language of the source content.
+
+# Output policy
+
+- Output a SINGLE raw JSON object mapping the target field's `name` to its
+generated value, for example {"title": "..."}.
+- The object MUST contain exactly one entry: the single target field.
+- DO NOT wrap the JSON in markdown fences (no ```json, no ```).
+- DO NOT add prose, commentary, or trailing text.]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Instruction: {{instruction}}
+
+Field definitions: {{objectFields}}
+
+Current values: {{properties}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Generate Field Value
+					</label>
+				</labels>
+				<name>generateFieldValue</name>
+				<target>generateFieldValue</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94025

**What is being fixed:** From the AI Assistant inside the Content Editor there was no way to generate the value of a single field of the entry being edited — such as its title — from the values already filled in the entry's other fields or from a short brief. Every field had to be written by hand.

**How it is being fixed:** Adds a new "Generate Field Value" AI Hub agent. It registers the workflow definition external reference code (`L_GENERATE_FIELD_VALUE`) and display-name constants in `portal-workflow-api`, adds the agent definition to the site initializer — taking a single `instruction` input and returning the generated `properties`, with the field definitions and current field values of the open entry resolved automatically so the user is never asked for them — and ships the accompanying Generate Field Value workflow definition (JSON metadata plus an LLM-node XML flow). Integration coverage is added in the AI Hub REST tests (`AgentDefinitionResourceTest`, `AgentInstanceResourceTest`) and the site initializer test.