### PR TITLE
LPD-98279 Fix the AI Assistant chat container scroll

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -110,7 +110,7 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	const instructionDefinitionScopeRef = useRef<string>(
 		instructionDefinitionScope
 	);
-	const messagesEndRef = useRef<HTMLDivElement | null>(null);
+	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -120,18 +120,26 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		instructionDefinitionScopeRef.current = instructionDefinitionScope;
 	}, [context, getContext, instructionDefinitionScope]);
 
+	useEffect(() => {
+		setTimeout(() => {
+			const container = messagesContainerRef.current;
+
+			container?.scrollTo({
+				behavior: 'smooth',
+				top: container.scrollHeight,
+			});
+		}, 0);
+	}, [messages]);
+
 	const sendMessage = useCallback((text: string) => {
 		if (!text.trim()) {
 			return;
 		}
 
-		setMessages((previousMessages) => {
-			setTimeout(() => {
-				messagesEndRef.current?.scrollIntoView({behavior: 'smooth'});
-			}, 0);
-
-			return [...previousMessages, {sender: 'user', text}];
-		});
+		setMessages((previousMessages) => [
+			...previousMessages,
+			{sender: 'user', text},
+		]);
 
 		setMessage('');
 
@@ -227,25 +235,17 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 					try {
 						const dataJSON = JSON.parse(event.data);
 
-						setMessages((previousMessages) => {
-							setTimeout(() => {
-								messagesEndRef.current?.scrollIntoView({
-									behavior: 'smooth',
-								});
-							}, 0);
-
-							return [
-								...previousMessages,
-								{
-									agentDefinitionExternalReferenceCodes:
-										dataJSON[
-											'agentDefinitionExternalReferenceCodes'
-										] ?? [],
-									sender: 'assistant',
-									text: dataJSON['data'],
-								},
-							];
-						});
+						setMessages((previousMessages) => [
+							...previousMessages,
+							{
+								agentDefinitionExternalReferenceCodes:
+									dataJSON[
+										'agentDefinitionExternalReferenceCodes'
+									] ?? [],
+								sender: 'assistant',
+								text: dataJSON['data'],
+							},
+						]);
 
 						setMessage('');
 					}
@@ -285,22 +285,14 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 						text = '';
 					}
 
-					setMessages((previousMessages) => {
-						setTimeout(() => {
-							messagesEndRef.current?.scrollIntoView({
-								behavior: 'smooth',
-							});
-						}, 0);
-
-						return [
-							...previousMessages,
-							{
-								error: true,
-								sender: 'assistant',
-								text,
-							},
-						];
-					});
+					setMessages((previousMessages) => [
+						...previousMessages,
+						{
+							error: true,
+							sender: 'assistant',
+							text,
+						},
+					]);
 
 					setIsGenerating(false);
 				}
@@ -326,26 +318,17 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		const handleCategorize = (payload: CategorizeEventPayload) => {
 			setActive(true);
 
-			setMessages((previousMessages) => {
-				setTimeout(() => {
-					messagesEndRef.current?.scrollIntoView({
-						behavior: 'smooth',
-					});
-				}, 0);
-
-				return [
-					...previousMessages,
-					{
-						sender: 'user',
-						text:
-							payload.agent ===
-							ECategorizationAgent.AUTO_CATEGORIZE
-								? Liferay.Language.get('add-categories')
-								: Liferay.Language.get('generate-tags'),
-					},
-					{categorization: payload, sender: 'assistant', text: ''},
-				];
-			});
+			setMessages((previousMessages) => [
+				...previousMessages,
+				{
+					sender: 'user',
+					text:
+						payload.agent === ECategorizationAgent.AUTO_CATEGORIZE
+							? Liferay.Language.get('add-categories')
+							: Liferay.Language.get('generate-tags'),
+				},
+				{categorization: payload, sender: 'assistant', text: ''},
+			]);
 		};
 
 		Liferay.on(CATEGORIZE_EVENT, handleCategorize);
@@ -357,7 +340,10 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 
 	const chatSurface = (
 		<>
-			<div className="ai-assistant-chat__messages-container">
+			<div
+				className="ai-assistant-chat__messages-container"
+				ref={messagesContainerRef}
+			>
 				{!initialMessage && (
 					<AIAssistantMessageBalloon
 						error={false}
@@ -422,8 +408,6 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 						</span>
 					</div>
 				)}
-
-				<div ref={messagesEndRef} />
 			</div>
 
 			{!!quickActions?.length && (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -75,7 +75,7 @@ async function renderAndOpen() {
 
 describe('AIAssistantChat', () => {
 	beforeEach(() => {
-		window.HTMLElement.prototype.scrollIntoView = jest.fn();
+		window.HTMLElement.prototype.scrollTo = jest.fn();
 
 		mockCreateEventSource.mockReset();
 		mockCreateEventSource.mockResolvedValue(null);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98279

## What Is Being Fixed

The AI Assistant chat kept the newest message in view by calling `scrollIntoView` on an empty sentinel element at the bottom of the message list. `scrollIntoView` scrolls every scrollable ancestor up to the viewport, so instead of scrolling only the chat's own message list it moved the whole page. For short conversations — such as the "You have exceeded your quota." reply — the message list had nothing to scroll internally, so the page scrolled while the chat itself stayed put, leaving the newest message out of view.

## How It Is Being Fixed

The four per-call-site scroll invocations, each embedded inside a `setMessages` state updater, are replaced by a single `useEffect` keyed on `messages`, so the append callbacks stay pure and the scroll runs once per message-list change. The effect scrolls the messages container directly with `container.scrollTo({top: container.scrollHeight})` rather than calling `scrollIntoView` on a bottom sentinel: because `scrollIntoView` scrolls every scrollable ancestor, the old approach moved the whole page, whereas `scrollTo` on the container moves only the container and never the page. The now-unused sentinel `div` and its ref are removed. The existing Jest test's browser-API mock is updated from `scrollIntoView` to `scrollTo`, since jsdom implements the former as a no-op stub but not the latter.

## Why Are There No Tests?

The change is covered by the module's existing AIAssistantChat Jest suite (14 suites, 62 tests), which exercises every render path that reaches the scroll effect. The scroll behavior itself — the actual pixel scrolling and which element moves — cannot be asserted in jsdom, which implements neither layout (`scrollHeight` is always 0) nor `Element.scrollTo`; that is verified manually in the browser. A new test would add no meaningful signal beyond the existing coverage.

## PR Check

**pr-check: PASS** — tested on `57781f994b85a9fd934e4e95c6f7ff642e49cf1c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "57781f994b85a9fd934e4e95c6f7ff642e49cf1c"} -->
