### PR TITLE
LPD-97449 Identify issue reporters with the cell user token

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -109,6 +109,7 @@ public class AIHubCellConfigurationModelListener
 				company.getPortalURL(0), 0, null, "AI Hub Cell", null,
 				Arrays.asList(), false,
 				Arrays.asList(
+					"Liferay.Headless.Admin.User.everything.read",
 					"Liferay.Headless.Batch.Engine.everything",
 					"Liferay.Headless.CMP.everything.read",
 					"Liferay.Object.Admin.REST.everything.read",

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/api.ts
@@ -6,6 +6,7 @@
 import {EventSource} from 'eventsource';
 import {fetch} from 'frontend-js-web';
 
+import postAuthorizationToken from '../utils/postAuthorizationToken';
 import {HttpRequestAction} from './types';
 
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
@@ -67,42 +68,6 @@ export async function executeHttpRequestAction({
 		}),
 		method,
 	});
-}
-
-async function postAuthorizationToken() {
-	try {
-		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
-			{
-				method: 'POST',
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(
-				`Unable to generate authorization token: ${response.statusText}`
-			);
-		}
-
-		const data = await response.json();
-
-		if (!data?.accessToken) {
-			throw new Error('Unable to generate authorization token.');
-		}
-
-		if (!data?.userToken) {
-			throw new Error('Unable to generate user token.');
-		}
-
-		if (!data?.serviceURL) {
-			throw new Error('Unable to find service URL.');
-		}
-
-		return data;
-	}
-	catch (error) {
-		console.warn((error as Error).message);
-	}
 }
 
 export async function postChatByExternalReferenceCodeMessage({

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/api.ts
@@ -6,53 +6,10 @@
 import {EventSource} from 'eventsource';
 import {fetch} from 'frontend-js-web';
 
+import postAuthorizationToken from '../utils/postAuthorizationToken';
 import {CATEGORIZATION_INTENT_AGENT, ECategorizationAgent} from './types';
 
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
-
-interface AuthorizationToken {
-	accessToken: string;
-	serviceURL: string;
-	userToken: string;
-}
-
-async function postAuthorizationToken(): Promise<
-	AuthorizationToken | undefined
-> {
-	try {
-		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
-			{
-				method: 'POST',
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(
-				`Unable to generate authorization token: ${response.statusText}`
-			);
-		}
-
-		const data = await response.json();
-
-		if (!data?.accessToken) {
-			throw new Error('Unable to generate authorization token.');
-		}
-
-		if (!data?.userToken) {
-			throw new Error('Unable to generate user token.');
-		}
-
-		if (!data?.serviceURL) {
-			throw new Error('Unable to find service URL.');
-		}
-
-		return data;
-	}
-	catch (error) {
-		console.warn((error as Error).message);
-	}
-}
 
 export async function createCategorizationEventSource(): Promise<EventSource | null> {
 	const editMode = document.body.classList.contains('has-edit-mode-menu');

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/ReportFeedback/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/ReportFeedback/api.ts
@@ -5,6 +5,8 @@
 
 import {fetch} from 'frontend-js-web';
 
+import postAuthorizationToken from '../utils/postAuthorizationToken';
+
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
 export type ReportFeedbackReason =
@@ -30,14 +32,26 @@ export interface ReportFeedbackPayload {
 }
 
 export async function postAIIssueReport(payload: ReportFeedbackPayload) {
-	const response = await fetch(`${AI_HUB_ENDPOINT}/reports`, {
-		body: JSON.stringify(payload),
-		headers: new Headers({
-			'Accept': 'application/json',
-			'Content-Type': 'application/json',
-		}),
-		method: 'POST',
-	});
+	const authorizationToken = await postAuthorizationToken();
+
+	if (!authorizationToken) {
+		throw new Error('Unable to generate authorization token.');
+	}
+
+	const response = await fetch(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/reports`,
+		{
+			body: JSON.stringify(payload),
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
+				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
+			}),
+			method: 'POST',
+		}
+	);
 
 	if (!response.ok) {
 		throw new Error(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
@@ -5,6 +5,8 @@
 
 import {fetch} from 'frontend-js-web';
 
+import postAuthorizationToken from '../utils/postAuthorizationToken';
+
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
 export async function putAgentInstanceResume({
@@ -34,40 +36,4 @@ export async function putAgentInstanceResume({
 			method: 'PUT',
 		}
 	);
-}
-
-async function postAuthorizationToken() {
-	try {
-		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
-			{
-				method: 'POST',
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(
-				`Unable to generate authorization token: ${response.statusText}`
-			);
-		}
-
-		const data = await response.json();
-
-		if (!data?.accessToken) {
-			throw new Error('Unable to generate authorization token.');
-		}
-
-		if (!data?.userToken) {
-			throw new Error('Unable to generate user token.');
-		}
-
-		if (!data?.serviceURL) {
-			throw new Error('Unable to find service URL.');
-		}
-
-		return data;
-	}
-	catch (error) {
-		console.warn((error as Error).message);
-	}
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/WritingAssistant/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/WritingAssistant/api.ts
@@ -6,6 +6,7 @@
 import {EventSource} from 'eventsource';
 import {fetch} from 'frontend-js-web';
 
+import postAuthorizationToken from '../utils/postAuthorizationToken';
 import {EActionType} from './types';
 
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
@@ -37,42 +38,6 @@ export async function createEventSource() {
 			withCredentials: true,
 		}
 	);
-}
-
-async function postAuthorizationToken() {
-	try {
-		const response = await fetch(
-			'/o/ai-hub-cell/v1.0/authorization-tokens',
-			{
-				method: 'POST',
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(
-				`Unable to generate authorization token: ${response.statusText}`
-			);
-		}
-
-		const data = await response.json();
-
-		if (!data?.accessToken) {
-			throw new Error('Unable to generate authorization token.');
-		}
-
-		if (!data?.userToken) {
-			throw new Error('Unable to generate user token.');
-		}
-
-		if (!data?.serviceURL) {
-			throw new Error('Unable to find service URL.');
-		}
-
-		return data;
-	}
-	catch (error) {
-		console.warn((error as Error).message);
-	}
 }
 
 export async function postAgentInstance(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/utils/postAuthorizationToken.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/utils/postAuthorizationToken.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+export interface AuthorizationToken {
+	accessToken: string;
+	serviceURL: string;
+	userToken: string;
+}
+
+export default async function postAuthorizationToken(): Promise<
+	AuthorizationToken | undefined
+> {
+	try {
+		const response = await fetch(
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			{
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Unable to generate authorization token: ${response.statusText}`
+			);
+		}
+
+		const data = await response.json();
+
+		if (!data?.accessToken) {
+			throw new Error('Unable to generate authorization token.');
+		}
+
+		if (!data?.userToken) {
+			throw new Error('Unable to generate user token.');
+		}
+
+		if (!data?.serviceURL) {
+			throw new Error('Unable to find service URL.');
+		}
+
+		return data;
+	}
+	catch (error) {
+		console.warn((error as Error).message);
+	}
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/ReportFeedback/api.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/ReportFeedback/api.test.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+import {postAIIssueReport} from '../../../src/main/resources/META-INF/resources/js/ReportFeedback/api';
+
+jest.mock('frontend-js-web', () => ({fetch: jest.fn()}));
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+const randomString = () => Math.random().toString(36).slice(2, 10);
+
+const authorizationToken = {
+	accessToken: randomString(),
+	serviceURL: 'https://ai-hub.liferay.com',
+	userToken: randomString(),
+};
+
+const payload = {
+	agentDefinitionExternalReferenceCodes: ['agent-1'],
+	feedback: 'positive' as const,
+	surface: 'clickToChat' as const,
+};
+
+function jsonResponse(body: unknown, ok = true) {
+	return {
+		json: () => Promise.resolve(body),
+		ok,
+		status: ok ? 200 : 500,
+		statusText: ok ? 'OK' : 'Internal Server Error',
+		text: () => Promise.resolve(JSON.stringify(body)),
+	};
+}
+
+describe('postAIIssueReport', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	it('authorizes the report with the access token and the user token', async () => {
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse(authorizationToken) as never
+		);
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse({id: 'report-1'}) as never
+		);
+
+		await postAIIssueReport(payload);
+
+		const [, reportInit] = mockFetch.mock.calls[1];
+
+		const headers = reportInit?.headers as Headers;
+
+		expect(headers.get('Authorization')).toBe(
+			`Bearer ${authorizationToken.accessToken}`
+		);
+		expect(headers.get('Liferay-AI-Hub-Cell-On-Behalf-Of')).toBe(
+			authorizationToken.userToken
+		);
+	});
+
+	it('posts the report to the reports endpoint of the service URL', async () => {
+		const responseId = randomString();
+
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse(authorizationToken) as never
+		);
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse({id: responseId}) as never
+		);
+
+		const result = await postAIIssueReport(payload);
+
+		expect(result).toEqual({id: responseId});
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+
+		const [reportURL] = mockFetch.mock.calls[1];
+
+		expect(reportURL).toBe(
+			'https://ai-hub.liferay.com/o/ai-hub/v1.0/reports'
+		);
+	});
+
+	it('throws error when the request fails', async () => {
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse(authorizationToken) as never
+		);
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, false) as never);
+
+		await expect(postAIIssueReport(payload)).rejects.toThrow(
+			'Unable to send feedback'
+		);
+	});
+
+	it('throws error without posting the report when no authorization token is generated', async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, false) as never);
+
+		await expect(postAIIssueReport(payload)).rejects.toThrow(
+			'Unable to generate authorization token.'
+		);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97449

