### PR TITLE
LPD-92741 [AI Hub][DXP] Translate Content Agent

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
@@ -16,6 +16,7 @@
 		"@clayui/list": "^3.165.0",
 		"@clayui/loading-indicator": "^3.165.0",
 		"@clayui/modal": "^3.165.0",
+		"@clayui/multi-select": "^3.165.0",
 		"@clayui/panel": "^3.165.0",
 		"@clayui/provider": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -33,6 +33,7 @@ import ContentTypeSelectorMessageBalloon, {
 } from './components/ContentTypeSelectorMessageBalloon';
 import ContentsMessageBalloon from './components/ContentsMessageBalloon';
 import ImageMessageBalloon from './components/ImageMessageBalloon';
+import TranslateContentMessageBalloon from './components/TranslateContentMessageBalloon';
 import UserMessageBalloon from './components/UserMessageBalloon';
 import {ChatMessageSentData, Message} from './types';
 import buildAssistantMessage from './utils/buildAssistantMessage';
@@ -112,6 +113,9 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 		instructionDefinitionScope
 	);
 	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+	const sourceLanguageIdRef = useRef<string>(
+		Liferay.ThemeDisplay.getLanguageId()
+	);
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 	const fileUploadSelectorRef = useRef<string | undefined>(undefined);
@@ -144,6 +148,18 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 			});
 		}, 0);
 	}, [messages]);
+
+	useEffect(() => {
+		const onLocaleChanged = ({languageId}: {languageId: string}) => {
+			sourceLanguageIdRef.current = languageId;
+		};
+
+		Liferay.on('localizationSelect:localeChanged', onLocaleChanged);
+
+		return () => {
+			Liferay.detach('localizationSelect:localeChanged', onLocaleChanged);
+		};
+	}, []);
 
 	const sendMessage = useCallback((text: string) => {
 		if (!text.trim()) {
@@ -511,6 +527,38 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 							/>
 						);
 					}
+
+					try {
+						const json = JSON.parse(
+							item.text
+								.trim()
+								.replace(/^```(?:json)?/i, '')
+								.replace(/```$/, '')
+								.trim()
+						);
+
+						if (json?.action === 'translate') {
+							const {
+								agentInstanceId,
+								availableLanguageIds,
+								results,
+								targetLanguageIds,
+							} = json;
+
+							return (
+								<TranslateContentMessageBalloon
+									agentInstanceId={agentInstanceId}
+									availableLanguageIds={availableLanguageIds}
+									key={index}
+									requestedLanguageIds={targetLanguageIds}
+									results={results}
+									setIsGenerating={setIsGenerating}
+									sourceLanguageIdRef={sourceLanguageIdRef}
+								/>
+							);
+						}
+					}
+					catch {}
 
 					return (
 						<AIAssistantMessageBalloon

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -332,6 +332,13 @@ html#{$cadmin-selector} .cadmin {
 			}
 		}
 
+		.ai-assistant-chat__language-select {
+			.form-control,
+			input {
+				cursor: pointer;
+			}
+		}
+
 		.ai-feedback-actions-row {
 			gap: 0.375rem;
 		}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -339,12 +339,7 @@ html#{$cadmin-selector} .cadmin {
 		}
 
 		.ai-assistant-chat__language-select {
-			align-items: flex-start;
-			display: flex;
-			flex-direction: column;
-			gap: 0.5rem;
 			margin: 0.5rem;
-			width: 100%;
 
 			.form-control,
 			input {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -375,6 +375,10 @@ html#{$cadmin-selector} .cadmin {
 			flex-direction: row;
 			gap: 0.5rem;
 			margin: 0.5rem;
+
+			.btn {
+				border-radius: 0.5rem;
+			}
 		}
 
 		.ai-assistant-chat__translation-review {
@@ -382,6 +386,10 @@ html#{$cadmin-selector} .cadmin {
 			flex-direction: column;
 			gap: 0.5rem;
 			margin: 0.5rem;
+
+			.btn {
+				border-radius: 0.5rem;
+			}
 		}
 
 		.ai-feedback-actions-row {
@@ -392,6 +400,10 @@ html#{$cadmin-selector} .cadmin {
 			display: flex;
 			justify-content: flex-end;
 			margin-bottom: 0.5rem;
+
+			.btn {
+				border-radius: 0.5rem;
+			}
 		}
 
 		.ai-assistant-chat__user-image {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -211,8 +211,6 @@ html#{$cadmin-selector} .cadmin {
 			background: $cadmin-danger-l2;
 		}
 		.ai-assistant-chat__ai-assistant-message-balloon {
-			background: $cadmin-gray-100;
-			border-radius: 0.25rem;
 			display: flex;
 			flex-direction: column;
 			margin-bottom: 0.5rem;
@@ -427,7 +425,23 @@ html#{$cadmin-selector} .cadmin {
 		}
 
 		.ai-assistant-chat__user-message {
-			max-width: 70%;
+			align-items: center;
+			display: flex;
+			justify-content: flex-end;
+			margin-bottom: 0.5rem;
+
+			&-avatar {
+				flex-shrink: 0;
+				margin-left: 0.5rem;
+			}
+
+			&-content {
+				background: $cadmin-gray-100;
+				border-radius: 0.5rem;
+				max-width: 70%;
+				overflow-wrap: break-word;
+				padding: 0.5rem;
+			}
 		}
 
 		.ai-assistant-chat__suggestion-hint {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -404,6 +404,12 @@ html#{$cadmin-selector} .cadmin {
 			gap: 0.375rem;
 		}
 
+		.ai-assistant-chat__user-action {
+			display: flex;
+			justify-content: flex-end;
+			margin-bottom: 0.5rem;
+		}
+
 		.ai-assistant-chat__user-image {
 			align-items: center;
 			border-radius: 50%;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -370,26 +370,11 @@ html#{$cadmin-selector} .cadmin {
 			}
 		}
 
