### PR TITLE
LPD-99254 Inject AI-generated images into CMS file upload fields

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -123,15 +123,13 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	}, [context, getContext, instructionDefinitionScope]);
 
 	useEffect(() => {
-		const fieldElement = triggerRef.current?.closest(
-			'[data-ai-assistant-field-id]'
-		);
+		const fieldId = triggerRef.current
+			?.closest('[data-ai-assistant-field-id]')
+			?.getAttribute('data-ai-assistant-field-id');
 
-		if (fieldElement) {
-			fileUploadSelectorRef.current = `[data-ai-assistant-field-id="${fieldElement.getAttribute(
-				'data-ai-assistant-field-id'
-			)}"]`;
-		}
+		fileUploadSelectorRef.current = fieldId
+			? `[data-ai-assistant-field-id="${fieldId}"]`
+			: '[data-ai-assistant-field-id]';
 	}, []);
 
 	useEffect(() => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -277,6 +277,71 @@ describe('AIAssistantChat', () => {
 		).toHaveLength(2);
 	});
 
+	it('injects the image into a select file field found on the page when no field context is provided', async () => {
+		const originalDataTransfer = (global as {DataTransfer?: unknown})
+			.DataTransfer;
+
+		(global as {DataTransfer?: unknown}).DataTransfer = class {
+			items = {
+				_files: [] as File[],
+				add(file: File) {
+					this._files.push(file);
+				},
+			};
+
+			get files() {
+				return this.items._files;
+			}
+		};
+
+		const field = document.createElement('div');
+
+		field.setAttribute('data-ai-assistant-field-id', '');
+		field.innerHTML = '<input class="file-upload-input" type="file" />';
+
+		document.body.appendChild(field);
+
+		const fileInput = field.querySelector(
+			'.file-upload-input'
+		) as HTMLInputElement;
+
+		let files: File[] = [];
+
+		Object.defineProperty(fileInput, 'files', {
+			configurable: true,
+			get: () => files,
+			set: (value) => {
+				files = value;
+			},
+		});
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		await renderAndOpen();
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({
+					data: 'AAA',
+					mimeType: 'image/png',
+					type: 'image',
+				})
+			);
+		});
+
+		fireEvent.click(screen.getByRole('button', {name: 'save-image'}));
+
+		expect(fileInput.files).toHaveLength(1);
+
+		field.remove();
+
+		(global as {DataTransfer?: unknown}).DataTransfer =
+			originalDataTransfer;
+	});
+
 	it('defaults the mime type to image/png when the image event omits it', async () => {
 		const fakeEventSource = createFakeEventSource();
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -93,20 +93,64 @@ describe('AIAssistantChat', () => {
 		};
 	});
 
-	it('shows the chat input immediately on open', async () => {
+	it('accumulates several image events into a single balloon', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
 		await renderAndOpen();
 
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({
+					data: 'AAA',
+					mimeType: 'image/png',
+					type: 'image',
+				})
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({
+					data: 'BBB',
+					mimeType: 'image/png',
+					type: 'image',
+				})
+			);
+		});
+
+		const images = screen.getAllByAltText('generated-image');
+
+		expect(images).toHaveLength(2);
+		expect(images[0]).toHaveAttribute('src', 'data:image/png;base64,AAA');
+		expect(images[1]).toHaveAttribute('src', 'data:image/png;base64,BBB');
+
 		expect(
-			screen.getByPlaceholderText('Ask me anything...')
-		).toBeInTheDocument();
+			screen.getAllByRole('checkbox', {name: 'generated-image'})
+		).toHaveLength(2);
 	});
 
