### PR TITLE
LPD-94224 Categorize generated content entries for content gaps

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/CategorizeContentEntriesServiceNodeDelegate.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/CategorizeContentEntriesServiceNodeDelegate.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alberto Sousa
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class CategorizeContentEntriesServiceNodeDelegate
+	implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+			Map<String, String> inputVariables,
+			Map<String, Serializable> workflowContext)
+		throws Exception {
+
+		String inputContentEntriesPayload = inputVariables.get(
+			"contentEntriesPayload");
+
+		JSONArray taxonomyCategoryIdsJSONArray =
+			_getTaxonomyCategoryIdsJSONArray(
+				inputVariables.get("taxonomyCategoryIds"));
+
+		if (Validator.isNull(inputContentEntriesPayload) ||
+			(taxonomyCategoryIdsJSONArray.length() == 0)) {
+
+			workflowContext.put(
+				"contentEntriesPayload", inputContentEntriesPayload);
+
+			return inputContentEntriesPayload;
+		}
+
+		JSONArray contentEntriesPayloadJSONArray = _jsonFactory.createJSONArray(
+			inputContentEntriesPayload);
+
+		for (int i = 0; i < contentEntriesPayloadJSONArray.length(); i++) {
+			JSONObject jsonObject =
+				contentEntriesPayloadJSONArray.getJSONObject(i);
+
+			jsonObject.put("taxonomyCategoryIds", taxonomyCategoryIdsJSONArray);
+		}
+
+		String outputContentEntriesPayload =
+			contentEntriesPayloadJSONArray.toString();
+
+		workflowContext.put(
+			"contentEntriesPayload", outputContentEntriesPayload);
+
+		return outputContentEntriesPayload;
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#GenerateContent#categorizeContentEntries";
+	}
+
+	private JSONArray _getTaxonomyCategoryIdsJSONArray(
+			String taxonomyCategoryIds)
+		throws Exception {
+
+		if (Validator.isNull(taxonomyCategoryIds)) {
+			return _jsonFactory.createJSONArray();
+		}
+
+		String trimmedTaxonomyCategoryIds = taxonomyCategoryIds.trim();
+
+		if (trimmedTaxonomyCategoryIds.startsWith(StringPool.OPEN_BRACKET) &&
+			trimmedTaxonomyCategoryIds.endsWith(StringPool.CLOSE_BRACKET)) {
+
+			return _jsonFactory.createJSONArray(trimmedTaxonomyCategoryIds);
+		}
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (String taxonomyCategoryId :
+				StringUtil.split(trimmedTaxonomyCategoryIds)) {
+
+			long taxonomyCategoryIdLong = GetterUtil.getLong(
+				taxonomyCategoryId);
+
+			if (taxonomyCategoryIdLong > 0) {
+				jsonArray.put(taxonomyCategoryIdLong);
+			}
+		}
+
+		return jsonArray;
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/workflow/node/delegate/CategorizeContentEntriesServiceNodeDelegateTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/workflow/node/delegate/CategorizeContentEntriesServiceNodeDelegateTest.java
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.node.delegate;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Alberto Sousa
+ */
+public class CategorizeContentEntriesServiceNodeDelegateTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_categorizeContentEntriesServiceNodeDelegate, "_jsonFactory",
+			_jsonFactory);
+	}
+
+	@Test
+	public void testExecute() throws Exception {
+		long taxonomyCategoryId1 = RandomTestUtil.randomLong();
+		long taxonomyCategoryId2 = RandomTestUtil.randomLong();
+
+		_testExecute(
+			taxonomyCategoryId1, taxonomyCategoryId2,
+			JSONUtil.putAll(
+				taxonomyCategoryId1, taxonomyCategoryId2
+			).toString());
+		_testExecute(
+			taxonomyCategoryId1, taxonomyCategoryId2,
+			taxonomyCategoryId1 + "," + taxonomyCategoryId2);
+
+		_testExecuteWithoutTaxonomyCategoryIds();
+	}
+
+	private void _assertTaxonomyCategoryIds(
+			String contentEntriesPayload, long taxonomyCategoryId1,
+			long taxonomyCategoryId2)
+		throws Exception {
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray(
+			contentEntriesPayload);
+
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			JSONArray taxonomyCategoryIdsJSONArray = jsonObject.getJSONArray(
+				"taxonomyCategoryIds");
+
+			Assert.assertEquals(2, taxonomyCategoryIdsJSONArray.length());
+			Assert.assertEquals(
+				taxonomyCategoryId1, taxonomyCategoryIdsJSONArray.getLong(0));
+			Assert.assertEquals(
+				taxonomyCategoryId2, taxonomyCategoryIdsJSONArray.getLong(1));
+		}
+	}
+
+	private void _testExecute(
+			long taxonomyCategoryId1, long taxonomyCategoryId2,
+			String taxonomyCategoryIds)
+		throws Exception {
+
+		Map<String, Serializable> workflowContext = new HashMap<>();
+
+		String contentEntriesPayload =
+			_categorizeContentEntriesServiceNodeDelegate.execute(
+				HashMapBuilder.put(
+					"contentEntriesPayload", _CONTENT_ENTRIES_PAYLOAD
+				).put(
+					"taxonomyCategoryIds", taxonomyCategoryIds
+				).build(),
+				workflowContext);
+
+		Assert.assertEquals(
+			contentEntriesPayload,
+			workflowContext.get("contentEntriesPayload"));
+		_assertTaxonomyCategoryIds(
+			contentEntriesPayload, taxonomyCategoryId1, taxonomyCategoryId2);
+	}
+
+	private void _testExecuteWithoutTaxonomyCategoryIds() throws Exception {
+		String contentEntriesPayload =
+			_categorizeContentEntriesServiceNodeDelegate.execute(
+				HashMapBuilder.put(
+					"contentEntriesPayload", _CONTENT_ENTRIES_PAYLOAD
+				).build(),
+				new HashMap<>());
+
+		Assert.assertEquals(_CONTENT_ENTRIES_PAYLOAD, contentEntriesPayload);
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray(
+			contentEntriesPayload);
+
+		JSONObject jsonObject = jsonArray.getJSONObject(0);
+
+		Assert.assertFalse(jsonObject.has("taxonomyCategoryIds"));
+	}
+
+	private static final String _CONTENT_ENTRIES_PAYLOAD =
+		"[{\"externalReferenceCode\": \"entry-1\", \"properties\": " +
+			"{\"title\": \"Entry 1\"}}, {\"externalReferenceCode\": " +
+				"\"entry-2\", \"properties\": {\"title\": \"Entry 2\"}}]";
+
+	private final CategorizeContentEntriesServiceNodeDelegate
+		_categorizeContentEntriesServiceNodeDelegate =
+			new CategorizeContentEntriesServiceNodeDelegate();
+	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
@@ -154,11 +154,11 @@ so re-running the same brief updates the existing draft instead of duplicating.
 			<transition>
 				<labels>
 					<label language-id="en_US">