-		.ai-assistant-chat__translation-actions {
-			display: flex;
-			flex-direction: row;
-			gap: 0.5rem;
-			margin: 0.5rem;
-
-			.btn {
-				border-radius: 0.5rem;
-			}
-		}
-
 		.ai-assistant-chat__translation-review {
 			display: flex;
 			flex-direction: column;
 			gap: 0.5rem;
 			margin: 0.5rem;
-
-			.btn {
-				border-radius: 0.5rem;
-			}
 		}
 
 		.ai-feedback-actions-row {
@@ -398,6 +383,7 @@ html#{$cadmin-selector} .cadmin {
 
 		.ai-assistant-chat__user-action {
 			display: flex;
+			gap: 0.5rem;
 			justify-content: flex-end;
 			margin-bottom: 0.5rem;
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -377,22 +377,6 @@ html#{$cadmin-selector} .cadmin {
 			margin: 0.5rem;
 		}
 
-		.ai-assistant-chat__translation-results {
-			list-style: none;
-			margin: 0.5rem;
-			padding-left: 0;
-		}
-
-		.ai-assistant-chat__translation-result {
-			align-items: center;
-			display: flex;
-			margin-bottom: 0.25rem;
-
-			&-language {
-				flex-grow: 1;
-			}
-		}
-
 		.ai-assistant-chat__translation-review {
 			display: flex;
 			flex-direction: column;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -17,6 +17,10 @@ html#{$cadmin-selector} {
 		padding: 0;
 	}
 
+	.ai-assistant-chat__language-id-icon {
+		margin-right: 0.5rem;
+	}
+
 	.ai-assistant-chat__trigger.btn {
 		align-items: center;
 		background-color: transparent;
@@ -208,6 +212,10 @@ html#{$cadmin-selector} .cadmin {
 		}
 		.ai-assistant-chat__ai-assistant-message-balloon {
 			background: $cadmin-gray-100;
+			border-radius: 0.25rem;
+			display: flex;
+			flex-direction: column;
+			margin-bottom: 0.5rem;
 		}
 
 		.ai-assistant-chat__content-generation-balloon {
@@ -333,10 +341,65 @@ html#{$cadmin-selector} .cadmin {
 		}
 
 		.ai-assistant-chat__language-select {
+			align-items: flex-start;
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin: 0.5rem;
+			width: 100%;
+
 			.form-control,
 			input {
 				cursor: pointer;
 			}
+		}
+
+		.ai-assistant-chat__message-header {
+			display: flex;
+			flex-direction: row;
+			font-weight: 600;
+
+			&-icon {
+				color: $cadmin-primary;
+				display: inline-block;
+				font-size: 12px;
+				margin-left: 0.5rem;
+				margin-top: 0.5rem;
+			}
+
+			&-text {
+				margin: 0.5rem;
+			}
+		}
+
+		.ai-assistant-chat__translation-actions {
+			display: flex;
+			flex-direction: row;
+			gap: 0.5rem;
+			margin: 0.5rem;
+		}
+
+		.ai-assistant-chat__translation-results {
+			list-style: none;
+			margin: 0.5rem;
+			padding-left: 0;
+		}
+
+		.ai-assistant-chat__translation-result {
+			align-items: center;
+			display: flex;
+			margin-bottom: 0.25rem;
+
+			&-language {
+				flex-grow: 1;
+			}
+		}
+
+		.ai-assistant-chat__translation-review {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin: 0.5rem;
 		}
 
 		.ai-feedback-actions-row {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -49,23 +49,16 @@ const TranslateContentMessageBalloon: React.FC<
 
 	if (step === 'confirm') {
 		return (
-			<MessageBalloon>
-				<MessageHeader
-					message={Liferay.Language.get(
-						'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
-					)}
-				/>
+			<>
+				<MessageBalloon>
+					<MessageHeader
+						message={Liferay.Language.get(
+							'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+						)}
+					/>
+				</MessageBalloon>
 
-				<div className="ai-assistant-chat__translation-actions">
-					<ClayButton
-						disabled={submitted}
-						displayType="primary"
-						onClick={() => submit(selectedLanguageIds)}
-						size="sm"
-					>
-						{Liferay.Language.get('overwrite-all')}
-					</ClayButton>
-
+				<div className="ai-assistant-chat__user-action">
 					<ClayButton
 						disabled={submitted}
 						displayType="secondary"
@@ -74,33 +67,48 @@ const TranslateContentMessageBalloon: React.FC<
 					>
 						{Liferay.Language.get('review')}
 					</ClayButton>
+
+					<ClayButton
+						disabled={submitted}
+						displayType="primary"
+						onClick={() => submit(selectedLanguageIds)}
+						size="sm"
+					>
+						{Liferay.Language.get('overwrite-all')}
+					</ClayButton>
 				</div>
-			</MessageBalloon>
+			</>
 		);
 	}
 
 	if (step === 'review') {
 		return (
-			<MessageBalloon>
-				<MessageHeader
-					message={Liferay.Language.get(
-						'select-the-translations-you-want-to-overwrite'
-					)}
-				/>
+			<>
+				<MessageBalloon>
+					<MessageHeader
+						message={Liferay.Language.get(
+							'select-the-translations-you-want-to-overwrite'
+						)}
+					/>
 
-				<div className="ai-assistant-chat__translation-review">
-					{translatedLanguageIds.map((languageId) => (
-						<ClayCheckbox
-							checked={selectedLanguageIds.includes(languageId)}
-							disabled={submitted}
-							key={languageId}
-							label={languageId}
-							onChange={() =>
-								toggleSelectedLanguageId(languageId)
-							}
-						/>
-					))}
+					<div className="ai-assistant-chat__translation-review">
+						{translatedLanguageIds.map((languageId) => (
+							<ClayCheckbox
+								checked={selectedLanguageIds.includes(
+									languageId
+								)}
+								disabled={submitted}
+								key={languageId}
+								label={languageId}
+								onChange={() =>
+									toggleSelectedLanguageId(languageId)
+								}
+							/>
+						))}
+					</div>
+				</MessageBalloon>
 
+				<div className="ai-assistant-chat__user-action">
 					<ClayButton
 						disabled={submitted || !selectedLanguageIds.length}
 						displayType="primary"
@@ -110,7 +118,7 @@ const TranslateContentMessageBalloon: React.FC<
 						{Liferay.Language.get('overwrite')}
 					</ClayButton>
 				</div>
-			</MessageBalloon>
+			</>
 		);
 	}
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -5,7 +5,6 @@
 
 import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
-import ClayLabel from '@clayui/label';
 import ClayMultiSelect from '@clayui/multi-select';
 import React from 'react';
 
@@ -44,25 +43,6 @@ const TranslateContentMessageBalloon: React.FC<
 						'the-content-has-been-translated'
 					)}
 				/>
-
-				<ul className="ai-assistant-chat__translation-results">
-					{results.map(({targetLanguageId}) => (
-						<li
-							className="ai-assistant-chat__translation-result"
-							key={targetLanguageId}
-						>
-							<LanguageIdIcon languageId={targetLanguageId} />
-
-							<span className="ai-assistant-chat__translation-result-language">
-								{targetLanguageId}
-							</span>
-
-							<ClayLabel displayType="success">
-								{Liferay.Language.get('translated')}
-							</ClayLabel>
-						</li>
-					))}
-				</ul>
 			</MessageBalloon>
 		);
 	}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {ClayCheckbox} from '@clayui/form';
