### PR TITLE
LPD-98277 Handle AI Assistant chat answers by message type

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -29,16 +29,10 @@ import AIAssistantFooterDisclaimer from './components/AIAssistantFooterDisclaime
 import AIAssistantMessageBalloon from './components/AIAssistantMessageBalloon';
 import CategorizationMessageBalloon from './components/CategorizationMessageBalloon';
 import UserMessageBalloon from './components/UserMessageBalloon';
+import {ChatMessageSentData, Message} from './types';
+import buildAssistantMessage from './utils/buildAssistantMessage';
 
 import './chat.scss';
-
-interface message {
-	agentDefinitionExternalReferenceCodes?: string[];
-	categorization?: CategorizeEventPayload;
-	error?: boolean;
-	sender: string;
-	text: string;
-}
 
 interface ReportContext {
 	agentDefinitionExternalReferenceCodes: string[];
@@ -79,13 +73,13 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		{}
 	);
 	const [isGenerating, setIsGenerating] = useState<boolean>(false);
-	const [messages, setMessages] = useState<message[]>([]);
+	const [messages, setMessages] = useState<Message[]>([]);
 	const [message, setMessage] = useState<string>('');
 	const [reportContext, setReportContext] = useState<ReportContext | null>(
 		null
 	);
 
-	const handleThumbsUp = (index: number, item: message) => {
+	const handleThumbsUp = (index: number, item: Message) => {
 		if (feedbackGiven[index]) {
 			return;
 		}
@@ -233,18 +227,13 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 				'Chat Message Sent',
 				(event) => {
 					try {
-						const dataJSON = JSON.parse(event.data);
+						const dataJSON: ChatMessageSentData = JSON.parse(
+							event.data
+						);
 
 						setMessages((previousMessages) => [
 							...previousMessages,
-							{
-								agentDefinitionExternalReferenceCodes:
-									dataJSON[
-										'agentDefinitionExternalReferenceCodes'
-									] ?? [],
-								sender: 'assistant',
-								text: dataJSON['data'],
-							},
+							buildAssistantMessage(dataJSON),
 						]);
 
 						setMessage('');

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/constants.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const CONTENT_GAP_ANALYSIS_ERC = 'L_CONTENT_GAP_ANALYSIS';

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/types.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {CategorizeEventPayload} from '../Categorization/events';
+
+export interface Message {
+	agentDefinitionExternalReferenceCodes?: string[];
+	categorization?: CategorizeEventPayload;
+	error?: boolean;
+	images?: string[];
+	sender: string;
+	text: string;
+}
+
+export interface ChatMessageSentData {
+	agentDefinitionExternalReferenceCodes?: string[];
+	data?: string;
+	mimeType?: string;
+	type?: string;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/buildAssistantMessage.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/buildAssistantMessage.ts
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {CONTENT_GAP_ANALYSIS_ERC} from '../constants';
+import {ChatMessageSentData, Message} from '../types';
+import formatContentGapAnalysis from './formatContentGapAnalysis';
+
+const TEXT_ANSWER_FORMATTERS: Record<string, (data: string) => string | null> =
+	{
+		[CONTENT_GAP_ANALYSIS_ERC]: formatContentGapAnalysis,
+	};
+
+function formatTextAnswer(
+	data: string,
+	agentDefinitionExternalReferenceCodes: string[]
+): string {
+	for (const agentDefinitionExternalReferenceCode of agentDefinitionExternalReferenceCodes) {
+		const formatter =
+			TEXT_ANSWER_FORMATTERS[agentDefinitionExternalReferenceCode];
+
+		if (formatter) {
+			return formatter(data) ?? data;
+		}
+	}
+
+	return data;
+}
+
+export default function buildAssistantMessage(
+	dataJSON: ChatMessageSentData
+): Message {
+	const agentDefinitionExternalReferenceCodes =
+		dataJSON.agentDefinitionExternalReferenceCodes ?? [];
+
+	const data = dataJSON.data ?? '';
+
+	if (dataJSON.type === 'image') {
+		return {
+			agentDefinitionExternalReferenceCodes,
+			images: [`data:${dataJSON.mimeType ?? 'image/png'};base64,${data}`],
+			sender: 'assistant',
+			text: '',
+		};
+	}
+
+	return {
+		agentDefinitionExternalReferenceCodes,
+		sender: 'assistant',
+		text: formatTextAnswer(data, agentDefinitionExternalReferenceCodes),
+	};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/formatContentGapAnalysis.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/formatContentGapAnalysis.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+interface GapAnalysis {
+	gaps: {
+		funnelStageName: string;
+		personaName: string;
+		reason: string;
+		severity: string;
+	}[];
+	summary?: {overview?: string};
+}
+
+export default function formatContentGapAnalysis(data: string): string | null {
+	let gapAnalysis: GapAnalysis;
+
+	try {
+		gapAnalysis = JSON.parse(
+			data.slice(data.indexOf('{'), data.lastIndexOf('}') + 1)
+		);
+	}
+	catch {
+		return null;
+	}
+
+	if (!gapAnalysis || !Array.isArray(gapAnalysis.gaps)) {
+		return null;
+	}
+
+	const overview = gapAnalysis.summary?.overview ?? '';
+
+	const gaps = gapAnalysis.gaps
+		.map(
+			(gap) =>
+				`- **${gap.personaName} / ${gap.funnelStageName}** (${gap.severity}) — ${gap.reason}`
+		)
+		.join('\n');
+
+	return [overview, gaps].filter(Boolean).join('\n\n') || null;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/buildAssistantMessage.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/buildAssistantMessage.test.ts
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {CONTENT_GAP_ANALYSIS_ERC} from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/constants';
+import buildAssistantMessage from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/utils/buildAssistantMessage';
+
+const GAP_ANSWER = JSON.stringify({
+	gaps: [
+		{
+			funnelStageName: 'Awareness',
+			personaName: 'Decision Maker',
+			reason: 'No content yet.',
+			severity: 'high',
+		},
+	],
+	summary: {overview: 'One gap to address.'},
+});
+
+describe('buildAssistantMessage', () => {
+	it('builds an image message with a base64 data URI', () => {
+		expect(
+			buildAssistantMessage({
+				agentDefinitionExternalReferenceCodes: [
+					CONTENT_GAP_ANALYSIS_ERC,
+				],
+				data: 'iVBORw0KGgo=',
+				mimeType: 'image/jpeg',
+				type: 'image',
+			})
+		).toEqual({
+			agentDefinitionExternalReferenceCodes: [CONTENT_GAP_ANALYSIS_ERC],
+			images: ['data:image/jpeg;base64,iVBORw0KGgo='],
+			sender: 'assistant',
+			text: '',
+		});
+	});
+
+	it('defaults a missing data field to an empty string', () => {
+		expect(buildAssistantMessage({}).text).toBe('');
+	});
+
+	it('defaults missing agent reference codes to an empty array', () => {
+		expect(
+			buildAssistantMessage({data: 'hi'})
+				.agentDefinitionExternalReferenceCodes
+		).toEqual([]);
+	});
+
+	it('defaults the image mime type to image/png when missing', () => {
+		expect(
+			buildAssistantMessage({data: 'iVBORw0KGgo=', type: 'image'}).images
+		).toEqual(['data:image/png;base64,iVBORw0KGgo=']);
+	});
+
+	it('formats a Content Gap Analysis text answer into bulleted markdown', () => {
+		expect(
+			buildAssistantMessage({
+				agentDefinitionExternalReferenceCodes: [
+					CONTENT_GAP_ANALYSIS_ERC,
+				],
+				data: GAP_ANSWER,
+				type: 'text',
+			})
+		).toEqual({
+			agentDefinitionExternalReferenceCodes: [CONTENT_GAP_ANALYSIS_ERC],
+			sender: 'assistant',
+			text:
+				'One gap to address.\n\n' +
+				'- **Decision Maker / Awareness** (high) — No content yet.',
+		});
+	});
+
+	it('formats when the answer omits the type (defaults to text)', () => {
+		expect(
+			buildAssistantMessage({
+				agentDefinitionExternalReferenceCodes: [
+					CONTENT_GAP_ANALYSIS_ERC,
+				],
+				data: GAP_ANSWER,
+			}).text
+		).toContain('- **Decision Maker / Awareness** (high)');
+	});
+
+	it('passes through text answers from agents without a formatter', () => {
+		expect(
+			buildAssistantMessage({
+				agentDefinitionExternalReferenceCodes: ['L_SOMETHING_ELSE'],
+				data: 'Plain answer.',
+			}).text
+		).toBe('Plain answer.');
+	});
+});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/formatContentGapAnalysis.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/formatContentGapAnalysis.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import formatContentGapAnalysis from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/utils/formatContentGapAnalysis';
+
+describe('formatContentGapAnalysis', () => {
+	it('parses a payload wrapped in markdown code fences', () => {
+		const gaps = [
+			{
+				funnelStageName: 'Awareness',
+				personaName: 'Decision Maker',
+				reason: 'No content yet.',
+				severity: 'high',
+			},
+		];
+
+		const data = '```json\n' + JSON.stringify({gaps}) + '\n```';
+
+		expect(formatContentGapAnalysis(data)).toBe(
+			'- **Decision Maker / Awareness** (high) — No content yet.'
+		);
+	});
+
+	it('renders the gaps list when the summary or its overview is absent', () => {
+		const gaps = [
+			{
+				funnelStageName: 'Awareness',
+				personaName: 'Decision Maker',
+				reason: 'No content yet.',
+				severity: 'high',
+			},
+		];
+
+		const expected =
+			'- **Decision Maker / Awareness** (high) — No content yet.';
+
+		expect(formatContentGapAnalysis(JSON.stringify({gaps}))).toBe(expected);
+
+		expect(
+			formatContentGapAnalysis(JSON.stringify({gaps, summary: {}}))
+		).toBe(expected);
+	});
+
+	it('renders the summary overview followed by a bulleted gaps list', () => {
+		const data = JSON.stringify({
+			gaps: [
+				{
+					currentCount: 0,
+					funnelStageId: 'f1',
+					funnelStageName: 'Awareness',
+					personaId: 'p1',
+					personaName: 'Decision Maker',
+					reason: 'No content yet.',
+					severity: 'high',
+				},
+				{
+					currentCount: 0,
+					funnelStageId: 'f2',
+					funnelStageName: 'Retention',
+					personaId: 'p2',
+					personaName: 'End User',
+					reason: 'Only one asset.',
+					severity: 'medium',
+				},
+			],
+			summary: {
+				funnelStageCount: 2,
+				gapCount: 2,
+				overview: 'You have two gaps to address.',
+				personaCount: 2,
+			},
+		});
+
+		expect(formatContentGapAnalysis(data)).toBe(
+			'You have two gaps to address.\n\n' +
+				'- **Decision Maker / Awareness** (high) — No content yet.\n' +
+				'- **End User / Retention** (medium) — Only one asset.'
+		);
+	});
+
+	it('returns null for non-JSON payloads', () => {
+		expect(formatContentGapAnalysis('I cannot fulfill this request')).toBe(
+			null
+		);
+	});
+
+	it('returns null when the payload is not a gap-analysis object', () => {
+		expect(formatContentGapAnalysis(JSON.stringify({foo: 'bar'}))).toBe(
+			null
+		);
+	});
+
+	it('returns null when there is nothing to show', () => {
+		expect(
+			formatContentGapAnalysis(JSON.stringify({gaps: [], summary: {}}))
+		).toBe(null);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98277
https://liferay.atlassian.net/browse/LPD-98279

## What Is Being Fixed

The AI Assistant chat built assistant messages inline in the "Chat Message Sent" handler, and each feature (Content Gap Analysis text formatting, image balloons) diverged in how it turned an SSE payload into a message. There was no shared, extensible way to handle answers by message type.

## How It Is Being Fixed

Introduces a reusable message-type layer. A single `buildAssistantMessage(dataJSON)` turns a "Chat Message Sent" payload into a message, dispatching by type: image answers become a base64 data-URI image message, and text answers pass through a pluggable per-agent formatter registry (`TEXT_ANSWER_FORMATTERS`), so supporting a new agent's answer is a one-line registry entry plus its external reference code constant. The `message` and `ChatMessageSentData` types move to a shared `types` module, the agent reference codes to a `constants` module, and the Content Gap Analysis formatter is the first registered formatter. The handler is wired to the builder.

This branch also includes the reusable `scrollToBottom` extraction (LPD-98279). That refactor is independent — the message-type handling does not depend on it, so this PR can be merged without it (or LPD-98279 can merge on its own first).

## PR Check

**pr-check: PASS** — tested on `52b8b98b35308b9a7486ac00cc563daa6d46438b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "52b8b98b35308b9a7486ac00cc563daa6d46438b"} -->