-	it('shows the footer disclaimer', async () => {
+	it('defaults the mime type to image/png when the image event omits it', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
 		await renderAndOpen();
 
-		expect(
-			screen.getByText('ai-generated-responses-may-be-inaccurate')
-		).toBeInTheDocument();
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({data: 'CCC', type: 'image'})
+			);
+		});
+
+		expect(screen.getByAltText('generated-image')).toHaveAttribute(
+			'src',
+			'data:image/png;base64,CCC'
+		);
 	});
 
 	it('exposes the feedback row on a successful message and wires the codes', async () => {
@@ -168,6 +212,74 @@ describe('AIAssistantChat', () => {
 				name: 'send-negative-feedback-or-report-legal-concern',
 			})
 		).not.toBeInTheDocument();
+	});
+
+	it('injects the image into a select file field found on the page when no field context is provided', async () => {
+		const originalDataTransfer = (global as {DataTransfer?: unknown})
+			.DataTransfer;
+
+		(global as {DataTransfer?: unknown}).DataTransfer = class {
+			items = {
+				_files: [] as File[],
+				add(file: File) {
+					this._files.push(file);
+				},
+			};
+
+			get files() {
+				return this.items._files;
+			}
+		};
+
+		const field = document.createElement('div');
+
+		field.setAttribute('data-ai-assistant-field-id', '');
+		field.innerHTML = '<input class="file-upload-input" type="file" />';
+
+		document.body.appendChild(field);
+
+		try {
+			const fileInput = field.querySelector(
+				'.file-upload-input'
+			) as HTMLInputElement;
+
+			let files: File[] = [];
+
+			Object.defineProperty(fileInput, 'files', {
+				configurable: true,
+				get: () => files,
+				set: (value) => {
+					files = value;
+				},
+			});
+
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+			await renderAndOpen();
+
+			await act(async () => {
+				fakeEventSource.emit(
+					'Chat Message Sent',
+					JSON.stringify({
+						data: 'AAA',
+						mimeType: 'image/png',
+						type: 'image',
+					})
+				);
+			});
+
+			fireEvent.click(screen.getByRole('button', {name: 'save-image'}));
+
+			expect(fileInput.files).toHaveLength(1);
+		}
+		finally {
+			field.remove();
+
+			(global as {DataTransfer?: unknown}).DataTransfer =
+				originalDataTransfer;
+		}
 	});
 
 	it('merges the static context and the getContext snapshot when sending', async () => {
@@ -237,128 +349,19 @@ describe('AIAssistantChat', () => {
 		);
 	});
 
-	it('accumulates several image events into a single balloon', async () => {
-		const fakeEventSource = createFakeEventSource();
-
-		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
-
+	it('shows the chat input immediately on open', async () => {
 		await renderAndOpen();
-
-		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({
-					data: 'AAA',
-					mimeType: 'image/png',
-					type: 'image',
-				})
-			);
-		});
-
-		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({
-					data: 'BBB',
-					mimeType: 'image/png',
-					type: 'image',
-				})
-			);
-		});
-
-		const images = screen.getAllByAltText('generated-image');
-
-		expect(images).toHaveLength(2);
-		expect(images[0]).toHaveAttribute('src', 'data:image/png;base64,AAA');
-		expect(images[1]).toHaveAttribute('src', 'data:image/png;base64,BBB');
 
 		expect(
-			screen.getAllByRole('checkbox', {name: 'generated-image'})
-		).toHaveLength(2);
+			screen.getByPlaceholderText('Ask me anything...')
+		).toBeInTheDocument();
 	});
 