Companion pull request: https://github.com/liferay-ai-hub/liferay-portal-ee/pull/35

## What Is Being Fixed

The first attempt attached the reporter's address to a `Liferay-AI-Hub-Cell-On-Behalf-Of-Email` header read from `Liferay.ThemeDisplay.getUserEmailAddress()`. Any caller could set that header to an arbitrary address, so the stored reporter was not verifiable, and no server-side code ever read it.

## How It Is Being Fixed

`postAIIssueReport` now follows the authorization flow the chat surfaces already use. It requests an authorization token and posts to `${serviceURL}/o/ai-hub/v1.0/reports` with `Authorization: Bearer <accessToken>` and `Liferay-AI-Hub-Cell-On-Behalf-Of: <userToken>`. The user token is minted on the customer's own instance, so the server resolves a verified address rather than trusting client input. The companion pull request performs that resolution.

`postAuthorizationToken` was duplicated across all five `api.ts` surfaces. It moves to `js/utils/postAuthorizationToken.ts` and every surface imports it, so the report and chat clients cannot drift apart again — the divergence between them is what let the report path ship without the `Authorization` header in the first place.

`AIHubCellConfigurationModelListener` grants `Liferay.Headless.Admin.User.everything.read` to the `AI-HUB-CELL` OAuth2 application. Without that scope the minted user token cannot reach `/o/headless-admin-user/v1.0/my-user-account`, and the resolution fails with a 403.

The unit suite covers the three states of the report request: the endpoint derived from the service URL, both authorization headers when a token is available, and no report request at all when the token cannot be generated.

## PR Check

**pr-check: PASS** — tested on `de9aa784da2530c4c96b04fbf353340c099fe7ec`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "de9aa784da2530c4c96b04fbf353340c099fe7ec"} -->