-						Post Content Entries
+						Categorize Content Entries
 					</label>
 				</labels>
-				<name>postContentEntries</name>
-				<target>postContentEntries</target>
+				<name>categorizeContentEntries</name>
+				<target>categorizeContentEntries</target>
 				<default>true</default>
 			</transition>
 		</transitions>
@@ -170,6 +170,51 @@ Number of entries requested: {{count}}
 Space id: {{spaceId}}]]>
 		</user-message>
 	</llm>
+	<service>
+		<name>categorizeContentEntries</name>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "contentEntriesPayload",
+						"type": "string"
+					},
+					{
+						"name": "taxonomyCategoryIds",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<java-delegate>javaDelegate#GenerateContent#categorizeContentEntries</java-delegate>
+		<labels>
+			<label language-id="en_US">
+				Categorize Content Entries
+			</label>
+		</labels>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "contentEntriesPayload",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Post Content Entries
+					</label>
+				</labels>
+				<name>postContentEntries</name>
+				<target>postContentEntries</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</service>
 	<http-request>
 		<name>postContentEntries</name>
 		<labels>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94224

## Dependencies

- https://github.com/liferay-ai-hub/liferay-portal/pull/636

Per review, the new node's java-delegate is namespaced as `javaDelegate#GenerateContent#categorizeContentEntries`. That multi-segment form is only accepted after #636 relaxes the Kaleo `ServiceNodeValidator` from `[\w.$]+#\w+` (a single `#`) to `[\w.$]+(#\w+)+`. Until #636 merges, the Generate Content workflow fails Kaleo validation on deploy — which is the cause of the Integration test failure recorded below. This PR should merge on top of, or after, #636.

## What Is Being Fixed

The Generate Content agent produces draft content entries from a brief but leaves them uncategorized. In the Content Gap Analysis flow, content generated to fill a gap must carry that gap's taxonomy categories (persona and funnel stage) so it lands in the right place and actually closes the gap. Without this, the user has to categorize every generated draft by hand.

## How It Is Being Fixed

A new categorizeContentEntries service node is inserted into the Generate Content workflow definition, between the LLM that builds the entry payloads and the batch-engine POST that persists them. Its CategorizeContentEntriesServiceNodeDelegate reads the optional taxonomyCategoryIds input and injects those numeric category ids into every content-entry payload before it is posted, so the batch-engine import applies them on create. The step is opt-in and a no-op when no ids are supplied or the payload is empty, so the agent's existing free-form Generate Content behavior is unchanged. Numeric taxonomyCategoryIds are used rather than external reference codes because they validate against the connected and ancestor groups, which the cross-group content and vocabulary layout of the CMP flow requires.

## Test Plan

Ran the focused premerge plan for the branch against a local bundle:

| Test | Type | Result |
| --- | --- | --- |
| CategorizeContentEntriesServiceNodeDelegateTest | Unit | PASS (3/3: no ids, comma separated, JSON array) |
| AIHubSiteInitializerTest | Integration | FAIL — blocked by #636; Kaleo rejects the namespaced java-delegate until its ServiceNodeValidator change merges |

## PR Check

**pr-check: PASS** — tested on `191c095fa0c6945940a5d8cad562aea4a8b43853`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "191c095fa0c6945940a5d8cad562aea4a8b43853"} -->
