### PR TITLE
LPD-98258 Grant the AI Hub Cell OAuth2 application CMP read scope

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -110,6 +110,7 @@ public class AIHubCellConfigurationModelListener
 				Arrays.asList(), false,
 				Arrays.asList(
 					"Liferay.Headless.Batch.Engine.everything",
+					"Liferay.Headless.CMP.everything.read",
 					"Liferay.Portal.Search.REST.everything.read"),
 				false, new ServiceContext());
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98258

## What Is Being Fixed

The Content Gap Analysis agent fetches a project's content coverage from the headless-cmp endpoint using the AI Hub Cell's user token, which is minted from the AI-HUB-CELL OAuth2 application. That application's scope list did not include CMP read access, so the coverage call returned 403 and the agent could not run.

## How It Is Being Fixed

Add `Liferay.Headless.CMP.everything.read` to the AI-HUB-CELL OAuth2 application's scope list in `AIHubCellConfigurationModelListener`, so the cell-minted user token is authorized to call `GET /o/headless-cmp/v1.0/projects/{projectId}/content-coverage`.

## Why Are There No Tests?

The change appends a single scope alias to the OAuth2 application's scope list. No existing test asserts the contents of that list (or of the sibling provisioning application's list) — a repo-wide search finds no coverage of these scope aliases — so this follows the established convention of not testing individual scope entries.

## PR Check

**pr-check: PASS** — tested on `afd19a8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (ai-hub-cell-impl) | PASS |

<!-- pr-check {"result": "success", "sha": "afd19a8b639ffe4a434903aa72f694d8c2cc4ad5"} -->
