### PR TITLE
LPD-93954 Add the AI Assistant next to the CMS Select File button

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
@@ -1,10 +1,13 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:ai-hub-cell:ai-hub-cell-api")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:frontend-js:frontend-js-importmaps-extender-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
@@ -31,15 +31,26 @@ public class AIHubCellJSComponentsWebDynamicJSImportMapsContributor
 			HttpServletRequest httpServletRequest, Writer writer)
 		throws IOException {
 
-		writer.write("\"@liferay/ai-hub-cell-js-components-web\": \"");
-
 		AbsolutePortalURLBuilder absolutePortalURLBuilder =
 			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
 				httpServletRequest);
 
+		writer.write("\"@liferay/ai-hub-cell-js-components-web\": \"");
+
 		ESModuleAbsolutePortalURLBuilder esModuleAbsolutePortalURLBuilder =
 			absolutePortalURLBuilder.forESModule(
 				"ai-hub-cell-js-components-web", "index.js");
+
+		writer.write(esModuleAbsolutePortalURLBuilder.build());
+
+		writer.write("\", ");
+
+		writer.write(
+			"\"@liferay/ai-hub-cell-js-components-web" +
+				"/renderAIAssistantChat\": \"");
+
+		esModuleAbsolutePortalURLBuilder = absolutePortalURLBuilder.forESModule(
+			"ai-hub-cell-js-components-web", "renderAIAssistantChat.js");
 
 		writer.write(esModuleAbsolutePortalURLBuilder.build());
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.js.importmaps.extender;
+
+import com.liferay.frontend.js.importmaps.extender.DynamicJSImportMapsContributor;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.ESModuleAbsolutePortalURLBuilder;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(service = DynamicJSImportMapsContributor.class)
+public class AIHubCellJSComponentsWebDynamicJSImportMapsContributor
+	implements DynamicJSImportMapsContributor {
+
+	@Override
+	public void writeGlobalImports(
+			HttpServletRequest httpServletRequest, Writer writer)
+		throws IOException {
+
+		writer.write("\"@liferay/ai-hub-cell-js-components-web\": \"");
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		ESModuleAbsolutePortalURLBuilder esModuleAbsolutePortalURLBuilder =
+			absolutePortalURLBuilder.forESModule(
+				"ai-hub-cell-js-components-web", "index.js");
+
+		writer.write(esModuleAbsolutePortalURLBuilder.build());
+
+		writer.write(StringPool.QUOTE);
+	}
+
+	@Override
+	public void writeScopedImports(
+		HttpServletRequest httpServletRequest, Writer writer) {
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/node-scripts.config.js
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/node-scripts.config.js
@@ -5,4 +5,8 @@
 
 module.exports = {
 	main: './src/main/resources/META-INF/resources/js/index.ts',
+	submodules: {
+		renderAIAssistantChat:
+			'./src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts',
+	},
 };

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
@@ -20,6 +20,7 @@
 		"@clayui/provider": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
 		"@clayui/tooltip": "^3.165.0",
+		"@liferay/frontend-js-react-web": "*",
 		"ckeditor5": "46.0.3",
 		"classnames": "2.3.1",
 		"eventsource": "^4.0.0",

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts
@@ -28,3 +28,4 @@ export type {
 	ReportFeedbackSurface,
 } from './ReportFeedback/api';
 export {default as WritingAssistant} from './WritingAssistant/WritingAssistant';
+export {default as renderAIAssistantChat} from './renderAIAssistantChat';

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render} from '@liferay/frontend-js-react-web';
+
+import AIAssistantChat from './AIAssistantChat/AIAssistantChat';
+
+import type {ComponentProps} from 'react';
+
+export default function renderAIAssistantChat(
+	container: Element,
+	props: ComponentProps<typeof AIAssistantChat>
+): void {
+
+	// @ts-ignore
+
+	render(AIAssistantChat, props, container);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0ea2f2d32ca5e3f6ecf91645c4ca8b6706f6b1a9",
+	"@generated": "cbb1daa9016dfa3314c9adb1f287a0de753968b5",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -37,6 +40,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "cbb1daa9016dfa3314c9adb1f287a0de753968b5",
+	"@generated": "ccd3d4fe7d8e132c13b1ea7994c0e35e3518f4f9",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"./js/renderAIAssistantChat.ts"
+			],
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
 			],

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "3d7556e4c1aadc42591e52c6f717a1fe45fdd8ec",
+	"@generated": "71ded35b5c69053ed6393386c89600df93f1e8b7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -39,6 +42,9 @@
 		"../src/**/*.tsx"
 	],
 	"references": [
+		{
+			"path": "../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "71ded35b5c69053ed6393386c89600df93f1e8b7",
+	"@generated": "6ca14dd151021d5978f3892334ee67140d27925f",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"./../src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts"
+			],
 			"@liferay/frontend-js-react-web": [
 				"../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
 			],

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
@@ -30,9 +30,9 @@
 					<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentElementId}-file-upload-help-text" aria-labelledby="${fragmentElementId}-file-upload-label ${fragmentElementId}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentElementId}-file-upload-error-message[/#if]" class="file-upload-input sr-only" formenctype="multipart/form-data" id="${fragmentElementId}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
 				</div>
 
-				<div class="ml-2">
-					<lfr-drop-zone data-lfr-drop-zone-id="aiAssistant"></lfr-drop-zone>
-				</div>
+				[#if input.attributes.isCMS?? && input.attributes.isCMS]
+					<div class="file-upload-ai-assistant ml-2"></div>
+				[/#if]
 
 				<strong aria-label="${htmlUtil.escape(input.label)}" class="forms-file-upload-file-name pl-2" data-placeholder="${languageUtil.get(locale, "no-file-selected")}" role="textbox" value="">
 					[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
@@ -27,8 +27,8 @@ const selectButton = document.getElementById(
 const aiAssistantContainer = wrapper.querySelector('.file-upload-ai-assistant');
 
 if (aiAssistantContainer && Liferay.FeatureFlags['LPD-62272']) {
-	import('@liferay/ai-hub-cell-js-components-web').then(
-		({renderAIAssistantChat}) => {
+	import('@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat').then(
+		({default: renderAIAssistantChat}) => {
 			renderAIAssistantChat(aiAssistantContainer, {
 				hideTriggerLabel: true,
 				instructionDefinitionScope: 'cms',

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
@@ -24,6 +24,20 @@ const selectButton = document.getElementById(
 	`${fragmentElementId}-file-upload-button-label`
 );
 
+const aiAssistantContainer = wrapper.querySelector('.file-upload-ai-assistant');
+
+if (aiAssistantContainer && Liferay.FeatureFlags['LPD-62272']) {
+	import('@liferay/ai-hub-cell-js-components-web').then(
+		({renderAIAssistantChat}) => {
+			renderAIAssistantChat(aiAssistantContainer, {
+				hideTriggerLabel: true,
+				instructionDefinitionScope: 'cms',
+				triggerRound: true,
+			});
+		}
+	);
+}
+
 function showRemoveButton() {
 	removeButton.classList.remove('d-none');
 	removeButton.addEventListener('click', onRemoveFile);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "c21af488eac21699c13b4b510fed533e5709e38d",
+	"@generated": "218c58278ba223c56823296ae1507f74500446a0",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/ai-hub-cell-js-components-web": [
 				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts"
 			],
 			"@liferay/cookies-banner-web": [
 				"../../../../../../../cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/index.d.ts"

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "1c5e8fbb9eb65f8fa3276ac33fe70f0928919d64",
+	"@generated": "c7831b39e9a50c693b48b3c677471695bc421f5a",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/ai-hub-cell-js-components-web": [
 				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts"
 			],
 			"@liferay/analytics-reports-js-components-web": [
 				"../../../../../../../analytics/analytics-reports-js-components-web/src/main/resources/META-INF/resources/js/index.ts"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "23f0ee3fb99ff23a7a956e5c7c321ee7227182b4",
+	"@generated": "8ed33286f24f526761e9edc54983175daea83307",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/ai-hub-cell-js-components-web": [
 				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"../../../../../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts"
 			],
 			"@liferay/analytics-reports-js-components-web": [
 				"../../../../../../../analytics/analytics-reports-js-components-web/src/main/resources/META-INF/resources/js/index.ts"

--- a/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "19322937c50366a2242e182ed7eb0389c3146efb",
+	"@generated": "86c440f4cbc0b5dfbc17e8c2fdb33b8e6e7692a1",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,6 +13,9 @@
 		"paths": {
 			"@liferay/ai-hub-cell-js-components-web": [
 				"../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/ai-hub-cell-js-components-web/renderAIAssistantChat": [
+				"../../../ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts"
 			],
 			"@liferay/analytics-reports-js-components-web": [
 				"../../../analytics/analytics-reports-js-components-web/src/main/resources/META-INF/resources/js/index.ts"

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,14 +10,14 @@
  */
 
 module.exports = {
-	hash: 'e63d387db0f2e94f8b50c6ecf8ffd08efb924ee3133eb60f47c9948a086b5e41',
+	hash: '9c7324f0ede56ac7e4503c6d2240f8a06b192e49ac55d17aad8af21225709dcb',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],
 		'@liferay/account-validator-vies-web': [],
 		'@liferay/address-web': [],
 		'@liferay/ai-creator-openai-web': [],
-		'@liferay/ai-hub-cell-js-components-web': [],
+		'@liferay/ai-hub-cell-js-components-web': ['./renderAIAssistantChat'],
 		'@liferay/ai-hub-web': [],
 		'@liferay/analytics-reports-js-components-web': [],
 		'@liferay/analytics-settings-web': [],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93954

## What Is Being Fixed

The CMS file-upload input fragment had no way to launch the AI Assistant next to its Select File button. The renderer was exported only from the ai-hub-cell-js-components-web index bundle, so a fragment — which runs in a native ES module context and cannot resolve @liferay/frontend-js-react-web — could not mount it, and importing the renderer by module name pulled in the entire index bundle.

## How It Is Being Fixed

The ai-hub-cell-js-components-web module now owns the mount through renderAIAssistantChat and publishes it as a dedicated submodule entry point in the import map, so the file-upload input fragment imports only the renderer and mounts the AI Assistant next to the Select File button. The tsconfig and global node-scripts config files are regenerated to expose the new submodule path.

## Why Are There No Tests?

This is a packaging refactor that moves the already-tested renderAIAssistantChat into its own submodule entry point and wires the file-upload input fragment to it, with no change to the renderer's behavior. The existing ai-hub-cell-js-components-web Jest suite (14 suites, 62 tests) covers the renderer and passed.

## PR Check

**pr-check: PASS** — tested on `90258dd90678868547416c4b774cf640a0e0b24d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "90258dd90678868547416c4b774cf640a0e0b24d"} -->