-	it('injects the image into a select file field found on the page when no field context is provided', async () => {
-		const originalDataTransfer = (global as {DataTransfer?: unknown})
-			.DataTransfer;
-
-		(global as {DataTransfer?: unknown}).DataTransfer = class {
-			items = {
-				_files: [] as File[],
-				add(file: File) {
-					this._files.push(file);
-				},
-			};
-
-			get files() {
-				return this.items._files;
-			}
-		};
-
-		const field = document.createElement('div');
-
-		field.setAttribute('data-ai-assistant-field-id', '');
-		field.innerHTML = '<input class="file-upload-input" type="file" />';
-
-		document.body.appendChild(field);
-
-		const fileInput = field.querySelector(
-			'.file-upload-input'
-		) as HTMLInputElement;
-
-		let files: File[] = [];
-
-		Object.defineProperty(fileInput, 'files', {
-			configurable: true,
-			get: () => files,
-			set: (value) => {
-				files = value;
-			},
-		});
-
-		const fakeEventSource = createFakeEventSource();
-
-		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
-
+	it('shows the footer disclaimer', async () => {
 		await renderAndOpen();
 
-		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({
-					data: 'AAA',
-					mimeType: 'image/png',
-					type: 'image',
-				})
-			);
-		});
-
-		fireEvent.click(screen.getByRole('button', {name: 'save-image'}));
-
-		expect(fileInput.files).toHaveLength(1);
-
-		field.remove();
-
-		(global as {DataTransfer?: unknown}).DataTransfer =
-			originalDataTransfer;
-	});
-
-	it('defaults the mime type to image/png when the image event omits it', async () => {
-		const fakeEventSource = createFakeEventSource();
-
-		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
-
-		await renderAndOpen();
-
-		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({data: 'CCC', type: 'image'})
-			);
-		});
-
-		expect(screen.getByAltText('generated-image')).toHaveAttribute(
-			'src',
-			'data:image/png;base64,CCC'
-		);
+		expect(
+			screen.getByText('ai-generated-responses-may-be-inaccurate')
+		).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -231,6 +231,11 @@ export default function AssetsFDSPropsTransformer({
 				}${additionalAPIURLParameters}`
 			: otherProps.apiURL;
 
+	const GENERATE_WITH_AI_ACTIONS = [
+		'generateContentWithAI',
+		'generateImageWithAI',
+	];
+
 	return {
 		...otherProps,
 		additionalAPIURLParameters,
@@ -249,7 +254,7 @@ export default function AssetsFDSPropsTransformer({
 				creationMenu.primaryItems,
 				ACTIONS
 			).map((item) =>
-				item.data?.action === 'generateContentWithAI'
+				GENERATE_WITH_AI_ACTIONS.includes(item.data?.action ?? '')
 					? {...item, className: 'cms-generate-content-with-ai'}
 					: item
 			),

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
@@ -231,4 +231,27 @@ describe('AssetsFDSPropsTransformer', () => {
 
 		expect(result.hideManagementBarInEmptyState).toBe(false);
 	});
+
+	it('marks the generate with AI creation menu items with the purple class', () => {
+		const result = AssetsFDSPropsTransformer({
+			additionalProps: mockAdditionalProps,
+			creationMenu: {
+				primaryItems: [
+					{data: {action: 'generateContentWithAI'}, label: 'content'},
+					{data: {action: 'generateImageWithAI'}, label: 'image'},
+					{data: {action: 'addFolder'}, label: 'folder'},
+				],
+			},
+			hideManagementBarInEmptyState: false,
+			id: 'com.liferay.site.cms.site.initializer-allSection',
+			views: [],
+		});
+
+		const [contentItem, imageItem, folderItem] =
+			result.creationMenu.primaryItems;
+
+		expect(contentItem.className).toBe('cms-generate-content-with-ai');
+		expect(imageItem.className).toBe('cms-generate-content-with-ai');
+		expect(folderItem.className).toBeUndefined();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99254

## What Is Being Fixed

When generating an image with the AI Assistant, the result was always saved to Files even when a file upload field was present to receive it. Separately, the "Generate Single Image With AI" and "Generate Multiple Images With AI" creation-menu items did not get the purple treatment that "Generate Content With AI" has.

## How It Is Being Fixed

The AI Assistant now resolves a file upload field selector when it opens — the specific field when its trigger sits inside one, otherwise the first file upload field on the page — so a generated image is injected into that field and only falls back to saving in Files when no field is present. The creation-menu transformer now also tags the generate-image-with-AI actions with the same purple class used by the generate-content action. A unit test covers the field-injection path, and the AIAssistantChat suite was sorted alphabetically with its injection test's teardown made failure-safe.

## PR Check

**pr-check: PASS** — tested on `d2974f64073be283aa6a751182634df911ea116c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d2974f64073be283aa6a751182634df911ea116c"} -->
