### PR TITLE
LPD-94145 Follow-up: Add the AI Assistant next to the CMS Select File button

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -23,6 +23,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
+import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -40,6 +41,7 @@ import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormRelationshipStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -90,6 +92,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
+import com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantIconComponentSectionFragmentRenderer;
 import com.liferay.site.cms.site.initializer.internal.fragment.renderer.SpacesComponentSectionFragmentRenderer;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -1096,6 +1099,45 @@ public class ActionUtil {
 		return getBaseViewFolderURL(themeDisplay) + objectEntryFolderId;
 	}
 
+	private static void _addAIAssistantFragmentDropZone(
+			List<FragmentEntryLink> addedFragmentEntryLinks,
+			FragmentEntryLinkService fragmentEntryLinkService,
+			FragmentRendererRegistry fragmentRendererRegistry,
+			FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem,
+			Layout layout, LayoutStructure layoutStructure,
+			long segmentsExperienceId, ServiceContext serviceContext)
+		throws Exception {
+
+		if (fragmentStyledLayoutStructureItem == null) {
+			return;
+		}
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			StringPool.BLANK, fragmentEntryLinkService,
+			fragmentRendererRegistry,
+			AIAssistantIconComponentSectionFragmentRenderer.class.getName(),
+			layout, segmentsExperienceId, serviceContext);
+
+		if (fragmentEntryLink == null) {
+			return;
+		}
+
+		FragmentDropZoneLayoutStructureItem
+			fragmentDropZoneLayoutStructureItem =
+				(FragmentDropZoneLayoutStructureItem)
+					layoutStructure.addFragmentDropZoneLayoutStructureItem(
+						fragmentStyledLayoutStructureItem.getItemId(), -1);
+
+		fragmentDropZoneLayoutStructureItem.setFragmentDropZoneId(
+			"aiAssistant");
+
+		layoutStructure.addFragmentStyledLayoutStructureItem(
+			fragmentEntryLink.getFragmentEntryLinkId(),
+			fragmentDropZoneLayoutStructureItem.getItemId(), 0);
+
+		addedFragmentEntryLinks.add(fragmentEntryLink);
+	}
+
 	private static LayoutPageTemplateEntry
 			_addEditContentDefaultLayoutPageTemplateEntry(
 				long classNameId, FormManager formManager,
@@ -1214,7 +1256,7 @@ public class ActionUtil {
 			0, contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
-	private static void _addInputFragmentEntryLink(
+	private static FragmentStyledLayoutStructureItem _addInputFragmentEntryLink(
 			List<FragmentEntryLink> addedFragmentEntryLinks,
 			JSONObject configurationJSONObject, FormManager formManager,
 			String fragmentEntryKey, InfoField<?> infoField, Layout layout,
@@ -1225,7 +1267,7 @@ public class ActionUtil {
 		throws Exception {
 
 		if (infoField == null) {
-			return;
+			return null;
 		}
 
 		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
@@ -1235,7 +1277,7 @@ public class ActionUtil {
 				serviceContext);
 
 		if (fragmentStyledLayoutStructureItem == null) {
-			return;
+			return null;
 		}
 
 		fragmentStyledLayoutStructureItem.updateItemConfig(
@@ -1266,6 +1308,8 @@ public class ActionUtil {
 		if (fragmentEntryLink != null) {
 			addedFragmentEntryLinks.add(fragmentEntryLink);
 		}
+
+		return fragmentStyledLayoutStructureItem;
 	}
 
 	private static LayoutStructure _addInputFragmentEntryLinks(
@@ -1419,11 +1463,24 @@ public class ActionUtil {
 					}
 				}
 
-				_addInputFragmentEntryLink(
-					addedFragmentEntryLinks, null, formManager, null,
-					(InfoField<?>)infoFieldSetEntry, layout, layoutStructure,
-					layoutStructureItem, readOnly, segmentsExperienceId,
-					serviceContext, stylesJSONObject);
+				FragmentStyledLayoutStructureItem
+					fragmentStyledLayoutStructureItem =
+						_addInputFragmentEntryLink(
+							addedFragmentEntryLinks, null, formManager, null,
+							infoField, layout, layoutStructure,
+							layoutStructureItem, readOnly, segmentsExperienceId,
+							serviceContext, stylesJSONObject);
+
+				if (!readOnly &&
+					(FileInfoFieldType.INSTANCE ==
+						infoField.getInfoFieldType())) {
+
+					_addAIAssistantFragmentDropZone(
+						addedFragmentEntryLinks, fragmentEntryLinkService,
+						fragmentRendererRegistry,
+						fragmentStyledLayoutStructureItem, layout,
+						layoutStructure, segmentsExperienceId, serviceContext);
+				}
 			}
 			else if (infoFieldSetEntry instanceof InfoFieldSet) {
 				layoutStructure = _addInputFragmentEntryLinks(


### PR DESCRIPTION
### What

Isolates the changes to `ActionUtil.java` that were previously part of commit `108d8162c794960b425fca4239c4201cdcc6b1f7` ("LPD-94145 Add the AI Assistant next to the CMS Select File button") into a standalone PR.

### Why

Split out per [this review comment on #612](https://github.com/liferay-ai-hub/liferay-portal/pull/612#issuecomment-4931694991). This PR contains **only** the `ActionUtil.java` diff; the companion changes (the `AIAssistantIconComponentSectionFragmentRenderer` and related front-end/CMP work) will land through a separate PR.

### Changes

`modules/apps/site/site-cms-site-initializer/.../internal/util/ActionUtil.java`:

- Adds `_addAIAssistantFragmentDropZone(...)`, which appends an `aiAssistant` fragment drop zone containing the AI Assistant icon fragment to a field's input fragment.
- `_addInputFragmentEntryLink(...)` now returns the created `FragmentStyledLayoutStructureItem` (instead of `void`) so the caller can attach the drop zone to it.
- `_addInputFragmentEntryLinks(...)` wires the drop zone in for non-read-only `FileInfoFieldType` fields.