+import ClayLabel from '@clayui/label';
+import ClayMultiSelect from '@clayui/multi-select';
+import React from 'react';
+
+import LanguageIdIcon from '../../TranslateContent/components/LanguageIdIcon';
+import MessageBalloon from '../../TranslateContent/components/MessageBalloon';
+import MessageHeader from '../../TranslateContent/components/MessageHeader';
+import {TranslateContentMessageBalloonProps} from '../../TranslateContent/types';
+import useTranslateContentAgent from '../../TranslateContent/useTranslateContentAgent';
+
+import '../chat.scss';
+
+const TranslateContentMessageBalloon: React.FC<
+	TranslateContentMessageBalloonProps
+> = (props) => {
+	const {availableLanguageIds, results} = props;
+
+	const {
+		onTranslate,
+		selectedLanguageIds,
+		setSelectedLanguageIds,
+		setStep,
+		setValue,
+		step,
+		submit,
+		submitted,
+		toggleSelectedLanguageId,
+		translatedLanguageIds,
+		value,
+	} = useTranslateContentAgent(props);
+
+	if (results?.length) {
+		return (
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'the-content-has-been-translated'
+					)}
+				/>
+
+				<ul className="list-unstyled m-2">
+					{results.map(({targetLanguageId}) => (
+						<li
+							className="align-items-center d-flex mb-1"
+							key={targetLanguageId}
+						>
+							<LanguageIdIcon languageId={targetLanguageId} />
+
+							<span className="flex-grow-1">
+								{targetLanguageId}
+							</span>
+
+							<ClayLabel displayType="success">
+								{Liferay.Language.get('translated')}
+							</ClayLabel>
+						</li>
+					))}
+				</ul>
+			</MessageBalloon>
+		);
+	}
+
+	if (step === 'confirm') {
+		return (
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+					)}
+				/>
+
+				<div className="c-gap-2 d-flex flex-row m-2">
+					<ClayButton
+						disabled={submitted}
+						displayType="primary"
+						onClick={() => submit(selectedLanguageIds)}
+						size="sm"
+					>
+						{Liferay.Language.get('overwrite-all')}
+					</ClayButton>
+
+					<ClayButton
+						disabled={submitted}
+						displayType="secondary"
+						onClick={() => setStep('review')}
+						size="sm"
+					>
+						{Liferay.Language.get('review')}
+					</ClayButton>
+				</div>
+			</MessageBalloon>
+		);
+	}
+
+	if (step === 'review') {
+		return (
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'select-the-translations-you-want-to-overwrite'
+					)}
+				/>
+
+				<div className="c-gap-2 d-flex flex-column m-2">
+					{translatedLanguageIds.map((languageId) => (
+						<ClayCheckbox
+							checked={selectedLanguageIds.includes(languageId)}
+							disabled={submitted}
+							key={languageId}
+							label={languageId}
+							onChange={() =>
+								toggleSelectedLanguageId(languageId)
+							}
+						/>
+					))}
+
+					<ClayButton
+						disabled={submitted || !selectedLanguageIds.length}
+						displayType="primary"
+						onClick={() => submit(selectedLanguageIds)}
+						size="sm"
+					>
+						{Liferay.Language.get('overwrite')}
+					</ClayButton>
+				</div>
+			</MessageBalloon>
+		);
+	}
+
+	return (
+		<MessageBalloon>
+			<MessageHeader
+				message={Liferay.Language.get(
+					'which-languages-would-you-like-to-translate-into'
+				)}
+			/>
+
+			<div
+				className="ai-assistant-chat__language-select align-items-start c-gap-2 d-flex flex-column m-2 w-100"
+				style={{maxWidth: '18rem'}}
+			>
+				<ClayMultiSelect
+					disabled={submitted}
+					items={selectedLanguageIds.map((languageId) => ({
+						label: languageId,
+						value: languageId,
+					}))}
+					onChange={setValue}
+					onItemsChange={(newItems) =>
+						setSelectedLanguageIds(
+							newItems.map((item) => item.value)
+						)
+					}
+					placeholder={Liferay.Language.get('select-languages')}
+					sourceItems={(availableLanguageIds ?? []).map(
+						(languageId) => ({
+							label: languageId,
+							value: languageId,
+						})
+					)}
+					spritemap={Liferay.Icons.spritemap}
+					value={value}
+				>
+					{(item) => (
+						<ClayMultiSelect.Item
+							key={item.value}
+							onClick={(event) => {
+								event.preventDefault();
+
+								toggleSelectedLanguageId(item.value);
+
+								setValue('');
+							}}
+							style={{cursor: 'pointer'}}
+							textValue={item.label}
+						>
+							<LanguageIdIcon languageId={item.value} />
+
+							{item.label}
+						</ClayMultiSelect.Item>
+					)}
+				</ClayMultiSelect>
+
+				<ClayButton
+					disabled={!selectedLanguageIds.length || submitted}
+					displayType="primary"
+					onClick={onTranslate}
+					size="sm"
+				>
+					{Liferay.Language.get('translate')}
+				</ClayButton>
+			</div>
+		</MessageBalloon>
+	);
+};
+
+export default TranslateContentMessageBalloon;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -22,14 +22,21 @@ const TranslateContentMessageBalloon: React.FC<
 	const {availableLanguageIds, results} = props;
 
 	const {
+		confirmDisabled,
 		onTranslate,
+		overwrite,
+		overwriteAll,
+		overwriteDisabled,
+		overwriteLanguageIds,
+		review,
+		selectDisabled,
 		selectedLanguageIds,
 		setSelectedLanguageIds,
-		setStep,
 		setValue,
-		step,
-		submit,
+		showConfirm,
+		showReview,
 		submitted,
+		toggleOverwriteLanguageId,
 		toggleSelectedLanguageId,
 		translatedLanguageIds,
 		value,
@@ -47,81 +54,6 @@ const TranslateContentMessageBalloon: React.FC<
 		);
 	}
 
