### PR TITLE
LPD-99327 Send the openAIAssistantChat message only once

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -358,6 +358,13 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 
 			runtimeContextRef.current = payload?.context ?? {};
 
+			if (payload?.context) {
+				contextRef.current = {
+					...contextRef.current,
+					...payload.context,
+				};
+			}
+
 			if (payload?.contentTypes?.length) {
 				setMessages((previousMessages) => [
 					...previousMessages,
@@ -409,32 +416,6 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 			Liferay.detach(CATEGORIZE_EVENT, handleCategorize);
 		};
 	}, []);
-
-	useEffect(() => {
-		const handleOpen = (payload: {
-			context?: ChatContext;
-			message?: string;
-		}) => {
-			setActive(true);
-
-			if (payload?.context) {
-				contextRef.current = {
-					...contextRef.current,
-					...payload.context,
-				};
-			}
-
-			if (payload?.message) {
-				sendMessage(payload.message);
-			}
-		};
-
-		Liferay.on('openAIAssistantChat', handleOpen);
-
-		return () => {
-			Liferay.detach('openAIAssistantChat', handleOpen);
-		};
-	}, [sendMessage]);
 
 	const chatSurface = (
 		<>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -212,6 +212,30 @@ describe('AIAssistantChat', () => {
 		);
 	});
 
+	it('sends the message once when the openAIAssistantChat event fires', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		(Liferay.on as jest.Mock).mockClear();
+
+		await renderAndOpen();
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'ref-code');
+		});
+
+		const openChatHandlers = (Liferay.on as jest.Mock).mock.calls
+			.filter(([eventName]) => eventName === 'openAIAssistantChat')
+			.map(([, handler]) => handler);
+
+		await act(async () => {
+			openChatHandlers.forEach((handler) => handler({message: 'Hi'}));
+		});
+
+		expect(mockPostChat).toHaveBeenCalledTimes(1);
+	});
+
 	it('renders a generated image from an image event', async () => {
 		const fakeEventSource = createFakeEventSource();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99327

## What Is Being Fixed

AIAssistantChat registered two `openAIAssistantChat` listeners that both called `sendMessage`, so any event carrying a message (the Generate Image With AI action, and the content gap matrix cell Generate action) appended the user message twice and issued two backend requests.

## How It Is Being Fixed

The two `openAIAssistantChat` `useEffect` handlers are merged into one. It still performs both context writes the component relies on — `runtimeContextRef` (spread last into the send context) and the `contextRef` merge (read by the image balloon for save props) — but calls `sendMessage` only once. A regression test fires the event and asserts a single send.

## PR Check

**pr-check: PASS** — tested on `1b0196cfb8066cb30ba90d23c31dcb9fa009823b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1b0196cfb8066cb30ba90d23c31dcb9fa009823b"} -->