-	if (step === 'confirm') {
-		return (
-			<>
-				<MessageBalloon>
-					<MessageHeader
-						message={Liferay.Language.get(
-							'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
-						)}
-					/>
-				</MessageBalloon>
-
-				<div className="ai-assistant-chat__user-action">
-					<ClayButton
-						disabled={submitted}
-						displayType="secondary"
-						onClick={() => setStep('review')}
-						size="sm"
-					>
-						{Liferay.Language.get('review')}
-					</ClayButton>
-
-					<ClayButton
-						disabled={submitted}
-						displayType="primary"
-						onClick={() => submit(selectedLanguageIds)}
-						size="sm"
-					>
-						{Liferay.Language.get('overwrite-all')}
-					</ClayButton>
-				</div>
-			</>
-		);
-	}
-
-	if (step === 'review') {
-		return (
-			<>
-				<MessageBalloon>
-					<MessageHeader
-						message={Liferay.Language.get(
-							'select-the-translations-you-want-to-overwrite'
-						)}
-					/>
-
-					<div className="ai-assistant-chat__translation-review">
-						{translatedLanguageIds.map((languageId) => (
-							<ClayCheckbox
-								checked={selectedLanguageIds.includes(
-									languageId
-								)}
-								disabled={submitted}
-								key={languageId}
-								label={languageId}
-								onChange={() =>
-									toggleSelectedLanguageId(languageId)
-								}
-							/>
-						))}
-					</div>
-				</MessageBalloon>
-
-				<div className="ai-assistant-chat__user-action">
-					<ClayButton
-						disabled={submitted || !selectedLanguageIds.length}
-						displayType="primary"
-						onClick={() => submit(selectedLanguageIds)}
-						size="sm"
-					>
-						{Liferay.Language.get('overwrite')}
-					</ClayButton>
-				</div>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<MessageBalloon>
@@ -136,7 +68,7 @@ const TranslateContentMessageBalloon: React.FC<
 					style={{maxWidth: '18rem'}}
 				>
 					<ClayMultiSelect
-						disabled={submitted}
+						disabled={selectDisabled}
 						items={selectedLanguageIds.map((languageId) => ({
 							label: languageId,
 							value: languageId,
@@ -182,7 +114,7 @@ const TranslateContentMessageBalloon: React.FC<
 			{!!selectedLanguageIds.length && (
 				<div className="ai-assistant-chat__user-action">
 					<ClayButton
-						disabled={submitted}
+						disabled={selectDisabled}
 						displayType="primary"
 						onClick={onTranslate}
 						size="sm"
@@ -190,6 +122,77 @@ const TranslateContentMessageBalloon: React.FC<
 						{Liferay.Language.get('translate')}
 					</ClayButton>
 				</div>
+			)}
+
+			{showConfirm && (
+				<>
+					<MessageBalloon>
+						<MessageHeader
+							message={Liferay.Language.get(
+								'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+							)}
+						/>
+					</MessageBalloon>
+
+					<div className="ai-assistant-chat__user-action">
+						<ClayButton
+							disabled={confirmDisabled}
+							displayType="secondary"
+							onClick={review}
+							size="sm"
+						>
+							{Liferay.Language.get('review')}
+						</ClayButton>
+
+						<ClayButton
+							disabled={confirmDisabled}
+							displayType="primary"
+							onClick={overwriteAll}
+							size="sm"
+						>
+							{Liferay.Language.get('overwrite-all')}
+						</ClayButton>
+					</div>
+				</>
+			)}
+
+			{showReview && (
+				<>
+					<MessageBalloon>
+						<MessageHeader
+							message={Liferay.Language.get(
+								'select-the-translations-you-want-to-overwrite'
+							)}
+						/>
+
+						<div className="ai-assistant-chat__translation-review">
+							{translatedLanguageIds.map((languageId) => (
+								<ClayCheckbox
+									checked={overwriteLanguageIds.includes(
+										languageId
+									)}
+									disabled={submitted}
+									key={languageId}
+									label={languageId}
+									onChange={() =>
+										toggleOverwriteLanguageId(languageId)
+									}
+								/>
+							))}
+						</div>
+					</MessageBalloon>
+
+					<div className="ai-assistant-chat__user-action">
+						<ClayButton
+							disabled={overwriteDisabled}
+							displayType="primary"
+							onClick={overwrite}
+							size="sm"
+						>
+							{Liferay.Language.get('overwrite')}
+						</ClayButton>
+					</div>
+				</>
 			)}
 		</>
 	);

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -63,10 +63,7 @@ const TranslateContentMessageBalloon: React.FC<
 					)}
 				/>
 
-				<div
-					className="ai-assistant-chat__language-select"
-					style={{maxWidth: '18rem'}}
-				>
+				<div className="ai-assistant-chat__language-select">
 					<ClayMultiSelect
 						disabled={selectDisabled}
 						items={selectedLanguageIds.map((languageId) => ({

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -135,69 +135,75 @@ const TranslateContentMessageBalloon: React.FC<
 	}
 
 	return (
-		<MessageBalloon>
-			<MessageHeader
-				message={Liferay.Language.get(
-					'which-languages-would-you-like-to-translate-into'
-				)}
-			/>
+		<>
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'which-languages-would-you-like-to-translate-into'
+					)}
+				/>
 
-			<div
-				className="ai-assistant-chat__language-select"
-				style={{maxWidth: '18rem'}}
-			>
-				<ClayMultiSelect
-					disabled={submitted}
-					items={selectedLanguageIds.map((languageId) => ({
-						label: languageId,
-						value: languageId,
-					}))}
-					onChange={setValue}
-					onItemsChange={(newItems) =>
-						setSelectedLanguageIds(
-							newItems.map((item) => item.value)
-						)
-					}
-					placeholder={Liferay.Language.get('select-languages')}
-					sourceItems={(availableLanguageIds ?? []).map(
-						(languageId) => ({
+				<div
+					className="ai-assistant-chat__language-select"
+					style={{maxWidth: '18rem'}}
+				>
+					<ClayMultiSelect
+						disabled={submitted}
+						items={selectedLanguageIds.map((languageId) => ({
 							label: languageId,
 							value: languageId,
-						})
-					)}
-					spritemap={Liferay.Icons.spritemap}
-					value={value}
-				>
-					{(item) => (
-						<ClayMultiSelect.Item
-							key={item.value}
-							onClick={(event) => {
-								event.preventDefault();
+						}))}
+						onChange={setValue}
+						onItemsChange={(newItems) =>
+							setSelectedLanguageIds(
+								newItems.map((item) => item.value)
+							)
+						}
+						placeholder={Liferay.Language.get('select-languages')}
+						sourceItems={(availableLanguageIds ?? []).map(
+							(languageId) => ({
+								label: languageId,
+								value: languageId,
+							})
+						)}
+						spritemap={Liferay.Icons.spritemap}
+						value={value}
+					>
+						{(item) => (
+							<ClayMultiSelect.Item
+								key={item.value}
+								onClick={(event) => {
+									event.preventDefault();
 
-								toggleSelectedLanguageId(item.value);
+									toggleSelectedLanguageId(item.value);
 
-								setValue('');
-							}}
-							style={{cursor: 'pointer'}}
-							textValue={item.label}
-						>
-							<LanguageIdIcon languageId={item.value} />
+									setValue('');
+								}}
+								style={{cursor: 'pointer'}}
+								textValue={item.label}
+							>
+								<LanguageIdIcon languageId={item.value} />
 
-							{item.label}
-						</ClayMultiSelect.Item>
-					)}
-				</ClayMultiSelect>
+								{item.label}
+							</ClayMultiSelect.Item>
+						)}
+					</ClayMultiSelect>
+				</div>
+			</MessageBalloon>
 
-				<ClayButton
-					disabled={!selectedLanguageIds.length || submitted}
-					displayType="primary"
-					onClick={onTranslate}
-					size="sm"
-				>
-					{Liferay.Language.get('translate')}
-				</ClayButton>
-			</div>
-		</MessageBalloon>
+			{!!selectedLanguageIds.length && (
+				<div className="ai-assistant-chat__user-action">
+					<ClayButton
+						disabled={submitted}
+						displayType="primary"
+						onClick={onTranslate}
+						size="sm"
+					>
+						{Liferay.Language.get('translate')}
+					</ClayButton>
+				</div>
+			)}
+		</>
 	);
 };
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -45,15 +45,15 @@ const TranslateContentMessageBalloon: React.FC<
 					)}
 				/>
 
-				<ul className="list-unstyled m-2">
+				<ul className="ai-assistant-chat__translation-results">
 					{results.map(({targetLanguageId}) => (
 						<li
-							className="align-items-center d-flex mb-1"
+							className="ai-assistant-chat__translation-result"
 							key={targetLanguageId}
 						>
 							<LanguageIdIcon languageId={targetLanguageId} />
 
-							<span className="flex-grow-1">
+							<span className="ai-assistant-chat__translation-result-language">
 								{targetLanguageId}
 							</span>
 
@@ -76,7 +76,7 @@ const TranslateContentMessageBalloon: React.FC<
 					)}
 				/>
 
-				<div className="c-gap-2 d-flex flex-row m-2">
+				<div className="ai-assistant-chat__translation-actions">
 					<ClayButton
 						disabled={submitted}
 						displayType="primary"
@@ -108,7 +108,7 @@ const TranslateContentMessageBalloon: React.FC<
 					)}
 				/>
 
-				<div className="c-gap-2 d-flex flex-column m-2">
+				<div className="ai-assistant-chat__translation-review">
 					{translatedLanguageIds.map((languageId) => (
 						<ClayCheckbox
 							checked={selectedLanguageIds.includes(languageId)}
@@ -143,7 +143,7 @@ const TranslateContentMessageBalloon: React.FC<
 			/>
 
 			<div
-				className="ai-assistant-chat__language-select align-items-start c-gap-2 d-flex flex-column m-2 w-100"
+				className="ai-assistant-chat__language-select"
 				style={{maxWidth: '18rem'}}
 			>
 				<ClayMultiSelect

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/UserMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/UserMessageBalloon.tsx
@@ -29,12 +29,12 @@ const UserChatItem: React.FC<{message: string}> = ({message}) => {
 	}, []);
 
 	return (
-		<div className="align-items-center d-flex justify-content-end mb-2">
-			<span className="ai-assistant-chat__user-message col-auto p-2 text-break">
+		<div className="ai-assistant-chat__user-message">
+			<span className="ai-assistant-chat__user-message-content">
 				{message}
 			</span>
 
-			<div className="flex-shrink-0 ml-2">
+			<div className="ai-assistant-chat__user-message-avatar">
 				<Avatar image={userAccount?.image} name={userAccount?.name} />
 			</div>
 		</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
+
+export async function putAgentInstanceResume({
+	agentInstanceId,
+	context,
+}: {
+	agentInstanceId: number;
+	context: Record<string, unknown>;
+}) {
+	const authorizationToken = await postAuthorizationToken();
+
+	if (!authorizationToken) {
+		return;
+	}
+
+	return await fetch(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/agent-instances/${agentInstanceId}/resume`,
+		{
+			body: JSON.stringify({context}),
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
+				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
+			}),
+			method: 'PUT',
+		}
+	);
+}
+
+async function postAuthorizationToken() {
+	try {
+		const response = await fetch(
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			{
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Unable to generate authorization token: ${response.statusText}`
+			);
+		}
+
+		const data = await response.json();
+
+		if (!data?.accessToken) {
+			throw new Error('Unable to generate authorization token.');
+		}
+
+		if (!data?.userToken) {
+			throw new Error('Unable to generate user token.');
+		}
+
+		if (!data?.serviceURL) {
+			throw new Error('Unable to find service URL.');
+		}
+
+		return data;
+	}
+	catch (error) {
+		console.warn((error as Error).message);
+	}
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 export default function LanguageIdIcon({languageId}: {languageId: string}) {
 	return (
 		<ClayIcon
-			className="mr-2"
+			className="ai-assistant-chat__language-id-icon"
 			spritemap={Liferay.Icons.spritemap}
 			symbol={languageId.replace(/_/g, '-').toLowerCase()}
 		/>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function LanguageIdIcon({languageId}: {languageId: string}) {
+	return (
+		<ClayIcon
+			className="mr-2"
+			spritemap={Liferay.Icons.spritemap}
+			symbol={languageId.replace(/_/g, '-').toLowerCase()}
+		/>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
@@ -11,7 +11,7 @@ export default function MessageBalloon({
 	children: React.ReactNode;
 }) {
 	return (
-		<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+		<div className="ai-assistant-chat__ai-assistant-message-balloon">
 			{children}
 		</div>
 	);

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+export default function MessageBalloon({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+			{children}
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
@@ -8,12 +8,14 @@ import React from 'react';
 
 export default function MessageHeader({message}: {message: string}) {
 	return (
-		<div className="d-flex flex-row font-weight-semi-bold">
-			<div className="align-items-start d-inline-block ml-2 mt-2 text-2 text-primary">
+		<div className="ai-assistant-chat__message-header">
+			<div className="ai-assistant-chat__message-header-icon">
 				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
 			</div>
 
-			<div className="m-2">{message}</div>
+			<div className="ai-assistant-chat__message-header-text">
+				{message}
+			</div>
 		</div>
 	);
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function MessageHeader({message}: {message: string}) {
+	return (
+		<div className="d-flex flex-row font-weight-semi-bold">
+			<div className="align-items-start d-inline-block ml-2 mt-2 text-2 text-primary">
+				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+			</div>
+
+			<div className="m-2">{message}</div>
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {MutableRefObject} from 'react';
+
+export interface Result {
+	fields?: Record<string, string>;
+	targetLanguageId: string;
+}
+
+export interface TranslateContentMessageBalloonProps {
+	agentInstanceId: number;
+	availableLanguageIds?: string[];
+	requestedLanguageIds?: string[];
+	results?: Result[];
+	setIsGenerating: (isGenerating: boolean) => void;
+	sourceLanguageIdRef: MutableRefObject<string>;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useEffect, useRef, useState} from 'react';
+import {Dispatch, SetStateAction, useEffect, useRef, useState} from 'react';
 
 import {putAgentInstanceResume} from './api';
 import {TranslateContentMessageBalloonProps} from './types';
@@ -20,6 +20,9 @@ export default function useTranslateContentAgent({
 }: TranslateContentMessageBalloonProps) {
 	const appliedRef = useRef<boolean>(false);
 
+	const [overwriteLanguageIds, setOverwriteLanguageIds] = useState<string[]>(
+		[]
+	);
 	const [selectedLanguageIds, setSelectedLanguageIds] = useState<string[]>(
 		() =>
 			(requestedLanguageIds ?? []).filter((languageId) =>
@@ -52,14 +55,17 @@ export default function useTranslateContentAgent({
 		}).catch(() => setIsGenerating(false));
 	};
 
-	const toggleSelectedLanguageId = (languageId: string) => {
-		setSelectedLanguageIds((previousSelectedLanguageIds) =>
-			previousSelectedLanguageIds.includes(languageId)
-				? previousSelectedLanguageIds.filter(
-						(selectedLanguageId) =>
-							selectedLanguageId !== languageId
+	const toggleLanguageId = (
+		setLanguageIds: Dispatch<SetStateAction<string[]>>,
+		languageId: string
+	) => {
+		setLanguageIds((previousLanguageIds) =>
+			previousLanguageIds.includes(languageId)
+				? previousLanguageIds.filter(
+						(previousLanguageId) =>
+							previousLanguageId !== languageId
 					)
-				: [...previousSelectedLanguageIds, languageId]
+				: [...previousLanguageIds, languageId]
 		);
 	};
 
@@ -76,6 +82,21 @@ export default function useTranslateContentAgent({
 		setStep('confirm');
 		setTranslatedLanguageIds(translatedLanguageIds);
 	};
+
+	const review = () => {
+		setOverwriteLanguageIds(translatedLanguageIds);
+		setStep('review');
+	};
+
+	const overwriteAll = () => submit(selectedLanguageIds);
+
+	const overwriteTargetLanguageIds = selectedLanguageIds.filter(
+		(languageId) =>
+			!translatedLanguageIds.includes(languageId) ||
+			overwriteLanguageIds.includes(languageId)
+	);
+
+	const overwrite = () => submit(overwriteTargetLanguageIds);
 
 	useEffect(() => {
 		if (appliedRef.current || !results?.length) {
@@ -103,15 +124,24 @@ export default function useTranslateContentAgent({
 	}, [results]);
 
 	return {
+		confirmDisabled: submitted || step === 'review',
 		onTranslate,
+		overwrite,
+		overwriteAll,
+		overwriteDisabled: submitted || !overwriteTargetLanguageIds.length,
+		overwriteLanguageIds,
+		review,
+		selectDisabled: submitted || step !== 'select',
 		selectedLanguageIds,
 		setSelectedLanguageIds,
-		setStep,
 		setValue,
-		step,
-		submit,
+		showConfirm: step === 'confirm' || step === 'review',
+		showReview: step === 'review',
 		submitted,
-		toggleSelectedLanguageId,
+		toggleOverwriteLanguageId: (languageId: string) =>
+			toggleLanguageId(setOverwriteLanguageIds, languageId),
+		toggleSelectedLanguageId: (languageId: string) =>
+			toggleLanguageId(setSelectedLanguageIds, languageId),
 		translatedLanguageIds,
 		value,
 	};

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
@@ -1,0 +1,118 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useEffect, useRef, useState} from 'react';
+
+import {putAgentInstanceResume} from './api';
+import {TranslateContentMessageBalloonProps} from './types';
+import {getPageContext} from './utils/getPageContext';
+import {getTranslatedLanguageIds} from './utils/getTranslatedLanguageIds';
+
+export default function useTranslateContentAgent({
+	agentInstanceId,
+	availableLanguageIds,
+	requestedLanguageIds,
+	results,
+	setIsGenerating,
+	sourceLanguageIdRef,
+}: TranslateContentMessageBalloonProps) {
+	const appliedRef = useRef<boolean>(false);
+
+	const [selectedLanguageIds, setSelectedLanguageIds] = useState<string[]>(
+		() =>
+			(requestedLanguageIds ?? []).filter((languageId) =>
+				(availableLanguageIds ?? []).includes(languageId)
+			)
+	);
+	const [step, setStep] = useState<'confirm' | 'review' | 'select'>('select');
+	const [submitted, setSubmitted] = useState<boolean>(false);
+	const [translatedLanguageIds, setTranslatedLanguageIds] = useState<
+		string[]
+	>([]);
+	const [value, setValue] = useState<string>('');
+
+	const submit = (targetLanguageIds: string[]) => {
+		setIsGenerating(true);
+		setSubmitted(true);
+
+		const sourceLanguageId = sourceLanguageIdRef.current;
+
+		const {fields, html} = getPageContext(sourceLanguageId);
+
+		putAgentInstanceResume({
+			agentInstanceId,
+			context: {
+				fields: JSON.stringify(fields),
+				html: JSON.stringify(html),
+				sourceLanguageId,
+				targetLanguageIds: JSON.stringify(targetLanguageIds),
+			},
+		}).catch(() => setIsGenerating(false));
+	};
+
+	const toggleSelectedLanguageId = (languageId: string) => {
+		setSelectedLanguageIds((previousSelectedLanguageIds) =>
+			previousSelectedLanguageIds.includes(languageId)
+				? previousSelectedLanguageIds.filter(
+						(selectedLanguageId) =>
+							selectedLanguageId !== languageId
+					)
+				: [...previousSelectedLanguageIds, languageId]
+		);
+	};
+
+	const onTranslate = () => {
+		const translatedLanguageIds =
+			getTranslatedLanguageIds(selectedLanguageIds);
+
+		if (!translatedLanguageIds.length) {
+			submit(selectedLanguageIds);
+
+			return;
+		}
+
+		setStep('confirm');
+		setTranslatedLanguageIds(translatedLanguageIds);
+	};
+
+	useEffect(() => {
+		if (appliedRef.current || !results?.length) {
+			return;
+		}
+
+		appliedRef.current = true;
+
+		for (const result of results) {
+			const fields: Record<string, string> = {};
+
+			for (const [name, value] of Object.entries(result.fields ?? {})) {
+				fields[name] = Liferay.Util.unescapeHTML(value);
+			}
+
+			if (!Object.keys(fields).length) {
+				continue;
+			}
+
+			Liferay.fire('localizationSelect:autoTranslate', {
+				fields,
+				languageId: result.targetLanguageId,
+			});
+		}
+	}, [results]);
+
+	return {
+		onTranslate,
+		selectedLanguageIds,
+		setSelectedLanguageIds,
+		setStep,
+		setValue,
+		step,
+		submit,
+		submitted,
+		toggleSelectedLanguageId,
+		translatedLanguageIds,
+		value,
+	};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const AUTO_TRANSLATABLE_TYPES = [
+	{isHtml: false, type: 'text'},
+	{isHtml: false, type: 'long-text'},
+	{isHtml: true, type: 'html'},
+];

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getPageContext(sourceLanguageId: string) {
+	const fields: Record<string, string> = {};
+	const html: Record<string, boolean> = {};
+
+	for (const {isHtml, type} of AUTO_TRANSLATABLE_TYPES) {
+		const inputs = document.querySelectorAll<HTMLInputElement>(
+			`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${sourceLanguageId}"]`
+		);
+
+		for (const input of inputs) {
+			const name = input.name.replace(/_[a-z]{2}_[A-Z]{2}$/, '');
+
+			fields[name] = input.value;
+			html[name] = isHtml;
+		}
+	}
+
+	return {fields, html};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getTranslatedLanguageIds(languageIds: string[]): string[] {
+	return languageIds.filter((languageId) =>
+		AUTO_TRANSLATABLE_TYPES.some(({type}) =>
+			Array.from(
+				document.querySelectorAll<HTMLInputElement>(
+					`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${languageId}"]`
+				)
+			).some((input) => Boolean(input.value))
+		)
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
@@ -56,7 +56,7 @@ describe('TranslateContentMessageBalloon', () => {
 			Liferay.Util.unescapeHTML = originalUnescapeHTML;
 		});
 
-		it('lists each translated language with a success label', () => {
+		it('shows a confirmation when the content has been translated', () => {
 			renderComponent({
 				results: [
 					{targetLanguageId: 'es_ES'},
@@ -67,9 +67,6 @@ describe('TranslateContentMessageBalloon', () => {
 			expect(
 				screen.getByText('the-content-has-been-translated')
 			).toBeInTheDocument();
-			expect(screen.getByText('es_ES')).toBeInTheDocument();
-			expect(screen.getByText('pt_BR')).toBeInTheDocument();
-			expect(screen.getAllByText('translated')).toHaveLength(2);
 		});
 
 		it('fires the auto translate event for each result with fields', () => {
@@ -104,12 +101,12 @@ describe('TranslateContentMessageBalloon', () => {
 	});
 
 	describe('when selecting languages', () => {
-		it('disables the translate button until a language is selected', () => {
+		it('hides the translate button until a language is selected', () => {
 			renderComponent();
 
 			expect(
-				screen.getByRole('button', {name: 'translate'})
-			).toBeDisabled();
+				screen.queryByRole('button', {name: 'translate'})
+			).not.toBeInTheDocument();
 		});
 
 		it('preselects requested languages that are available', () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import TranslateContentMessageBalloon from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon';
+import {putAgentInstanceResume} from '../../../../src/main/resources/META-INF/resources/js/TranslateContent/api';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/TranslateContent/api'
+);
+
+const mockPutAgentInstanceResume =
+	putAgentInstanceResume as jest.MockedFunction<
+		typeof putAgentInstanceResume
+	>;
+
+function renderComponent(props = {}) {
+	const setIsGenerating = jest.fn();
+
+	const view = render(
+		<TranslateContentMessageBalloon
+			agentInstanceId={12345}
+			availableLanguageIds={['es_ES', 'pt_BR', 'fr_FR']}
+			setIsGenerating={setIsGenerating}
+			sourceLanguageIdRef={{current: 'en_US'}}
+			{...props}
+		/>
+	);
+
+	return {setIsGenerating, ...view};
+}
+
+describe('TranslateContentMessageBalloon', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockPutAgentInstanceResume.mockResolvedValue(undefined);
+	});
+
+	describe('when results are available', () => {
+		let originalUnescapeHTML: typeof Liferay.Util.unescapeHTML;
+
+		beforeEach(() => {
+			originalUnescapeHTML = Liferay.Util.unescapeHTML;
+			Liferay.Util.unescapeHTML = (value: string) => value;
+		});
+
+		afterEach(() => {
+			Liferay.Util.unescapeHTML = originalUnescapeHTML;
+		});
+
+		it('lists each translated language with a success label', () => {
+			renderComponent({
+				results: [
+					{targetLanguageId: 'es_ES'},
+					{targetLanguageId: 'pt_BR'},
+				],
+			});
+
+			expect(
+				screen.getByText('the-content-has-been-translated')
+			).toBeInTheDocument();
+			expect(screen.getByText('es_ES')).toBeInTheDocument();
+			expect(screen.getByText('pt_BR')).toBeInTheDocument();
+			expect(screen.getAllByText('translated')).toHaveLength(2);
+		});
+
+		it('fires the auto translate event for each result with fields', () => {
+			renderComponent({
+				results: [
+					{
+						fields: {title: 'Hola'},
+						targetLanguageId: 'es_ES',
+					},
+				],
+			});
+
+			expect(Liferay.fire).toHaveBeenCalledWith(
+				'localizationSelect:autoTranslate',
+				{
+					fields: {title: 'Hola'},
+					languageId: 'es_ES',
+				}
+			);
+		});
+
+		it('does not fire the auto translate event when a result has no fields', () => {
+			renderComponent({
+				results: [{targetLanguageId: 'es_ES'}],
+			});
+
+			expect(Liferay.fire).not.toHaveBeenCalledWith(
+				'localizationSelect:autoTranslate',
+				expect.anything()
+			);
+		});
+	});
+
+	describe('when selecting languages', () => {
+		it('disables the translate button until a language is selected', () => {
+			renderComponent();
+
+			expect(
+				screen.getByRole('button', {name: 'translate'})
+			).toBeDisabled();
+		});
+
+		it('preselects requested languages that are available', () => {
+			renderComponent({requestedLanguageIds: ['es_ES', 'de_DE']});
+
+			expect(
+				screen.getByRole('button', {name: 'translate'})
+			).toBeEnabled();
+		});
+
+		it('submits the resume request for languages without an existing translation', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalledWith(
+				expect.objectContaining({
+					agentInstanceId: 12345,
+					context: expect.objectContaining({
+						sourceLanguageId: 'en_US',
+						targetLanguageIds: JSON.stringify(['es_ES']),
+					}),
+				})
+			);
+		});
+	});
+
+	describe('when a selected language is already translated', () => {
+		let fixture: HTMLDivElement;
+
+		beforeEach(() => {
+			fixture = document.createElement('div');
+			fixture.innerHTML = `
+				<div data-field-type="text" data-localizable="true">
+					<input name="field_es_ES" type="hidden" value="Hola" />
+				</div>
+			`;
+			document.body.appendChild(fixture);
+		});
+
+		afterEach(() => {
+			fixture.remove();
+		});
+
+		it('asks for confirmation before overwriting', async () => {
+			renderComponent({requestedLanguageIds: ['es_ES']});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+
+			expect(
+				screen.getByText(
+					'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+				)
+			).toBeInTheDocument();
+			expect(mockPutAgentInstanceResume).not.toHaveBeenCalled();
+		});
+
+		it('overwrites every translation when confirming', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+			await userEvent.click(
+				screen.getByRole('button', {name: 'overwrite-all'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalledWith(
+				expect.objectContaining({
+					context: expect.objectContaining({
+						targetLanguageIds: JSON.stringify(['es_ES']),
+					}),
+				})
+			);
+		});
+
+		it('lets the user review and overwrite the selected translations', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+			await userEvent.click(screen.getByRole('button', {name: 'review'}));
+
+			expect(screen.getByRole('checkbox', {name: 'es_ES'})).toBeChecked();
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'overwrite'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalled();
+		});
+	});
+
+	it('stops generating when the resume request fails', async () => {
+		mockPutAgentInstanceResume.mockRejectedValue(new Error('boom'));
+
+		const {setIsGenerating} = renderComponent({
+			requestedLanguageIds: ['es_ES'],
+		});
+
+		await act(async () => {
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+		});
+
+		expect(setIsGenerating).toHaveBeenCalledWith(true);
+		expect(setIsGenerating).toHaveBeenCalledWith(false);
+	});
+});


### PR DESCRIPTION
Supersedes #652.

cc @carolmariaabb 

## What

Introduces the **Translate Content Agent** for AI Hub, letting users translate localized content directly from the AI Assistant chat.

## Changes

- **[FE][ai-hub-cell-js-components-web]** Add content translation to the AI Assistant chat, including the `TranslateContent` agent, its message balloon, and supporting language keys. (LPD-92747)
- **[FE][ai-hub-cell-js-components-web]** Add unit tests covering the new content translation UI. (LPD-98783)

## PR Check

**pr-check: PASS** — tested on `553ef3506c222133e1d4e1895e7d4eb93d277bd1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "553ef3506c222133e1d4e1895e7d4eb93d277bd1"} -->

[7-21-2026, 6-25-34 PM (edited).webm](https://github.com/user-attachments/assets/ad55b34a-2520-4b2e-8b86-4555d7c117d6)
