### PR TITLE
LPD-95940 Add the AI Assistant content categorization flow

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/api.ts
@@ -6,7 +6,7 @@
 import {EventSource} from 'eventsource';
 import {fetch} from 'frontend-js-web';
 
-import {ECategorizationAgent} from './types';
+import {CATEGORIZATION_INTENT_AGENT, ECategorizationAgent} from './types';
 
 const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
 
@@ -88,7 +88,7 @@ export async function postCategorizationAgentInstance({
 	context,
 	sseEventSinkKey,
 }: {
-	agent: ECategorizationAgent;
+	agent: ECategorizationAgent | typeof CATEGORIZATION_INTENT_AGENT;
 	context: Record<string, unknown>;
 	sseEventSinkKey: string;
 }): Promise<void> {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
@@ -18,11 +18,11 @@ html:not(#__):not(#___) .cadmin .categorization-suggestions__loading-text {
 
 .categorization-suggestion-label--new.label,
 html:not(#__):not(#___) .cadmin .categorization-suggestion-label--new.label {
-	background-color: #f3effd;
-	border-color: #e3d9fb;
-	color: #6e3ad6;
+	background-color: $categorization-new-label-background-color;
+	border-color: $categorization-new-label-border-color;
+	color: $categorization-new-label-color;
 
 	.lexicon-icon {
-		color: #6e3ad6;
+		color: $categorization-new-label-color;
 	}
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
@@ -5,7 +5,8 @@
 	}
 }
 
-.categorization-suggestion-chip--new.label {
+.categorization-suggestion-chip--new.label,
+html:not(#__):not(#___) .cadmin .categorization-suggestion-chip--new.label {
 	background-color: #f3effd;
 	border-color: #e3d9fb;
 	color: #6e3ad6;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
@@ -1,8 +1,19 @@
+@import '../variables';
+
 .categorization-suggestions {
 	.categorization-suggestions__labels {
 		display: flex;
 		flex-wrap: wrap;
 	}
+}
+
+.categorization-suggestions__loading-text,
+html:not(#__):not(#___) .cadmin .categorization-suggestions__loading-text {
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	background-clip: text;
+	background-image: $ai-loading-gradient;
+	color: transparent;
 }
 
 .categorization-suggestion-label--new.label,

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/categorization.scss
@@ -1,12 +1,12 @@
 .categorization-suggestions {
-	.categorization-suggestions__chips {
+	.categorization-suggestions__labels {
 		display: flex;
 		flex-wrap: wrap;
 	}
 }
 
-.categorization-suggestion-chip--new.label,
-html:not(#__):not(#___) .cadmin .categorization-suggestion-chip--new.label {
+.categorization-suggestion-label--new.label,
+html:not(#__):not(#___) .cadmin .categorization-suggestion-label--new.label {
 	background-color: #f3effd;
 	border-color: #e3d9fb;
 	color: #6e3ad6;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
@@ -122,6 +122,7 @@ export default function CategorizationSuggestions({
 					disabled={committed}
 					displayType="secondary"
 					onClick={onRegenerate}
+					size="sm"
 				>
 					<ClayIcon
 						className="mr-2"
@@ -138,6 +139,7 @@ export default function CategorizationSuggestions({
 					disabled={committed || !suggestions.length}
 					displayType="primary"
 					onClick={() => onCommit(suggestions)}
+					size="sm"
 				>
 					{kind === 'categories'
 						? Liferay.Language.get('save-categories')

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
@@ -5,7 +5,6 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {sub} from 'frontend-js-web';
 import React from 'react';
 
@@ -72,15 +71,11 @@ export default function CategorizationSuggestions({
 
 	if (status === 'loading') {
 		return (
-			<div className="align-items-center categorization-suggestions d-flex">
-				<ClayLoadingIndicator className="mr-2" />
-
-				<span className="font-weight-semi-bold text-secondary">
-					{kind === 'categories'
-						? Liferay.Language.get('searching-for-categories')
-						: Liferay.Language.get('generating')}
-				</span>
-			</div>
+			<span className="categorization-suggestions categorization-suggestions__loading-text font-weight-semi-bold">
+				{kind === 'categories'
+					? Liferay.Language.get('searching-for-categories')
+					: Liferay.Language.get('generating-tags')}
+			</span>
 		);
 	}
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
@@ -10,7 +10,7 @@ import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {CategorizationStatus, Suggestion} from '../types';
-import SuggestionChip from './SuggestionChip';
+import SuggestionLabel from './SuggestionLabel';
 
 import '../categorization.scss';
 
@@ -110,9 +110,9 @@ export default function CategorizationSuggestions({
 		<div className="categorization-suggestions">
 			<p>{getIntroText(kind, suggestions)}</p>
 
-			<div className="categorization-suggestions__chips mb-3">
+			<div className="categorization-suggestions__labels mb-3">
 				{suggestions.map((suggestion) => (
-					<SuggestionChip
+					<SuggestionLabel
 						disabled={committed}
 						key={`${suggestion.id ?? suggestion.name}`}
 						onDismiss={onDismiss}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/SuggestionLabel.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/SuggestionLabel.tsx
@@ -10,21 +10,21 @@ import React from 'react';
 
 import {Suggestion} from '../types';
 
-interface SuggestionChipProps {
+interface SuggestionLabelProps {
 	disabled?: boolean;
 	onDismiss: (suggestion: Suggestion) => void;
 	suggestion: Suggestion;
 }
 
-export default function SuggestionChip({
+export default function SuggestionLabel({
 	disabled = false,
 	onDismiss,
 	suggestion,
-}: SuggestionChipProps) {
+}: SuggestionLabelProps) {
 	return (
 		<ClayLabel
-			className={classNames('categorization-suggestion-chip mr-2 mt-2', {
-				'categorization-suggestion-chip--new': suggestion.isNew,
+			className={classNames('categorization-suggestion-label mr-2 mt-2', {
+				'categorization-suggestion-label--new': suggestion.isNew,
 			})}
 			closeButtonProps={{
 				'aria-label': Liferay.Language.get('remove'),

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
@@ -9,9 +9,6 @@ export const CATEGORIZE_EVENT = 'cms:aiAssistant:categorize';
 
 export const COMMIT_EVENT = 'cms:aiAssistant:commit';
 
-export const OPEN_CATEGORIZATION_PANEL_EVENT =
-	'cms:aiAssistant:openCategorizationPanel';
-
 export const REQUEST_CATEGORIZE_EVENT = 'cms:aiAssistant:requestCategorize';
 
 export interface CategorizeEventPayload {
@@ -29,7 +26,6 @@ export interface CategorizeEventPayload {
 
 export interface CommitEventPayload {
 	agent: ECategorizationAgent;
-	notifyAssistantPanelOpen?: (categorizationPanelOpen: boolean) => void;
 	scopeId: number;
 	suggestions: Suggestion[];
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ECategorizationAgent, Suggestion} from './types';
+import {ECategorizationAgent, IntentAction, Suggestion} from './types';
 
 export const CATEGORIZE_EVENT = 'cms:aiAssistant:categorize';
 
@@ -23,6 +23,8 @@ export interface CategorizeEventPayload {
 	currentCategoryIds?: number[];
 	currentTagNames?: string[];
 	scopeId: number;
+	suppressUserMessage?: boolean;
+	targets?: string[];
 }
 
 export interface CommitEventPayload {
@@ -32,5 +34,5 @@ export interface CommitEventPayload {
 }
 
 export interface RequestCategorizePayload {
-	agent: ECategorizationAgent;
+	actions: IntentAction[];
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
@@ -29,6 +29,7 @@ export interface CategorizeEventPayload {
 
 export interface CommitEventPayload {
 	agent: ECategorizationAgent;
+	notifyAssistantPanelOpen?: (categorizationPanelOpen: boolean) => void;
 	scopeId: number;
 	suggestions: Suggestion[];
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/events.ts
@@ -9,16 +9,28 @@ export const CATEGORIZE_EVENT = 'cms:aiAssistant:categorize';
 
 export const COMMIT_EVENT = 'cms:aiAssistant:commit';
 
+export const OPEN_CATEGORIZATION_PANEL_EVENT =
+	'cms:aiAssistant:openCategorizationPanel';
+
+export const REQUEST_CATEGORIZE_EVENT = 'cms:aiAssistant:requestCategorize';
+
 export interface CategorizeEventPayload {
 	agent: ECategorizationAgent;
 	classNameId?: number;
 	cmsGroupId: number | string;
 	content: string;
 	count?: number;
+	currentCategoryIds?: number[];
+	currentTagNames?: string[];
 	scopeId: number;
 }
 
 export interface CommitEventPayload {
 	agent: ECategorizationAgent;
+	scopeId: number;
 	suggestions: Suggestion[];
+}
+
+export interface RequestCategorizePayload {
+	agent: ECategorizationAgent;
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/services/classifyCategorizationIntent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/services/classifyCategorizationIntent.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EventSource} from 'eventsource';
+
+import {
+	createCategorizationEventSource,
+	postCategorizationAgentInstance,
+} from '../api';
+import {CATEGORIZATION_INTENT_AGENT, IntentVerdict} from '../types';
+import {PASSTHROUGH, parseIntent} from '../utils/parseIntent';
+
+const TIMEOUT = 10000;
+
+export function classifyCategorizationIntent(
+	message: string
+): Promise<IntentVerdict> {
+	return new Promise<IntentVerdict>((resolve) => {
+		const timeout: {id?: ReturnType<typeof setTimeout>} = {};
+
+		let posted = false;
+		let settled = false;
+		let source: EventSource | null = null;
+
+		const finish = (verdict: IntentVerdict) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+
+			clearTimeout(timeout.id);
+
+			source?.close();
+
+			resolve(verdict);
+		};
+
+		timeout.id = setTimeout(() => finish(PASSTHROUGH), TIMEOUT);
+
+		createCategorizationEventSource()
+			.then((eventSource) => {
+				if (settled) {
+					eventSource?.close();
+
+					return;
+				}
+
+				if (!eventSource) {
+					finish(PASSTHROUGH);
+
+					return;
+				}
+
+				source = eventSource;
+
+				eventSource.addEventListener('Subscribe', (event) => {
+					if (posted) {
+						return;
+					}
+
+					posted = true;
+
+					postCategorizationAgentInstance({
+						agent: CATEGORIZATION_INTENT_AGENT,
+						context: {message},
+						sseEventSinkKey: event.data,
+					}).catch(() => finish(PASSTHROUGH));
+				});
+
+				eventSource.addEventListener(
+					CATEGORIZATION_INTENT_AGENT,
+					(event) => {
+						try {
+							finish(
+								parseIntent(JSON.parse(event.data).data ?? '')
+							);
+						}
+						catch {
+							finish(PASSTHROUGH);
+						}
+					}
+				);
+
+				eventSource.addEventListener('Agent Invocation Failed', () =>
+					finish(PASSTHROUGH)
+				);
+
+				eventSource.addEventListener('error', () =>
+					finish(PASSTHROUGH)
+				);
+			})
+			.catch(() => finish(PASSTHROUGH));
+	});
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/types.ts
@@ -8,6 +8,8 @@ export enum ECategorizationAgent {
 	GENERATE_TAGS = 'L_GENERATE_TAGS',
 }
 
+export const CATEGORIZATION_INTENT_AGENT = 'L_CATEGORIZATION_INTENT';
+
 export type CategorizationStatus =
 	| 'empty'
 	| 'error'
@@ -26,6 +28,17 @@ export interface CategorizationContext {
 	content: string;
 	count?: number;
 	existingTags?: string[];
+}
+
+export interface IntentAction {
+	agent: 'categorize' | 'tag';
+	count: number;
+	targets: string[];
+}
+
+export interface IntentVerdict {
+	actions: IntentAction[];
+	passthrough: boolean;
 }
 
 export interface Suggestion {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
@@ -43,6 +43,66 @@ function toRequestContext(
 	return requestContext;
 }
 
+function resolveTargetSuggestions(
+	agent: ECategorizationAgent,
+	context: CategorizationContext,
+	targets: string[]
+): Suggestion[] {
+	const suggestions: Suggestion[] = [];
+
+	if (agent === ECategorizationAgent.AUTO_CATEGORIZE) {
+		const candidateCategories = context.candidateCategories ?? [];
+		const seen = new Set<number>();
+
+		targets.forEach((target) => {
+			const name = target.trim().toLowerCase();
+
+			const candidateCategory = candidateCategories.find(
+				(candidate) => candidate.name.trim().toLowerCase() === name
+			);
+
+			if (candidateCategory && !seen.has(candidateCategory.id)) {
+				seen.add(candidateCategory.id);
+
+				suggestions.push({
+					id: candidateCategory.id,
+					name: candidateCategory.name,
+				});
+			}
+		});
+
+		return suggestions;
+	}
+
+	const existingTagsByLowerCase = new Map<string, string>();
+
+	(context.existingTags ?? []).forEach((existingTag) =>
+		existingTagsByLowerCase.set(existingTag.toLowerCase(), existingTag)
+	);
+
+	const seen = new Set<string>();
+
+	targets.forEach((target) => {
+		const name = target.trim();
+		const lowerCaseName = name.toLowerCase();
+
+		if (!name || seen.has(lowerCaseName)) {
+			return;
+		}
+
+		seen.add(lowerCaseName);
+
+		const existingTag = existingTagsByLowerCase.get(lowerCaseName);
+
+		suggestions.push({
+			isNew: existingTag === undefined,
+			name: existingTag ?? name,
+		});
+	});
+
+	return suggestions;
+}
+
 export default function useCategorizationAgent(agent: ECategorizationAgent) {
 	const [error, setError] = useState<string>();
 	const [status, setStatus] = useState<CategorizationStatus>('idle');
@@ -51,6 +111,7 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 	const connectingRef = useRef<boolean>(false);
 	const eventSourceRef = useRef<EventSource | null>(null);
 	const lastContextRef = useRef<CategorizationContext | null>(null);
+	const lastTargetsRef = useRef<string[] | null>(null);
 	const mountedRef = useRef<boolean>(true);
 	const pendingRef = useRef<boolean>(false);
 	const sseEventSinkKeyRef = useRef<string | null>(null);
@@ -180,6 +241,7 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 	const run = useCallback(
 		(context: CategorizationContext) => {
 			lastContextRef.current = context;
+			lastTargetsRef.current = null;
 
 			setError(undefined);
 			setSuggestions([]);
@@ -197,11 +259,33 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 		[connect, invoke]
 	);
 
+	const resolveTargets = useCallback(
+		(context: CategorizationContext, targets: string[]) => {
+			lastContextRef.current = context;
+			lastTargetsRef.current = targets;
+
+			setError(undefined);
+
+			const resolved = resolveTargetSuggestions(agent, context, targets);
+
+			setSuggestions(resolved);
+			setStatus(resolved.length ? 'ready' : 'empty');
+		},
+		[agent]
+	);
+
 	const regenerate = useCallback(() => {
-		if (lastContextRef.current) {
+		if (!lastContextRef.current) {
+			return;
+		}
+
+		if (lastTargetsRef.current) {
+			resolveTargets(lastContextRef.current, lastTargetsRef.current);
+		}
+		else {
 			run(lastContextRef.current);
 		}
-	}, [run]);
+	}, [resolveTargets, run]);
 
 	const reset = useCallback(() => {
 		setError(undefined);
@@ -225,5 +309,5 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 		};
 	}, [agent, closeEventSource]);
 
-	return {error, regenerate, reset, run, status, suggestions};
+	return {error, regenerate, reset, resolveTargets, run, status, suggestions};
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/utils/parseIntent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/utils/parseIntent.ts
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IntentAction, IntentVerdict} from '../types';
+import {stripCodeFences} from './parseSuggestions';
+
+const DEFAULT_COUNT = 3;
+const MAX_COUNT = 10;
+const MAX_TARGETS = 10;
+
+export const PASSTHROUGH: IntentVerdict = {actions: [], passthrough: true};
+
+interface RawAction {
+	agent?: unknown;
+	count?: unknown;
+	targets?: unknown;
+}
+
+function clampCount(count: unknown): number {
+	if (typeof count !== 'number' || !Number.isFinite(count)) {
+		return DEFAULT_COUNT;
+	}
+
+	const rounded = Math.round(count);
+
+	if (rounded < 1) {
+		return 1;
+	}
+
+	if (rounded > MAX_COUNT) {
+		return MAX_COUNT;
+	}
+
+	return rounded;
+}
+
+function parseTargets(targets: unknown): string[] {
+	if (!Array.isArray(targets)) {
+		return [];
+	}
+
+	const parsed: string[] = [];
+
+	targets.forEach((target) => {
+		if (parsed.length >= MAX_TARGETS || typeof target !== 'string') {
+			return;
+		}
+
+		const trimmed = target.trim();
+
+		if (trimmed) {
+			parsed.push(trimmed);
+		}
+	});
+
+	return parsed;
+}
+
+export function parseIntent(data: string): IntentVerdict {
+	let parsed: {actions?: unknown; passthrough?: unknown};
+
+	try {
+		parsed = JSON.parse(stripCodeFences(data));
+	}
+	catch {
+		return PASSTHROUGH;
+	}
+
+	if (!parsed || typeof parsed !== 'object' || parsed.passthrough === true) {
+		return PASSTHROUGH;
+	}
+
+	if (!Array.isArray(parsed.actions)) {
+		return PASSTHROUGH;
+	}
+
+	const actionsByAgent = new Map<'categorize' | 'tag', IntentAction>();
+
+	(parsed.actions as RawAction[]).forEach((rawAction) => {
+		const agent = rawAction?.agent;
+
+		if (
+			(agent === 'categorize' || agent === 'tag') &&
+			!actionsByAgent.has(agent)
+		) {
+			actionsByAgent.set(agent, {
+				agent,
+				count: clampCount(rawAction.count),
+				targets: parseTargets(rawAction.targets),
+			});
+		}
+	});
+
+	const actions: IntentAction[] = [];
+
+	(['categorize', 'tag'] as const).forEach((agent) => {
+		const action = actionsByAgent.get(agent);
+
+		if (action) {
+			actions.push(action);
+		}
+	});
+
+	if (!actions.length) {
+		return PASSTHROUGH;
+	}
+
+	return {actions, passthrough: false};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/utils/parseSuggestions.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/utils/parseSuggestions.ts
@@ -19,7 +19,7 @@ interface RawSuggestion {
 	name?: string;
 }
 
-function stripCodeFences(text: string): string {
+export function stripCodeFences(text: string): string {
 	const trimmed = text.trim();
 
 	const match = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
@@ -74,7 +74,7 @@ describe('CategorizationSuggestions', () => {
 		).toBeInTheDocument();
 	});
 
-	it('renders chips and commits the suggestions', () => {
+	it('renders labels and commits the suggestions', () => {
 		const onCommit = jest.fn();
 		const suggestions = [
 			{id: 1, name: 'International'},
@@ -117,7 +117,7 @@ describe('CategorizationSuggestions', () => {
 		expect(onRegenerate).toHaveBeenCalled();
 	});
 
-	it('fires dismiss when a chip close button is clicked', () => {
+	it('fires dismiss when a label close button is clicked', () => {
 		const onDismiss = jest.fn();
 		const suggestion = {isNew: false, name: 'Japan'};
 
@@ -147,7 +147,7 @@ describe('CategorizationSuggestions', () => {
 		);
 
 		expect(
-			container.querySelector('.categorization-suggestion-chip--new')
+			container.querySelector('.categorization-suggestion-label--new')
 		).toBeInTheDocument();
 	});
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
@@ -55,7 +55,7 @@ describe('CategorizationSuggestions', () => {
 			/>
 		);
 
-		expect(screen.getByText('generating')).toBeInTheDocument();
+		expect(screen.getByText('generating-tags')).toBeInTheDocument();
 	});
 
 	it('shows the no-match text when empty', () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/services/classifyCategorizationIntent.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/services/classifyCategorizationIntent.test.ts
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	createCategorizationEventSource,
+	postCategorizationAgentInstance,
+} from '../../../../src/main/resources/META-INF/resources/js/Categorization/api';
+import {classifyCategorizationIntent} from '../../../../src/main/resources/META-INF/resources/js/Categorization/services/classifyCategorizationIntent';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/Categorization/api'
+);
+
+const mockCreateEventSource =
+	createCategorizationEventSource as jest.MockedFunction<
+		typeof createCategorizationEventSource
+	>;
+const mockPostAgentInstance =
+	postCategorizationAgentInstance as jest.MockedFunction<
+		typeof postCategorizationAgentInstance
+	>;
+
+function createFakeEventSource() {
+	const listeners: Record<string, (event: {data: string}) => void> = {};
+
+	return {
+		addEventListener: jest.fn(
+			(type: string, handler: (event: {data: string}) => void) => {
+				listeners[type] = handler;
+			}
+		),
+		close: jest.fn(),
+		emit(type: string, data: string) {
+			listeners[type]?.({data});
+		},
+	};
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('classifyCategorizationIntent', () => {
+	beforeEach(() => {
+		mockCreateEventSource.mockReset();
+		mockPostAgentInstance.mockReset();
+		mockPostAgentInstance.mockResolvedValue(undefined);
+	});
+
+	it('posts the message and resolves the parsed verdict', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		const promise = classifyCategorizationIntent('tag this');
+
+		await flush();
+
+		fakeEventSource.emit('Subscribe', 'sink-1');
+
+		fakeEventSource.emit(
+			'L_CATEGORIZATION_INTENT',
+			JSON.stringify({
+				data: JSON.stringify({
+					actions: [{agent: 'tag', count: null, targets: []}],
+					passthrough: false,
+				}),
+			})
+		);
+
+		const verdict = await promise;
+
+		expect(mockPostAgentInstance).toHaveBeenCalledWith({
+			agent: 'L_CATEGORIZATION_INTENT',
+			context: {message: 'tag this'},
+			sseEventSinkKey: 'sink-1',
+		});
+		expect(verdict).toEqual({
+			actions: [{agent: 'tag', count: 3, targets: []}],
+			passthrough: false,
+		});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+
+	it('passes through and closes the event source after the timeout', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		const realSetTimeout = global.setTimeout;
+
+		let timeoutCallback: (() => void) | undefined;
+
+		const setTimeoutSpy = jest
+			.spyOn(global, 'setTimeout')
+			.mockImplementation(((callback: () => void, ms?: number) => {
+				if (ms === 10000) {
+					timeoutCallback = callback;
+
+					return 0 as never;
+				}
+
+				return realSetTimeout(callback, ms);
+			}) as never);
+
+		const promise = classifyCategorizationIntent('what is Liferay?');
+
+		await flush();
+
+		fakeEventSource.emit('Subscribe', 'sink-1');
+
+		timeoutCallback?.();
+
+		const verdict = await promise;
+
+		expect(verdict).toEqual({actions: [], passthrough: true});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+
+		setTimeoutSpy.mockRestore();
+	});
+
+	it('passes through when the classifier emits an invocation failure', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		const promise = classifyCategorizationIntent('tag this');
+
+		await flush();
+
+		fakeEventSource.emit('Subscribe', 'sink-1');
+
+		fakeEventSource.emit('Agent Invocation Failed', '');
+
+		const verdict = await promise;
+
+		expect(verdict).toEqual({actions: [], passthrough: true});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+
+	it('passes through when the event source errors', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		const promise = classifyCategorizationIntent('tag this');
+
+		await flush();
+
+		fakeEventSource.emit('Subscribe', 'sink-1');
+
+		fakeEventSource.emit('error', '');
+
+		const verdict = await promise;
+
+		expect(verdict).toEqual({actions: [], passthrough: true});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+
+	it('passes through when no event source is available', async () => {
+		mockCreateEventSource.mockResolvedValue(null);
+
+		const verdict = await classifyCategorizationIntent('tag this');
+
+		expect(verdict).toEqual({actions: [], passthrough: true});
+		expect(mockPostAgentInstance).not.toHaveBeenCalled();
+	});
+
+	it('passes through and closes the event source when the invocation fails', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockPostAgentInstance.mockRejectedValue(new Error('boom'));
+
+		const promise = classifyCategorizationIntent('tag this');
+
+		await flush();
+
+		fakeEventSource.emit('Subscribe', 'sink-1');
+
+		await flush();
+
+		const verdict = await promise;
+
+		expect(verdict).toEqual({actions: [], passthrough: true});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/services/getCandidateCategories.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/services/getCandidateCategories.test.ts
@@ -31,6 +31,23 @@ describe('getCandidateCategories', () => {
 		} as never;
 	});
 
+	it('caps the candidate set at the requested max', async () => {
+		const items = Array.from({length: 5}, (_, index) => ({
+			id: index + 1,
+			name: `c${index}`,
+		}));
+
+		mockFetch.mockResolvedValue(page(items) as never);
+
+		const result = await getCandidateCategories({
+			cmsGroupId: 20124,
+			max: 2,
+			scopeId: 555,
+		});
+
+		expect(result).toHaveLength(2);
+	});
+
 	it('queries the asset-libraries endpoint and maps id, name, vocabulary', async () => {
 		mockFetch.mockResolvedValue(
 			page([
@@ -72,22 +89,5 @@ describe('getCandidateCategories', () => {
 		expect(calledURL).toContain('/sites/20124/taxonomy-categories');
 		expect(calledURL).toContain("assetLibraries in ('-1')");
 		expect(calledURL).toContain("assetTypes in ('0')");
-	});
-
-	it('caps the candidate set at the requested max', async () => {
-		const items = Array.from({length: 5}, (_, index) => ({
-			id: index + 1,
-			name: `c${index}`,
-		}));
-
-		mockFetch.mockResolvedValue(page(items) as never);
-
-		const result = await getCandidateCategories({
-			cmsGroupId: 20124,
-			max: 2,
-			scopeId: 555,
-		});
-
-		expect(result).toHaveLength(2);
 	});
 });

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/utils/parseIntent.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/utils/parseIntent.test.ts
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {parseIntent} from '../../../../src/main/resources/META-INF/resources/js/Categorization/utils/parseIntent';
+
+const PASSTHROUGH = {actions: [], passthrough: true};
+
+describe('parseIntent', () => {
+	it('parses a categorize and tag request with categorize ordered first', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [
+					{agent: 'tag', count: null, targets: []},
+					{agent: 'categorize', count: null, targets: []},
+				],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.passthrough).toBe(false);
+		expect(verdict.actions.map((action) => action.agent)).toEqual([
+			'categorize',
+			'tag',
+		]);
+	});
+
+	it('strips markdown fences before parsing', () => {
+		const verdict = parseIntent(
+			'```json\n{"actions":[{"agent":"tag","count":2,"targets":["kayaking"]}],"passthrough":false}\n```'
+		);
+
+		expect(verdict.actions).toEqual([
+			{agent: 'tag', count: 2, targets: ['kayaking']},
+		]);
+	});
+
+	it('clamps a zero count to one and defaults a missing count to three', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [
+					{agent: 'categorize', count: 0, targets: []},
+					{agent: 'tag', targets: []},
+				],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.actions[0].count).toBe(1);
+		expect(verdict.actions[1].count).toBe(3);
+	});
+
+	it('caps the count at ten', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [{agent: 'tag', count: 99, targets: []}],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.actions[0].count).toBe(10);
+	});
+
+	it('drops unknown agents', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [
+					{agent: 'delete', targets: []},
+					{agent: 'tag', targets: []},
+				],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.actions.map((action) => action.agent)).toEqual(['tag']);
+	});
+
+	it('trims target names and drops blank ones', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [
+					{
+						agent: 'categorize',
+						targets: ['  Travel  ', '', 'Fishing'],
+					},
+				],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.actions[0].targets).toEqual(['Travel', 'Fishing']);
+	});
+
+	it('keeps only the first action when an agent repeats', () => {
+		const verdict = parseIntent(
+			JSON.stringify({
+				actions: [
+					{agent: 'tag', targets: ['a']},
+					{agent: 'tag', targets: ['b']},
+				],
+				passthrough: false,
+			})
+		);
+
+		expect(verdict.actions).toHaveLength(1);
+		expect(verdict.actions[0].targets).toEqual(['a']);
+	});
+
+	it('passes through when the model requests it', () => {
+		expect(
+			parseIntent(
+				JSON.stringify({
+					actions: [{agent: 'tag', targets: []}],
+					passthrough: true,
+				})
+			)
+		).toEqual(PASSTHROUGH);
+	});
+
+	it('passes through when no valid action remains', () => {
+		expect(
+			parseIntent(
+				JSON.stringify({
+					actions: [{agent: 'delete'}],
+					passthrough: false,
+				})
+			)
+		).toEqual(PASSTHROUGH);
+	});
+
+	it('passes through on malformed input', () => {
+		expect(parseIntent('not json')).toEqual(PASSTHROUGH);
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CategorizationSuggestionService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CategorizationSuggestionService.ts
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import CategoryService from '../../../common/services/CategoryService';
-import TagService from '../../../common/services/TagService';
-import {ITaxonomyCategoryBrief} from '../../../common/types/AssetType';
-import {CategorizationCommitSuggestion} from '../components/categorizationAgentEvents';
+import {ITaxonomyCategoryBrief} from '../types/AssetType';
+import CategoryService from './CategoryService';
+import TagService from './TagService';
+
+export interface CategorizationCommitSuggestion {
+	id?: number;
+	isNew?: boolean;
+	name: string;
+}
 
 async function createTagNames(
 	suggestions: CategorizationCommitSuggestion[],

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/StructureService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/StructureService.ts
@@ -9,6 +9,7 @@ import buildGroupObjectDefinitions from '../../structure_builder/utils/buildGrou
 import buildObjectDefinition from '../../structure_builder/utils/buildObjectDefinition';
 import buildObjectRelationships from '../../structure_builder/utils/buildObjectRelationships';
 import getRandomId from '../../structure_builder/utils/getRandomId';
+import {ObjectDefinition} from '../types/ObjectDefinition';
 import ApiHelper from './ApiHelper';
 
 export type StructureServiceError = 'in-use' | 'unexpected';
@@ -233,9 +234,16 @@ async function updateStructureWorkflow({
 	};
 }
 
+async function getStructure(externalReferenceCode: string) {
+	return ApiHelper.get<ObjectDefinition>(
+		`/o/object-admin/v1.0/object-definitions/by-external-reference-code/${externalReferenceCode}`
+	);
+}
+
 export default {
 	createStructure,
 	deleteStructure,
+	getStructure,
 	updateStructure,
 	updateStructureWorkflow,
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -12,34 +12,21 @@ import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {datetimeUtils} from '@liferay/object-js-components-web';
 import {LiferayEditorConfig} from 'frontend-editor-ckeditor-web';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, objectToFormData, sub} from 'frontend-js-web';
+import {fetch, objectToFormData} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import CategorizationSuggestionService from '../../common/services/CategorizationSuggestionService';
 import VocabularyService from '../../common/services/VocabularyService';
 import {IAssetObjectEntry} from '../../common/types/AssetType';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
-import {
-	AUTO_CATEGORIZE_AGENT,
-	CATEGORIZE_EVENT,
-	COMMIT_EVENT,
-	CategorizationAction,
-	CategorizationCommitPayload,
-	CategorizeEventPayload,
-	GENERATE_TAGS_AGENT,
-	OPEN_CATEGORIZATION_PANEL_EVENT,
-	REQUEST_CATEGORIZE_EVENT,
-	RequestCategorizePayload,
-} from '../../main_view/info_panel/components/categorizationAgentEvents';
 import ObjectEntryService from '../../main_view/info_panel/services/ObjectEntryService';
 import {Comment} from '../services/CommentService';
-import getEditedContent from '../utils/getEditedContent';
 import {EVENT_VALIDATE_FORM} from './ContentEditorToolbar';
 import {dateConfig, toMomentDate, toServerISOFormat} from './ScheduleField';
 import CategorizationPanel from './panels/CategorizationPanel';
 import CommentsPanel from './panels/CommentsPanel';
 import GeneralPanel from './panels/GeneralPanel';
 import SchedulePanel from './panels/SchedulePanel';
+import useAssistantCategorization from './useAssistantCategorization';
 
 type Props = {
 	addCommentURL: string;
@@ -331,192 +318,26 @@ function SidePanel(props: SidePanelProps) {
 	const [hasError, setHasError] = useState<boolean>(false);
 	const [panel, setPanel] = useState<React.Key | null>(null);
 
-	const categorizationFieldsRef = useRef(props.categorizationFields);
-	const panelRef = useRef(panel);
-
-	useEffect(() => {
-		categorizationFieldsRef.current = props.categorizationFields;
-	}, [props.categorizationFields]);
-
-	useEffect(() => {
-		panelRef.current = panel;
-	}, [panel]);
+	const openCategorizationPanel = useCallback(() => {
+		setPanel('categorization');
+	}, []);
 
 	const showErrorInPanel = useCallback((panelId: React.Key) => {
 		setPanel(panelId);
 		setHasError(true);
 	}, []);
 
-	const {assetLibraryId, cmsGroupId, contentAPIURL, onUpdateCategorization} =
-		props;
+	const {onUpdateCategorization} = props;
 
-	useEffect(() => {
-		const fireCategorize = async (actions: CategorizationAction[]) => {
-			const {data, error} =
-				await ObjectEntryService.getObjectEntry(contentAPIURL);
-
-			if (!data) {
-				if (error) {
-					console.error(error);
-				}
-
-				return;
-			}
-
-			const editedContent = await getEditedContent(
-				data.systemProperties?.objectDefinitionBrief
-					?.externalReferenceCode
-			);
-
-			actions.forEach((action) => {
-				const agent =
-					action.agent === 'categorize'
-						? AUTO_CATEGORIZE_AGENT
-						: GENERATE_TAGS_AGENT;
-
-				const payload: CategorizeEventPayload = {
-					agent,
-					cmsGroupId,
-					content: editedContent || data.contentRawText || '',
-					count: action.count,
-					scopeId:
-						agent === AUTO_CATEGORIZE_AGENT
-							? data.scopeId
-							: data.scopeId || assetLibraryId || cmsGroupId,
-					suppressUserMessage: true,
-					targets: action.targets,
-				};
-
-				if (agent === AUTO_CATEGORIZE_AGENT) {
-					payload.classNameId =
-						data.systemProperties?.objectDefinitionBrief
-							?.classNameId ?? -1;
-					payload.currentCategoryIds = (
-						data.taxonomyCategoryBriefs || []
-					).map((brief) => brief.taxonomyCategoryId);
-				}
-				else {
-					payload.currentTagNames = data.keywords || [];
-				}
-
-				Liferay.fire(CATEGORIZE_EVENT, payload);
-			});
-		};
-
-		const handleRequestCategorize = (payload: RequestCategorizePayload) => {
-			fireCategorize(payload.actions);
-		};
-
-		const handleCommit = async ({
-			agent,
-			notifyAssistantPanelOpen,
-			scopeId,
-			suggestions,
-		}: CategorizationCommitPayload) => {
-			const fields = categorizationFieldsRef.current;
-
-			if (panelRef.current === 'categorization' || !fields) {
-				return;
-			}
-
-			notifyAssistantPanelOpen?.(false);
-
-			if (agent === AUTO_CATEGORIZE_AGENT) {
-				const currentBriefs = fields.assetCategoryIds.value;
-
-				const briefs =
-					await CategorizationSuggestionService.resolveNewCategoryBriefs(
-						suggestions,
-						currentBriefs.map(
-							({taxonomyCategoryId}) => taxonomyCategoryId
-						)
-					);
-
-				if (!briefs.length) {
-					return;
-				}
-
-				const value = [...currentBriefs, ...briefs];
-
-				onUpdateCategorization([
-					'assetCategoryIds',
-					{
-						serverValue: value
-							.map(({taxonomyCategoryId}) => taxonomyCategoryId)
-							.join(','),
-						value,
-					},
-				]);
-
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'x-categories-have-been-successfully-added-to-the-selected-content'
-						),
-						`${briefs.length}`
-					),
-					type: 'success',
-				});
-			}
-			else if (agent === GENERATE_TAGS_AGENT) {
-				const names =
-					await CategorizationSuggestionService.createTagNames(
-						suggestions,
-						{
-							assetLibraryId:
-								scopeId || assetLibraryId || cmsGroupId,
-							cmsGroupId,
-						}
-					);
-
-				const currentNames = fields.assetTagNames.value;
-
-				const newNames = [
-					...new Set(
-						names.filter((name) => !currentNames.includes(name))
-					),
-				];
-
-				if (!newNames.length) {
-					return;
-				}
-
-				const keywords = [...currentNames, ...newNames];
-
-				onUpdateCategorization([
-					'assetTagNames',
-					{serverValue: keywords.join(','), value: keywords},
-				]);
-
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'x-tags-have-been-successfully-added-to-the-selected-content'
-						),
-						`${newNames.length}`
-					),
-					type: 'success',
-				});
-			}
-		};
-
-		const openCategorizationPanel = () => {
-			setPanel('categorization');
-		};
-
-		Liferay.on(COMMIT_EVENT, handleCommit);
-		Liferay.on(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
-		Liferay.on(OPEN_CATEGORIZATION_PANEL_EVENT, openCategorizationPanel);
-
-		return () => {
-			Liferay.detach(COMMIT_EVENT, handleCommit);
-			Liferay.detach(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
-			Liferay.detach(
-				OPEN_CATEGORIZATION_PANEL_EVENT,
-				openCategorizationPanel
-			);
-		};
-	}, [assetLibraryId, cmsGroupId, contentAPIURL, onUpdateCategorization]);
+	useAssistantCategorization({
+		assetLibraryId: props.assetLibraryId,
+		categorizationFields: props.categorizationFields,
+		cmsGroupId: props.cmsGroupId,
+		contentAPIURL: props.contentAPIURL,
+		onOpenCategorizationPanel: openCategorizationPanel,
+		onUpdateCategorization,
+		panel,
+	});
 
 	useEffect(() => {
 		const validateScheduleFields = ({event}: {event: MouseEvent}) => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -318,10 +318,6 @@ function SidePanel(props: SidePanelProps) {
 	const [hasError, setHasError] = useState<boolean>(false);
 	const [panel, setPanel] = useState<React.Key | null>(null);
 
-	const openCategorizationPanel = useCallback(() => {
-		setPanel('categorization');
-	}, []);
-
 	const showErrorInPanel = useCallback((panelId: React.Key) => {
 		setPanel(panelId);
 		setHasError(true);
@@ -334,7 +330,6 @@ function SidePanel(props: SidePanelProps) {
 		categorizationFields: props.categorizationFields,
 		cmsGroupId: props.cmsGroupId,
 		contentAPIURL: props.contentAPIURL,
-		onOpenCategorizationPanel: openCategorizationPanel,
 		onUpdateCategorization,
 		panel,
 	});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -22,6 +22,7 @@ import {
 	AUTO_CATEGORIZE_AGENT,
 	CATEGORIZE_EVENT,
 	COMMIT_EVENT,
+	CategorizationAction,
 	CategorizationCommitPayload,
 	CategorizeEventPayload,
 	GENERATE_TAGS_AGENT,
@@ -349,7 +350,7 @@ function SidePanel(props: SidePanelProps) {
 		props;
 
 	useEffect(() => {
-		const fireCategorize = async (agent: string) => {
+		const fireCategorize = async (actions: CategorizationAction[]) => {
 			const {data, error} =
 				await ObjectEntryService.getObjectEntry(contentAPIURL);
 
@@ -361,33 +362,43 @@ function SidePanel(props: SidePanelProps) {
 				return;
 			}
 
-			const payload: CategorizeEventPayload = {
-				agent,
-				cmsGroupId,
-				content: data.contentRawText ?? '',
-				scopeId:
-					agent === AUTO_CATEGORIZE_AGENT
-						? data.scopeId
-						: data.scopeId || assetLibraryId || cmsGroupId,
-			};
+			actions.forEach((action) => {
+				const agent =
+					action.agent === 'categorize'
+						? AUTO_CATEGORIZE_AGENT
+						: GENERATE_TAGS_AGENT;
 
-			if (agent === AUTO_CATEGORIZE_AGENT) {
-				payload.classNameId =
-					data.systemProperties?.objectDefinitionBrief?.classNameId ??
-					-1;
-				payload.currentCategoryIds = (
-					data.taxonomyCategoryBriefs || []
-				).map((brief) => brief.taxonomyCategoryId);
-			}
-			else {
-				payload.currentTagNames = data.keywords || [];
-			}
+				const payload: CategorizeEventPayload = {
+					agent,
+					cmsGroupId,
+					content: data.contentRawText ?? '',
+					count: action.count,
+					scopeId:
+						agent === AUTO_CATEGORIZE_AGENT
+							? data.scopeId
+							: data.scopeId || assetLibraryId || cmsGroupId,
+					suppressUserMessage: true,
+					targets: action.targets,
+				};
 
-			Liferay.fire(CATEGORIZE_EVENT, payload);
+				if (agent === AUTO_CATEGORIZE_AGENT) {
+					payload.classNameId =
+						data.systemProperties?.objectDefinitionBrief
+							?.classNameId ?? -1;
+					payload.currentCategoryIds = (
+						data.taxonomyCategoryBriefs || []
+					).map((brief) => brief.taxonomyCategoryId);
+				}
+				else {
+					payload.currentTagNames = data.keywords || [];
+				}
+
+				Liferay.fire(CATEGORIZE_EVENT, payload);
+			});
 		};
 
 		const handleRequestCategorize = (payload: RequestCategorizePayload) => {
-			fireCategorize(payload.agent);
+			fireCategorize(payload.actions);
 		};
 
 		const handleCommit = async ({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -403,6 +403,7 @@ function SidePanel(props: SidePanelProps) {
 
 		const handleCommit = async ({
 			agent,
+			notifyAssistantPanelOpen,
 			scopeId,
 			suggestions,
 		}: CategorizationCommitPayload) => {
@@ -411,6 +412,8 @@ function SidePanel(props: SidePanelProps) {
 			if (panelRef.current === 'categorization' || !fields) {
 				return;
 			}
+
+			notifyAssistantPanelOpen?.(false);
 
 			if (agent === AUTO_CATEGORIZE_AGENT) {
 				const currentBriefs = fields.assetCategoryIds.value;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -450,13 +450,15 @@ function SidePanel(props: SidePanelProps) {
 				});
 			}
 			else if (agent === GENERATE_TAGS_AGENT) {
-				const names = await CategorizationSuggestionService.createTagNames(
-					suggestions,
-					{
-						assetLibraryId: scopeId || assetLibraryId || cmsGroupId,
-						cmsGroupId,
-					}
-				);
+				const names =
+					await CategorizationSuggestionService.createTagNames(
+						suggestions,
+						{
+							assetLibraryId:
+								scopeId || assetLibraryId || cmsGroupId,
+							cmsGroupId,
+						}
+					);
 
 				const currentNames = fields.assetTagNames.value;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -15,6 +15,7 @@ import {openToast} from 'frontend-js-components-web';
 import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import CategorizationSuggestionService from '../../common/services/CategorizationSuggestionService';
 import VocabularyService from '../../common/services/VocabularyService';
 import {IAssetObjectEntry} from '../../common/types/AssetType';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
@@ -30,7 +31,6 @@ import {
 	REQUEST_CATEGORIZE_EVENT,
 	RequestCategorizePayload,
 } from '../../main_view/info_panel/components/categorizationAgentEvents';
-import CategorizationCommitService from '../../main_view/info_panel/services/CategorizationCommitService';
 import ObjectEntryService from '../../main_view/info_panel/services/ObjectEntryService';
 import {Comment} from '../services/CommentService';
 import {EVENT_VALIDATE_FORM} from './ContentEditorToolbar';
@@ -416,7 +416,7 @@ function SidePanel(props: SidePanelProps) {
 				const currentBriefs = fields.assetCategoryIds.value;
 
 				const briefs =
-					await CategorizationCommitService.resolveNewCategoryBriefs(
+					await CategorizationSuggestionService.resolveNewCategoryBriefs(
 						suggestions,
 						currentBriefs.map(
 							({taxonomyCategoryId}) => taxonomyCategoryId
@@ -450,7 +450,7 @@ function SidePanel(props: SidePanelProps) {
 				});
 			}
 			else if (agent === GENERATE_TAGS_AGENT) {
-				const names = await CategorizationCommitService.createTagNames(
+				const names = await CategorizationSuggestionService.createTagNames(
 					suggestions,
 					{
 						assetLibraryId: scopeId || assetLibraryId || cmsGroupId,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../main_view/info_panel/components/categorizationAgentEvents';
 import ObjectEntryService from '../../main_view/info_panel/services/ObjectEntryService';
 import {Comment} from '../services/CommentService';
+import getEditedContent from '../utils/getEditedContent';
 import {EVENT_VALIDATE_FORM} from './ContentEditorToolbar';
 import {dateConfig, toMomentDate, toServerISOFormat} from './ScheduleField';
 import CategorizationPanel from './panels/CategorizationPanel';
@@ -362,6 +363,11 @@ function SidePanel(props: SidePanelProps) {
 				return;
 			}
 
+			const editedContent = await getEditedContent(
+				data.systemProperties?.objectDefinitionBrief
+					?.externalReferenceCode
+			);
+
 			actions.forEach((action) => {
 				const agent =
 					action.agent === 'categorize'
@@ -371,7 +377,7 @@ function SidePanel(props: SidePanelProps) {
 				const payload: CategorizeEventPayload = {
 					agent,
 					cmsGroupId,
-					content: data.contentRawText ?? '',
+					content: editedContent || data.contentRawText || '',
 					count: action.count,
 					scopeId:
 						agent === AUTO_CATEGORIZE_AGENT

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -12,12 +12,24 @@ import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {datetimeUtils} from '@liferay/object-js-components-web';
 import {LiferayEditorConfig} from 'frontend-editor-ckeditor-web';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import VocabularyService from '../../common/services/VocabularyService';
 import {IAssetObjectEntry} from '../../common/types/AssetType';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
+import {
+	AUTO_CATEGORIZE_AGENT,
+	CATEGORIZE_EVENT,
+	COMMIT_EVENT,
+	CategorizationCommitPayload,
+	CategorizeEventPayload,
+	GENERATE_TAGS_AGENT,
+	OPEN_CATEGORIZATION_PANEL_EVENT,
+	REQUEST_CATEGORIZE_EVENT,
+	RequestCategorizePayload,
+} from '../../main_view/info_panel/components/categorizationAgentEvents';
+import CategorizationCommitService from '../../main_view/info_panel/services/CategorizationCommitService';
 import ObjectEntryService from '../../main_view/info_panel/services/ObjectEntryService';
 import {Comment} from '../services/CommentService';
 import {EVENT_VALIDATE_FORM} from './ContentEditorToolbar';
@@ -317,10 +329,172 @@ function SidePanel(props: SidePanelProps) {
 	const [hasError, setHasError] = useState<boolean>(false);
 	const [panel, setPanel] = useState<React.Key | null>(null);
 
+	const categorizationFieldsRef = useRef(props.categorizationFields);
+	const panelRef = useRef(panel);
+
+	useEffect(() => {
+		categorizationFieldsRef.current = props.categorizationFields;
+	}, [props.categorizationFields]);
+
+	useEffect(() => {
+		panelRef.current = panel;
+	}, [panel]);
+
 	const showErrorInPanel = useCallback((panelId: React.Key) => {
 		setPanel(panelId);
 		setHasError(true);
 	}, []);
+
+	const {assetLibraryId, cmsGroupId, contentAPIURL, onUpdateCategorization} =
+		props;
+
+	useEffect(() => {
+		const fireCategorize = async (agent: string) => {
+			const {data, error} =
+				await ObjectEntryService.getObjectEntry(contentAPIURL);
+
+			if (!data) {
+				if (error) {
+					console.error(error);
+				}
+
+				return;
+			}
+
+			const payload: CategorizeEventPayload = {
+				agent,
+				cmsGroupId,
+				content: data.contentRawText ?? '',
+				scopeId:
+					agent === AUTO_CATEGORIZE_AGENT
+						? data.scopeId
+						: data.scopeId || assetLibraryId || cmsGroupId,
+			};
+
+			if (agent === AUTO_CATEGORIZE_AGENT) {
+				payload.classNameId =
+					data.systemProperties?.objectDefinitionBrief?.classNameId ??
+					-1;
+				payload.currentCategoryIds = (
+					data.taxonomyCategoryBriefs || []
+				).map((brief) => brief.taxonomyCategoryId);
+			}
+			else {
+				payload.currentTagNames = data.keywords || [];
+			}
+
+			Liferay.fire(CATEGORIZE_EVENT, payload);
+		};
+
+		const handleRequestCategorize = (payload: RequestCategorizePayload) => {
+			fireCategorize(payload.agent);
+		};
+
+		const handleCommit = async ({
+			agent,
+			scopeId,
+			suggestions,
+		}: CategorizationCommitPayload) => {
+			const fields = categorizationFieldsRef.current;
+
+			if (panelRef.current === 'categorization' || !fields) {
+				return;
+			}
+
+			if (agent === AUTO_CATEGORIZE_AGENT) {
+				const currentBriefs = fields.assetCategoryIds.value;
+
+				const briefs =
+					await CategorizationCommitService.resolveNewCategoryBriefs(
+						suggestions,
+						currentBriefs.map(
+							({taxonomyCategoryId}) => taxonomyCategoryId
+						)
+					);
+
+				if (!briefs.length) {
+					return;
+				}
+
+				const value = [...currentBriefs, ...briefs];
+
+				onUpdateCategorization([
+					'assetCategoryIds',
+					{
+						serverValue: value
+							.map(({taxonomyCategoryId}) => taxonomyCategoryId)
+							.join(','),
+						value,
+					},
+				]);
+
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'x-categories-have-been-successfully-added-to-the-selected-content'
+						),
+						`${briefs.length}`
+					),
+					type: 'success',
+				});
+			}
+			else if (agent === GENERATE_TAGS_AGENT) {
+				const names = await CategorizationCommitService.createTagNames(
+					suggestions,
+					{
+						assetLibraryId: scopeId || assetLibraryId || cmsGroupId,
+						cmsGroupId,
+					}
+				);
+
+				const currentNames = fields.assetTagNames.value;
+
+				const newNames = [
+					...new Set(
+						names.filter((name) => !currentNames.includes(name))
+					),
+				];
+
+				if (!newNames.length) {
+					return;
+				}
+
+				const keywords = [...currentNames, ...newNames];
+
+				onUpdateCategorization([
+					'assetTagNames',
+					{serverValue: keywords.join(','), value: keywords},
+				]);
+
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'x-tags-have-been-successfully-added-to-the-selected-content'
+						),
+						`${newNames.length}`
+					),
+					type: 'success',
+				});
+			}
+		};
+
+		const openCategorizationPanel = () => {
+			setPanel('categorization');
+		};
+
+		Liferay.on(COMMIT_EVENT, handleCommit);
+		Liferay.on(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
+		Liferay.on(OPEN_CATEGORIZATION_PANEL_EVENT, openCategorizationPanel);
+
+		return () => {
+			Liferay.detach(COMMIT_EVENT, handleCommit);
+			Liferay.detach(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
+			Liferay.detach(
+				OPEN_CATEGORIZATION_PANEL_EVENT,
+				openCategorizationPanel
+			);
+		};
+	}, [assetLibraryId, cmsGroupId, contentAPIURL, onUpdateCategorization]);
 
 	useEffect(() => {
 		const validateScheduleFields = ({event}: {event: MouseEvent}) => {
@@ -341,8 +515,6 @@ function SidePanel(props: SidePanelProps) {
 			Liferay.detach(EVENT_VALIDATE_FORM, validateScheduleFields);
 		};
 	}, [props.scheduleFields, showErrorInPanel]);
-
-	const {onUpdateCategorization} = props;
 
 	useEffect(() => {
 		if (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CategorizationPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CategorizationPanel.tsx
@@ -7,6 +7,7 @@ import React, {useCallback} from 'react';
 
 import {IAssetObjectEntry} from '../../../common/types/AssetType';
 import AssetCategorization from '../../../main_view/info_panel/components/AssetCategorization';
+import getEditedContent from '../../utils/getEditedContent';
 import {
 	CategorizationFields,
 	UpdateCategorizationProps,
@@ -69,6 +70,7 @@ export default function CategorizationPanel({
 						categorizationFields?.assetCategoryIds?.value || [],
 				}}
 				cmsGroupId={cmsGroupId}
+				getContent={getEditedContent}
 				getObjectEntryURL={contentAPIURL}
 				hasUpdatePermission={hasUpdatePermission}
 				inputSize="sm"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/useAssistantCategorization.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/useAssistantCategorization.ts
@@ -16,7 +16,6 @@ import {
 	CategorizationCommitPayload,
 	CategorizeEventPayload,
 	GENERATE_TAGS_AGENT,
-	OPEN_CATEGORIZATION_PANEL_EVENT,
 	REQUEST_CATEGORIZE_EVENT,
 	RequestCategorizePayload,
 } from '../../main_view/info_panel/components/categorizationAgentEvents';
@@ -32,7 +31,6 @@ export default function useAssistantCategorization({
 	categorizationFields,
 	cmsGroupId,
 	contentAPIURL,
-	onOpenCategorizationPanel,
 	onUpdateCategorization,
 	panel,
 }: {
@@ -40,7 +38,6 @@ export default function useAssistantCategorization({
 	categorizationFields: CategorizationFields | null;
 	cmsGroupId: string;
 	contentAPIURL: string;
-	onOpenCategorizationPanel: () => void;
 	onUpdateCategorization: (props: UpdateCategorizationProps) => void;
 	panel: React.Key | null;
 }) {
@@ -116,7 +113,6 @@ export default function useAssistantCategorization({
 
 		const applyCommittedSuggestions = async ({
 			agent,
-			notifyAssistantPanelOpen,
 			scopeId,
 			suggestions,
 		}: CategorizationCommitPayload) => {
@@ -125,8 +121,6 @@ export default function useAssistantCategorization({
 			if (panelRef.current === 'categorization' || !fields) {
 				return;
 			}
-
-			notifyAssistantPanelOpen?.(false);
 
 			if (agent === AUTO_CATEGORIZE_AGENT) {
 				const currentBriefs = fields.assetCategoryIds.value;
@@ -209,21 +203,10 @@ export default function useAssistantCategorization({
 
 		Liferay.on(COMMIT_EVENT, applyCommittedSuggestions);
 		Liferay.on(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
-		Liferay.on(OPEN_CATEGORIZATION_PANEL_EVENT, onOpenCategorizationPanel);
 
 		return () => {
 			Liferay.detach(COMMIT_EVENT, applyCommittedSuggestions);
 			Liferay.detach(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
-			Liferay.detach(
-				OPEN_CATEGORIZATION_PANEL_EVENT,
-				onOpenCategorizationPanel
-			);
 		};
-	}, [
-		assetLibraryId,
-		cmsGroupId,
-		contentAPIURL,
-		onOpenCategorizationPanel,
-		onUpdateCategorization,
-	]);
+	}, [assetLibraryId, cmsGroupId, contentAPIURL, onUpdateCategorization]);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/useAssistantCategorization.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/useAssistantCategorization.ts
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
+import React, {useEffect, useRef} from 'react';
+
+import CategorizationSuggestionService from '../../common/services/CategorizationSuggestionService';
+import {
+	AUTO_CATEGORIZE_AGENT,
+	CATEGORIZE_EVENT,
+	COMMIT_EVENT,
+	CategorizationAction,
+	CategorizationCommitPayload,
+	CategorizeEventPayload,
+	GENERATE_TAGS_AGENT,
+	OPEN_CATEGORIZATION_PANEL_EVENT,
+	REQUEST_CATEGORIZE_EVENT,
+	RequestCategorizePayload,
+} from '../../main_view/info_panel/components/categorizationAgentEvents';
+import ObjectEntryService from '../../main_view/info_panel/services/ObjectEntryService';
+import getEditedContent from '../utils/getEditedContent';
+import {
+	CategorizationFields,
+	UpdateCategorizationProps,
+} from './ContentEditorSidePanel';
+
+export default function useAssistantCategorization({
+	assetLibraryId,
+	categorizationFields,
+	cmsGroupId,
+	contentAPIURL,
+	onOpenCategorizationPanel,
+	onUpdateCategorization,
+	panel,
+}: {
+	assetLibraryId: string;
+	categorizationFields: CategorizationFields | null;
+	cmsGroupId: string;
+	contentAPIURL: string;
+	onOpenCategorizationPanel: () => void;
+	onUpdateCategorization: (props: UpdateCategorizationProps) => void;
+	panel: React.Key | null;
+}) {
+	const categorizationFieldsRef = useRef(categorizationFields);
+	const panelRef = useRef(panel);
+
+	useEffect(() => {
+		categorizationFieldsRef.current = categorizationFields;
+	}, [categorizationFields]);
+
+	useEffect(() => {
+		panelRef.current = panel;
+	}, [panel]);
+
+	useEffect(() => {
+		const dispatchCategorizeEvents = async (
+			actions: CategorizationAction[]
+		) => {
+			const {data, error} =
+				await ObjectEntryService.getObjectEntry(contentAPIURL);
+
+			if (!data) {
+				if (error) {
+					console.error(error);
+				}
+
+				return;
+			}
+
+			const editedContent = await getEditedContent(
+				data.systemProperties?.objectDefinitionBrief
+					?.externalReferenceCode
+			);
+
+			actions.forEach((action) => {
+				const agent =
+					action.agent === 'categorize'
+						? AUTO_CATEGORIZE_AGENT
+						: GENERATE_TAGS_AGENT;
+
+				const payload: CategorizeEventPayload = {
+					agent,
+					cmsGroupId,
+					content: editedContent || data.contentRawText || '',
+					count: action.count,
+					scopeId:
+						agent === AUTO_CATEGORIZE_AGENT
+							? data.scopeId
+							: data.scopeId || assetLibraryId || cmsGroupId,
+					suppressUserMessage: true,
+					targets: action.targets,
+				};
+
+				if (agent === AUTO_CATEGORIZE_AGENT) {
+					payload.classNameId =
+						data.systemProperties?.objectDefinitionBrief
+							?.classNameId ?? -1;
+					payload.currentCategoryIds = (
+						data.taxonomyCategoryBriefs || []
+					).map((brief) => brief.taxonomyCategoryId);
+				}
+				else {
+					payload.currentTagNames = data.keywords || [];
+				}
+
+				Liferay.fire(CATEGORIZE_EVENT, payload);
+			});
+		};
+
+		const handleRequestCategorize = (payload: RequestCategorizePayload) => {
+			dispatchCategorizeEvents(payload.actions);
+		};
+
+		const applyCommittedSuggestions = async ({
+			agent,
+			notifyAssistantPanelOpen,
+			scopeId,
+			suggestions,
+		}: CategorizationCommitPayload) => {
+			const fields = categorizationFieldsRef.current;
+
+			if (panelRef.current === 'categorization' || !fields) {
+				return;
+			}
+
+			notifyAssistantPanelOpen?.(false);
+
+			if (agent === AUTO_CATEGORIZE_AGENT) {
+				const currentBriefs = fields.assetCategoryIds.value;
+
+				const briefs =
+					await CategorizationSuggestionService.resolveNewCategoryBriefs(
+						suggestions,
+						currentBriefs.map(
+							({taxonomyCategoryId}) => taxonomyCategoryId
+						)
+					);
+
+				if (!briefs.length) {
+					return;
+				}
+
+				const value = [...currentBriefs, ...briefs];
+
+				onUpdateCategorization([
+					'assetCategoryIds',
+					{
+						serverValue: value
+							.map(({taxonomyCategoryId}) => taxonomyCategoryId)
+							.join(','),
+						value,
+					},
+				]);
+
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'x-categories-have-been-successfully-added-to-the-selected-content'
+						),
+						`${briefs.length}`
+					),
+					type: 'success',
+				});
+			}
+			else if (agent === GENERATE_TAGS_AGENT) {
+				const names =
+					await CategorizationSuggestionService.createTagNames(
+						suggestions,
+						{
+							assetLibraryId:
+								scopeId || assetLibraryId || cmsGroupId,
+							cmsGroupId,
+						}
+					);
+
+				const currentNames = fields.assetTagNames.value;
+
+				const newNames = [
+					...new Set(
+						names.filter((name) => !currentNames.includes(name))
+					),
+				];
+
+				if (!newNames.length) {
+					return;
+				}
+
+				const keywords = [...currentNames, ...newNames];
+
+				onUpdateCategorization([
+					'assetTagNames',
+					{serverValue: keywords.join(','), value: keywords},
+				]);
+
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'x-tags-have-been-successfully-added-to-the-selected-content'
+						),
+						`${newNames.length}`
+					),
+					type: 'success',
+				});
+			}
+		};
+
+		Liferay.on(COMMIT_EVENT, applyCommittedSuggestions);
+		Liferay.on(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
+		Liferay.on(OPEN_CATEGORIZATION_PANEL_EVENT, onOpenCategorizationPanel);
+
+		return () => {
+			Liferay.detach(COMMIT_EVENT, applyCommittedSuggestions);
+			Liferay.detach(REQUEST_CATEGORIZE_EVENT, handleRequestCategorize);
+			Liferay.detach(
+				OPEN_CATEGORIZATION_PANEL_EVENT,
+				onOpenCategorizationPanel
+			);
+		};
+	}, [
+		assetLibraryId,
+		cmsGroupId,
+		contentAPIURL,
+		onOpenCategorizationPanel,
+		onUpdateCategorization,
+	]);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getEditedContent.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getEditedContent.ts
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import StructureService from '../../common/services/StructureService';
+import {ObjectField} from '../../common/types/ObjectDefinition';
+
+const EDITED_CONTENT_BUSINESS_TYPES = new Set<ObjectField['businessType']>([
+	'LongText',
+	'MultiselectPicklist',
+	'Picklist',
+	'RichText',
+	'String',
+	'Text',
+]);
+
+const MAX_EDITED_CONTENT_LENGTH = 20000;
+
+const objectFieldsPromises = new Map<string, Promise<ObjectField[] | null>>();
+
+function getObjectFields(
+	objectDefinitionExternalReferenceCode: string
+): Promise<ObjectField[] | null> {
+	let promise = objectFieldsPromises.get(
+		objectDefinitionExternalReferenceCode
+	);
+
+	if (!promise) {
+		promise = StructureService.getStructure(
+			objectDefinitionExternalReferenceCode
+		)
+			.then(({data, error}) => {
+				if (error || !data) {
+					objectFieldsPromises.delete(
+						objectDefinitionExternalReferenceCode
+					);
+
+					return null;
+				}
+
+				return data.objectFields ?? null;
+			})
+			.catch(() => {
+				objectFieldsPromises.delete(
+					objectDefinitionExternalReferenceCode
+				);
+
+				return null;
+			});
+
+		objectFieldsPromises.set(
+			objectDefinitionExternalReferenceCode,
+			promise
+		);
+	}
+
+	return promise;
+}
+
+type FieldControl = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+
+function getFieldControls(form: Element, fieldName: string): FieldControl[] {
+	const prefix = `ObjectField_${fieldName}`;
+
+	const controls: FieldControl[] = [];
+
+	form.querySelectorAll<FieldControl>(`[name*="${prefix}"]`).forEach(
+		(control) => {
+			const index = control.name.indexOf(prefix);
+
+			if (index > 0 && control.name[index - 1] !== '-') {
+				return;
+			}
+
+			const suffix = control.name.slice(index + prefix.length);
+
+			if (suffix && !/^(_[a-z]{2}_[A-Z]{2})?(-label)?$/.test(suffix)) {
+				return;
+			}
+
+			controls.push(control);
+		}
+	);
+
+	return controls;
+}
+
+function getFieldLabel(field: ObjectField): string {
+	return (
+		field.label[
+			Liferay.ThemeDisplay.getLanguageId() as Liferay.Language.Locale
+		] ||
+		Object.values(field.label)[0] ||
+		field.name
+	);
+}
+
+function getRichTextValues(form: Element): string[] {
+	return Array.from(
+		form.querySelectorAll<HTMLElement>('.ck-editor__editable')
+	).map((editable) => {
+		const editor = (
+			editable as HTMLElement & {
+				ckeditorInstance?: {getData: () => string};
+			}
+		).ckeditorInstance;
+
+		if (editor) {
+			const element = document.createElement('div');
+
+			element.innerHTML = editor.getData();
+
+			return (element.textContent ?? '').trim();
+		}
+
+		return (editable.innerText ?? editable.textContent ?? '').trim();
+	});
+}
+
+function getFieldValue(
+	form: Element,
+	field: ObjectField,
+	richTextValues: string[]
+): string {
+	if (field.businessType === 'RichText') {
+		return richTextValues.shift() ?? '';
+	}
+
+	const controls = getFieldControls(form, field.name);
+
+	if (field.businessType === 'MultiselectPicklist') {
+		const labels: string[] = [];
+
+		controls.forEach((control) => {
+			if (
+				control instanceof HTMLInputElement &&
+				control.type === 'checkbox'
+			) {
+				if (!control.checked || !control.value) {
+					return;
+				}
+
+				const label = form
+					.querySelector(`label[for="${control.id}"]`)
+					?.textContent?.trim();
+
+				labels.push(label || control.value);
+			}
+			else if (control instanceof HTMLSelectElement) {
+				Array.from(control.selectedOptions).forEach((option) => {
+					labels.push(option.text.trim() || option.value);
+				});
+			}
+		});
+
+		return labels.join(', ');
+	}
+
+	if (field.businessType === 'Picklist') {
+		const labelControl = controls.find((control) =>
+			control.name.endsWith('-label')
+		);
+
+		if (labelControl?.value.trim()) {
+			return labelControl.value.trim();
+		}
+
+		for (const control of controls) {
+			if (control instanceof HTMLSelectElement) {
+				const option = control.selectedOptions[0];
+
+				if (option?.text.trim()) {
+					return option.text.trim();
+				}
+			}
+			else if (control.value.trim()) {
+				return control.value.trim();
+			}
+		}
+
+		return '';
+	}
+
+	for (const control of controls) {
+		const value = control.value.trim();
+
+		if (value) {
+			return value;
+		}
+	}
+
+	return '';
+}
+
+export default async function getEditedContent(
+	objectDefinitionExternalReferenceCode: string | undefined
+): Promise<string> {
+	const form =
+		document.querySelector('.lfr-main-form-container') ||
+		document.querySelector('.lfr-layout-structure-item-form');
+
+	if (!form) {
+		return '';
+	}
+
+	const objectFields = objectDefinitionExternalReferenceCode
+		? await getObjectFields(objectDefinitionExternalReferenceCode)
+		: null;
+
+	const richTextValues = getRichTextValues(form);
+
+	const parts: string[] = [];
+
+	if (objectFields) {
+		objectFields.forEach((field) => {
+			if (!EDITED_CONTENT_BUSINESS_TYPES.has(field.businessType)) {
+				return;
+			}
+
+			const value = getFieldValue(form, field, richTextValues);
+
+			if (value) {
+				parts.push(`${getFieldLabel(field)}: ${value}`);
+			}
+		});
+	}
+	else {
+		const title = getFieldControls(form, 'title')
+			.map((control) => control.value.trim())
+			.find(Boolean);
+
+		if (title) {
+			parts.push(title);
+		}
+	}
+
+	parts.push(...richTextValues.filter(Boolean));
+
+	return parts.join('\n\n').slice(0, MAX_EDITED_CONTENT_LENGTH);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -39,6 +39,7 @@ const AssetCategories = ({
 	cmsGroupId,
 	collapsable = true,
 	errorMessage,
+	getContent,
 	hasUpdatePermission,
 	inputSize,
 	objectEntry,
@@ -51,6 +52,9 @@ const AssetCategories = ({
 	cmsGroupId: number | string;
 	collapsable?: boolean;
 	errorMessage?: string;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	hasUpdatePermission?: boolean;
 	inputSize?: CategorizationInputSize;
 	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
@@ -222,23 +226,31 @@ const AssetCategories = ({
 		[groupedTaxonomies.taxonomyVocabularies, isVisibleVocabulary]
 	);
 
-	const handleGenerateCategories = useCallback(() => {
+	const handleGenerateCategories = useCallback(async () => {
 		const {
 			scopeId,
-			systemProperties: {objectDefinitionBrief: {classNameId = -1} = {}},
+			systemProperties: {
+				objectDefinitionBrief: {
+					classNameId = -1,
+					externalReferenceCode,
+				} = {},
+			},
 		} = objectEntry;
 
 		Liferay.fire(CATEGORIZE_EVENT, {
 			agent: AUTO_CATEGORIZE_AGENT,
 			classNameId,
 			cmsGroupId,
-			content: (objectEntry as IAssetObjectEntry).contentRawText ?? '',
+			content:
+				(await getContent?.(externalReferenceCode)) ||
+				(objectEntry as IAssetObjectEntry).contentRawText ||
+				'',
 			currentCategoryIds: (objectEntry.taxonomyCategoryBriefs ?? []).map(
 				(brief) => brief.taxonomyCategoryId
 			),
 			scopeId,
 		});
-	}, [cmsGroupId, objectEntry]);
+	}, [cmsGroupId, getContent, objectEntry]);
 
 	return (
 		<ClayPanel

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -233,6 +233,9 @@ const AssetCategories = ({
 			classNameId,
 			cmsGroupId,
 			content: (objectEntry as IAssetObjectEntry).contentRawText ?? '',
+			currentCategoryIds: (objectEntry.taxonomyCategoryBriefs ?? []).map(
+				(brief) => brief.taxonomyCategoryId
+			),
 			scopeId,
 		});
 	}, [cmsGroupId, objectEntry]);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -8,12 +8,12 @@ import {openToast} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
 import React, {ComponentProps, useCallback, useEffect, useState} from 'react';
 
+import CategorizationSuggestionService from '../../../common/services/CategorizationSuggestionService';
 import CategoryService from '../../../common/services/CategoryService';
 import {
 	IAssetObjectEntry,
 	ITaxonomyCategoryBrief,
 } from '../../../common/types/AssetType';
-import CategorizationCommitService from '../services/CategorizationCommitService';
 import ObjectEntryService from '../services/ObjectEntryService';
 import AssetCategorizationSections from './AssetCategorizationSections';
 import {
@@ -161,7 +161,7 @@ export default function AssetCategorization({
 			);
 
 			const briefs =
-				await CategorizationCommitService.resolveNewCategoryBriefs(
+				await CategorizationSuggestionService.resolveNewCategoryBriefs(
 					suggestions,
 					currentIds
 				);
@@ -202,7 +202,7 @@ export default function AssetCategorization({
 				assetLibraryId ||
 				cmsGroupId;
 
-			const names = await CategorizationCommitService.createTagNames(
+			const names = await CategorizationSuggestionService.createTagNames(
 				suggestions,
 				{assetLibraryId: scopeId, cmsGroupId}
 			);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -38,6 +38,7 @@ export default function AssetCategorization({
 	categoriesErrorMessage,
 	categorization,
 	cmsGroupId,
+	getContent,
 	getObjectEntryURL,
 	hasUpdatePermission,
 	inputSize,
@@ -47,6 +48,9 @@ export default function AssetCategorization({
 	categoriesErrorMessage?: string;
 	categorization: Categorization;
 	cmsGroupId: number | string;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	getObjectEntryURL: string;
 	hasUpdatePermission: boolean;
 	inputSize?: CategorizationInputSize;
@@ -263,6 +267,7 @@ export default function AssetCategorization({
 			assetLibraryId={assetLibraryId}
 			cmsGroupId={cmsGroupId}
 			errorMessage={categoriesErrorMessage}
+			getContent={getContent}
 			hasUpdatePermission={hasUpdatePermission}
 			inputSize={inputSize}
 			objectEntry={objectEntry}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -238,11 +238,8 @@ export default function AssetCategorization({
 	useEffect(() => {
 		const handleCommit = ({
 			agent,
-			notifyAssistantPanelOpen,
 			suggestions,
 		}: CategorizationCommitPayload) => {
-			notifyAssistantPanelOpen?.(true);
-
 			if (agent === AUTO_CATEGORIZE_AGENT) {
 				addCategorySuggestions(suggestions);
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -234,8 +234,11 @@ export default function AssetCategorization({
 	useEffect(() => {
 		const handleCommit = ({
 			agent,
+			notifyAssistantPanelOpen,
 			suggestions,
 		}: CategorizationCommitPayload) => {
+			notifyAssistantPanelOpen?.(true);
+
 			if (agent === AUTO_CATEGORIZE_AGENT) {
 				addCategorySuggestions(suggestions);
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -9,11 +9,11 @@ import {sub} from 'frontend-js-web';
 import React, {ComponentProps, useCallback, useEffect, useState} from 'react';
 
 import CategoryService from '../../../common/services/CategoryService';
-import TagService from '../../../common/services/TagService';
 import {
 	IAssetObjectEntry,
 	ITaxonomyCategoryBrief,
 } from '../../../common/types/AssetType';
+import CategorizationCommitService from '../services/CategorizationCommitService';
 import ObjectEntryService from '../services/ObjectEntryService';
 import AssetCategorizationSections from './AssetCategorizationSections';
 import {
@@ -160,32 +160,15 @@ export default function AssetCategorization({
 				({taxonomyCategoryId}) => taxonomyCategoryId
 			);
 
-			const newSuggestions = suggestions.filter(
-				(suggestion) =>
-					typeof suggestion.id === 'number' &&
-					!currentIds.includes(suggestion.id)
-			);
+			const briefs =
+				await CategorizationCommitService.resolveNewCategoryBriefs(
+					suggestions,
+					currentIds
+				);
 
-			if (!newSuggestions.length) {
+			if (!briefs.length) {
 				return;
 			}
-
-			const briefs = (
-				await Promise.all(
-					newSuggestions.map(async (suggestion) => {
-						const {data} = await CategoryService.getCategoryById(
-							suggestion.id as number
-						);
-
-						return data
-							? {
-									embeddedTaxonomyCategory: data,
-									taxonomyCategoryId: Number(data.id),
-								}
-							: null;
-					})
-				)
-			).filter(Boolean) as ITaxonomyCategoryBrief[];
 
 			const newObjectEntry = {
 				...objectEntry,
@@ -219,29 +202,10 @@ export default function AssetCategorization({
 				assetLibraryId ||
 				cmsGroupId;
 
-			const names = (
-				await Promise.all(
-					suggestions.map(async (suggestion) => {
-						if (suggestion.isNew) {
-							const {data, status} = await TagService.createTag({
-								assetLibraryId: scopeId,
-								cmsGroupId,
-								name: suggestion.name,
-							});
-
-							if (data?.name) {
-								return data.name;
-							}
-
-							return status === 'CONFLICT'
-								? suggestion.name
-								: null;
-						}
-
-						return suggestion.name;
-					})
-				)
-			).filter((name): name is string => Boolean(name));
+			const names = await CategorizationCommitService.createTagNames(
+				suggestions,
+				{assetLibraryId: scopeId, cmsGroupId}
+			);
 
 			const newObjectEntry = {
 				...objectEntry,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorizationSections.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorizationSections.tsx
@@ -20,6 +20,7 @@ export default function AssetCategorizationSections({
 	assetLibraryId,
 	cmsGroupId,
 	errorMessage,
+	getContent,
 	hasUpdatePermission,
 	inputSize,
 	objectEntry,
@@ -28,6 +29,9 @@ export default function AssetCategorizationSections({
 	assetLibraryId: number | string;
 	cmsGroupId: number | string;
 	errorMessage?: string;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	hasUpdatePermission: boolean;
 	inputSize?: CategorizationInputSize;
 	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
@@ -78,6 +82,7 @@ export default function AssetCategorizationSections({
 			<AssetCategories
 				cmsGroupId={cmsGroupId}
 				errorMessage={errorMessage}
+				getContent={getContent}
 				hasUpdatePermission={hasUpdatePermission}
 				inputSize={inputSize}
 				objectEntry={objectEntry}
@@ -88,6 +93,7 @@ export default function AssetCategorizationSections({
 			<AssetTags
 				assetLibraryId={assetLibraryId}
 				cmsGroupId={cmsGroupId}
+				getContent={getContent}
 				hasUpdatePermission={hasUpdatePermission}
 				inputSize={inputSize}
 				key={objectEntry.keywords?.join(',') || 'tags'}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -29,6 +29,7 @@ const AssetTags = ({
 	assetLibraryId,
 	cmsGroupId,
 	collapsable = true,
+	getContent,
 	hasUpdatePermission,
 	inputSize,
 	objectEntry,
@@ -38,6 +39,9 @@ const AssetTags = ({
 	assetLibraryId?: number | string | null | undefined;
 	cmsGroupId: number | string;
 	collapsable?: boolean;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	hasUpdatePermission?: boolean;
 	inputSize?: CategorizationInputSize;
 	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
@@ -138,14 +142,20 @@ const AssetTags = ({
 		[objectEntry, updateObjectEntry]
 	);
 
-	const handleGenerateTags = useCallback(() => {
+	const handleGenerateTags = useCallback(async () => {
 		Liferay.fire(CATEGORIZE_EVENT, {
 			agent: GENERATE_TAGS_AGENT,
 			cmsGroupId,
-			content: (objectEntry as IAssetObjectEntry).contentRawText ?? '',
+			content:
+				(await getContent?.(
+					(objectEntry as IAssetObjectEntry).systemProperties
+						?.objectDefinitionBrief?.externalReferenceCode
+				)) ||
+				(objectEntry as IAssetObjectEntry).contentRawText ||
+				'',
 			scopeId,
 		});
-	}, [cmsGroupId, objectEntry, scopeId]);
+	}, [cmsGroupId, getContent, objectEntry, scopeId]);
 
 	return (
 		<ClayPanel

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {CategorizationCommitSuggestion} from '../../../common/services/CategorizationSuggestionService';
+
 export const AUTO_CATEGORIZE_AGENT = 'L_AUTO_CATEGORIZE';
 
 export const CATEGORIZE_EVENT = 'cms:aiAssistant:categorize';
@@ -28,11 +30,7 @@ export interface CategorizationCommitPayload {
 	suggestions: CategorizationCommitSuggestion[];
 }
 
-export interface CategorizationCommitSuggestion {
-	id?: number;
-	isNew?: boolean;
-	name: string;
-}
+export type {CategorizationCommitSuggestion};
 
 export interface CategorizeEventPayload {
 	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
@@ -16,6 +16,12 @@ export const OPEN_CATEGORIZATION_PANEL_EVENT =
 
 export const REQUEST_CATEGORIZE_EVENT = 'cms:aiAssistant:requestCategorize';
 
+export interface CategorizationAction {
+	agent: 'categorize' | 'tag';
+	count?: number;
+	targets?: string[];
+}
+
 export interface CategorizationCommitPayload {
 	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;
 	scopeId?: number | string;
@@ -33,11 +39,14 @@ export interface CategorizeEventPayload {
 	classNameId?: number;
 	cmsGroupId: number | string;
 	content: string;
+	count?: number;
 	currentCategoryIds?: number[];
 	currentTagNames?: string[];
 	scopeId: number | string;
+	suppressUserMessage?: boolean;
+	targets?: string[];
 }
 
 export interface RequestCategorizePayload {
-	agent: string;
+	actions: CategorizationAction[];
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
@@ -13,9 +13,6 @@ export const COMMIT_EVENT = 'cms:aiAssistant:commit';
 
 export const GENERATE_TAGS_AGENT = 'L_GENERATE_TAGS';
 
-export const OPEN_CATEGORIZATION_PANEL_EVENT =
-	'cms:aiAssistant:openCategorizationPanel';
-
 export const REQUEST_CATEGORIZE_EVENT = 'cms:aiAssistant:requestCategorize';
 
 export interface CategorizationAction {
@@ -26,7 +23,6 @@ export interface CategorizationAction {
 
 export interface CategorizationCommitPayload {
 	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;
-	notifyAssistantPanelOpen?: (categorizationPanelOpen: boolean) => void;
 	scopeId?: number | string;
 	suggestions: CategorizationCommitSuggestion[];
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
@@ -11,8 +11,14 @@ export const COMMIT_EVENT = 'cms:aiAssistant:commit';
 
 export const GENERATE_TAGS_AGENT = 'L_GENERATE_TAGS';
 
+export const OPEN_CATEGORIZATION_PANEL_EVENT =
+	'cms:aiAssistant:openCategorizationPanel';
+
+export const REQUEST_CATEGORIZE_EVENT = 'cms:aiAssistant:requestCategorize';
+
 export interface CategorizationCommitPayload {
-	agent: string;
+	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;
+	scopeId?: number | string;
 	suggestions: CategorizationCommitSuggestion[];
 }
 
@@ -20,4 +26,18 @@ export interface CategorizationCommitSuggestion {
 	id?: number;
 	isNew?: boolean;
 	name: string;
+}
+
+export interface CategorizeEventPayload {
+	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;
+	classNameId?: number;
+	cmsGroupId: number | string;
+	content: string;
+	currentCategoryIds?: number[];
+	currentTagNames?: string[];
+	scopeId: number | string;
+}
+
+export interface RequestCategorizePayload {
+	agent: string;
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/categorizationAgentEvents.ts
@@ -26,6 +26,7 @@ export interface CategorizationAction {
 
 export interface CategorizationCommitPayload {
 	agent: typeof AUTO_CATEGORIZE_AGENT | typeof GENERATE_TAGS_AGENT;
+	notifyAssistantPanelOpen?: (categorizationPanelOpen: boolean) => void;
 	scopeId?: number | string;
 	suggestions: CategorizationCommitSuggestion[];
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import CategoryService from '../../../common/services/CategoryService';
+import TagService from '../../../common/services/TagService';
+import {ITaxonomyCategoryBrief} from '../../../common/types/AssetType';
+import {CategorizationCommitSuggestion} from '../components/categorizationAgentEvents';
+
+async function createTagNames(
+	suggestions: CategorizationCommitSuggestion[],
+	{
+		assetLibraryId,
+		cmsGroupId,
+	}: {
+		assetLibraryId: number | string | null | undefined;
+		cmsGroupId: number | string;
+	}
+): Promise<string[]> {
+	return (
+		await Promise.all(
+			suggestions.map(async (suggestion) => {
+				if (suggestion.isNew) {
+					const {data, status} = await TagService.createTag({
+						assetLibraryId,
+						cmsGroupId,
+						name: suggestion.name,
+					});
+
+					if (data?.name) {
+						return data.name;
+					}
+
+					return status === 'CONFLICT' ? suggestion.name : null;
+				}
+
+				return suggestion.name;
+			})
+		)
+	).filter((name): name is string => Boolean(name));
+}
+
+async function resolveNewCategoryBriefs(
+	suggestions: CategorizationCommitSuggestion[],
+	currentCategoryIds: number[]
+): Promise<ITaxonomyCategoryBrief[]> {
+	const newSuggestions = suggestions.filter(
+		(suggestion) =>
+			typeof suggestion.id === 'number' &&
+			!currentCategoryIds.includes(suggestion.id)
+	);
+
+	if (!newSuggestions.length) {
+		return [];
+	}
+
+	return (
+		await Promise.all(
+			newSuggestions.map(async (suggestion) => {
+				const {data} = await CategoryService.getCategoryById(
+					suggestion.id as number
+				);
+
+				return data
+					? {
+							embeddedTaxonomyCategory: data,
+							taxonomyCategoryId: Number(data.id),
+						}
+					: null;
+			})
+		)
+	).filter(Boolean) as ITaxonomyCategoryBrief[];
+}
+
+export default {createTagNames, resolveNewCategoryBriefs};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/utils/ContentStructureUtil.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/utils/ContentStructureUtil.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ApiHelper from '../../common/services/ApiHelper';
+import StructureService from '../../common/services/StructureService';
 import {AssetLibrary} from '../../common/types/AssetLibrary';
-import {ObjectDefinition} from '../../common/types/ObjectDefinition';
 
 export async function isContentStructureMoveInvalid(
 	embedded: ItemData['embedded'],
@@ -34,15 +33,15 @@ export async function isContentStructureMoveInvalid(
 	}
 
 	try {
-		const response = await ApiHelper.get(
-			`/o/object-admin/v1.0/object-definitions/by-external-reference-code/${structureExternalReferenceCode}`
+		const response = await StructureService.getStructure(
+			structureExternalReferenceCode
 		);
 
 		if (response.error || !response.data) {
 			return true;
 		}
 
-		const objectDefinition = response.data as ObjectDefinition;
+		const objectDefinition = response.data;
 		const acceptedGroupSettings =
 			objectDefinition.objectDefinitionSettings?.find(
 				(setting) =>

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -305,13 +305,18 @@ describe('ContentEditorSidePanel', () => {
 			renderComponent();
 		});
 
+		const notifyAssistantPanelOpen = jest.fn();
+
 		await act(async () => {
 			handlers['cms:aiAssistant:commit']({
 				agent: 'L_GENERATE_TAGS',
+				notifyAssistantPanelOpen,
 				scopeId: 555,
 				suggestions: [{isNew: true, name: 'Culture'}],
 			});
 		});
+
+		expect(notifyAssistantPanelOpen).toHaveBeenCalledWith(false);
 
 		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -268,25 +268,6 @@ describe('ContentEditorSidePanel', () => {
 		});
 	});
 
-	it('opens the categorization panel when requested directly', async () => {
-		const handlers: Record<string, (payload: any) => void> = {};
-
-		(global as any).Liferay.on = jest.fn(
-			(name: string, callback: (payload: any) => void) => {
-				handlers[name] = callback;
-			}
-		);
-		(global as any).Liferay.fire = jest.fn();
-
-		renderComponent();
-
-		await act(async () => {
-			handlers['cms:aiAssistant:openCategorizationPanel']({});
-		});
-
-		expect(screen.getByText('categorization')).toBeInTheDocument();
-	});
-
 	it('persists a tag commit while the categorization panel is closed', async () => {
 		const handlers: Record<string, (payload: any) => void> = {};
 
@@ -305,18 +286,13 @@ describe('ContentEditorSidePanel', () => {
 			renderComponent();
 		});
 
-		const notifyAssistantPanelOpen = jest.fn();
-
 		await act(async () => {
 			handlers['cms:aiAssistant:commit']({
 				agent: 'L_GENERATE_TAGS',
-				notifyAssistantPanelOpen,
 				scopeId: 555,
 				suggestions: [{isNew: true, name: 'Culture'}],
 			});
 		});
-
-		expect(notifyAssistantPanelOpen).toHaveBeenCalledWith(false);
 
 		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -84,33 +84,6 @@ describe('ContentEditorSidePanel', () => {
 		(global as any).Liferay.on = () => {};
 		(global as any).Liferay.fire = () => {};
 		(global as any).Liferay.detach = () => {};
-	});
-
-	it('renders ContentEditorSidePanel', () => {
-		renderComponent();
-
-		['general', 'comments', 'schedule[noun]', 'categorization'].forEach(
-			(name) => expect(screen.getByTitle(name)).toBeInTheDocument()
-		);
-	});
-
-	it('closes the panel pressing the Close button', async () => {
-		renderComponent();
-
-		const panelButton = screen.getByLabelText('general');
-
-		await userEvent.click(panelButton);
-
-		await waitFor(() => {
-			expect(screen.getByText('general')).toBeInTheDocument();
-		});
-
-		await userEvent.click(screen.getByLabelText('close'));
-
-		await waitFor(() => {
-			expect(screen.queryByText('general')).not.toBeInTheDocument();
-			expect(panelButton).toHaveFocus();
-		});
 	});
 
 	it('calls the subscribe request', async () => {
@@ -193,88 +166,22 @@ describe('ContentEditorSidePanel', () => {
 		});
 	});
 
-	it('renders the hidden inputs with initial values', async () => {
-		renderComponent();
+	it('closes the panel pressing the Close button', async () => {
+		const {container} = renderComponent();
 
-		const expirationInput: HTMLInputElement | null = document.querySelector(
-			'[name="ObjectEntry_expirationDate"]'
-		);
-		const reviewInput: HTMLInputElement | null = document.querySelector(
-			'[name="ObjectEntry_reviewDate"]'
-		);
+		const panelButton = screen.getByLabelText('general');
 
-		expect(expirationInput?.value).toBe(EXPIRATION_DATE);
-		expect(reviewInput?.value).toBe(REVIEW_DATE);
-	});
-
-	it('persists the schedule field value when checking Never Expire and switching tabs', async () => {
-		renderComponent();
-
-		await userEvent.click(screen.getByLabelText('schedule[noun]'));
-
-		await waitFor(() => {
-			expect(screen.getByText('schedule[noun]')).toBeInTheDocument();
-		});
-
-		const expireCheckbox = screen.getAllByLabelText('never-expire')[0];
-
-		expect(expireCheckbox).not.toBeChecked();
-
-		await userEvent.click(expireCheckbox);
-
-		await waitFor(() => {
-			expect(expireCheckbox).toBeChecked();
-		});
-
-		await userEvent.click(screen.getByLabelText('general'));
+		await userEvent.click(panelButton);
 
 		await waitFor(() => {
 			expect(screen.getByText('general')).toBeInTheDocument();
 		});
 
-		await userEvent.click(screen.getByLabelText('schedule[noun]'));
+		await userEvent.click(within(container).getByLabelText('close'));
 
 		await waitFor(() => {
-			expect(screen.getByText('schedule[noun]')).toBeInTheDocument();
-			expect(expireCheckbox).toBeChecked();
-			expect(
-				screen.getByRole('textbox', {name: 'expiration-date'})
-			).toHaveValue('08/14/2025 12:01 AM');
-		});
-	});
-
-	it('fires the categorize event without opening the categorization panel when requested', async () => {
-		const handlers: Record<string, (payload: any) => void> = {};
-
-		(global as any).Liferay.on = jest.fn(
-			(name: string, callback: (payload: any) => void) => {
-				handlers[name] = callback;
-			}
-		);
-		(global as any).Liferay.fire = jest.fn();
-
-		renderComponent();
-
-		await act(async () => {
-			handlers['cms:aiAssistant:requestCategorize']({
-				actions: [{agent: 'categorize'}],
-			});
-		});
-
-		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
-
-		await waitFor(() => {
-			expect(global.Liferay.fire as jest.Mock).toHaveBeenCalledWith(
-				'cms:aiAssistant:categorize',
-				expect.objectContaining({
-					agent: 'L_AUTO_CATEGORIZE',
-					classNameId: 30982,
-					cmsGroupId: '21000',
-					content: 'Japan',
-					scopeId: 555,
-					suppressUserMessage: true,
-				})
-			);
+			expect(screen.queryByText('general')).not.toBeInTheDocument();
+			expect(panelButton).toHaveFocus();
 		});
 	});
 
@@ -326,6 +233,60 @@ describe('ContentEditorSidePanel', () => {
 		);
 	});
 
+	it('fires the categorize event without opening the categorization panel when requested', async () => {
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn();
+
+		renderComponent();
+
+		await act(async () => {
+			handlers['cms:aiAssistant:requestCategorize']({
+				actions: [{agent: 'categorize'}],
+			});
+		});
+
+		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(global.Liferay.fire as jest.Mock).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({
+					agent: 'L_AUTO_CATEGORIZE',
+					classNameId: 30982,
+					cmsGroupId: '21000',
+					content: 'Japan',
+					scopeId: 555,
+					suppressUserMessage: true,
+				})
+			);
+		});
+	});
+
+	it('opens the categorization panel when requested directly', async () => {
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn();
+
+		renderComponent();
+
+		await act(async () => {
+			handlers['cms:aiAssistant:openCategorizationPanel']({});
+		});
+
+		expect(screen.getByText('categorization')).toBeInTheDocument();
+	});
+
 	it('persists a tag commit while the categorization panel is closed', async () => {
 		const handlers: Record<string, (payload: any) => void> = {};
 
@@ -369,22 +330,61 @@ describe('ContentEditorSidePanel', () => {
 		});
 	});
 
-	it('opens the categorization panel when requested directly', async () => {
-		const handlers: Record<string, (payload: any) => void> = {};
-
-		(global as any).Liferay.on = jest.fn(
-			(name: string, callback: (payload: any) => void) => {
-				handlers[name] = callback;
-			}
-		);
-		(global as any).Liferay.fire = jest.fn();
-
+	it('persists the schedule field value when checking Never Expire and switching tabs', async () => {
 		renderComponent();
 
-		await act(async () => {
-			handlers['cms:aiAssistant:openCategorizationPanel']({});
+		await userEvent.click(screen.getByLabelText('schedule[noun]'));
+
+		await waitFor(() => {
+			expect(screen.getByText('schedule[noun]')).toBeInTheDocument();
 		});
 
-		expect(screen.getByText('categorization')).toBeInTheDocument();
+		const expireCheckbox = screen.getAllByLabelText('never-expire')[0];
+
+		expect(expireCheckbox).not.toBeChecked();
+
+		await userEvent.click(expireCheckbox);
+
+		await waitFor(() => {
+			expect(expireCheckbox).toBeChecked();
+		});
+
+		await userEvent.click(screen.getByLabelText('general'));
+
+		await waitFor(() => {
+			expect(screen.getByText('general')).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByLabelText('schedule[noun]'));
+
+		await waitFor(() => {
+			expect(screen.getByText('schedule[noun]')).toBeInTheDocument();
+			expect(expireCheckbox).toBeChecked();
+			expect(
+				screen.getByRole('textbox', {name: 'expiration-date'})
+			).toHaveValue('08/14/2025 12:01 AM');
+		});
+	});
+
+	it('renders ContentEditorSidePanel', () => {
+		renderComponent();
+
+		['general', 'comments', 'schedule[noun]', 'categorization'].forEach(
+			(name) => expect(screen.getByTitle(name)).toBeInTheDocument()
+		);
+	});
+
+	it('renders the hidden inputs with initial values', async () => {
+		renderComponent();
+
+		const expirationInput: HTMLInputElement | null = document.querySelector(
+			'[name="ObjectEntry_expirationDate"]'
+		);
+		const reviewInput: HTMLInputElement | null = document.querySelector(
+			'[name="ObjectEntry_reviewDate"]'
+		);
+
+		expect(expirationInput?.value).toBe(EXPIRATION_DATE);
+		expect(reviewInput?.value).toBe(REVIEW_DATE);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -4,11 +4,13 @@
  */
 
 import '@testing-library/jest-dom';
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import ContentEditorSidePanel from '../../../../src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel';
+import CategorizationCommitService from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService';
+import ObjectEntryService from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/ObjectEntryService';
 import {mockFetch} from '../../__mocks__/frontend-js-web';
 
 const EXPIRATION_DATE = '2025-08-14T00:01';
@@ -22,6 +24,12 @@ jest.mock('frontend-js-web', () => ({
 		getWeekdaysShort: jest.fn().mockReturnValue([]),
 	},
 }));
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/ObjectEntryService'
+);
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService'
+);
 
 const renderComponent = ({isSubscribed = false} = {}) => {
 	return render(
@@ -54,6 +62,28 @@ describe('ContentEditorSidePanel', () => {
 		global.Liferay.ThemeDisplay.getTimeZone = jest
 			.fn()
 			.mockReturnValue('utc');
+		global.Liferay.ThemeDisplay.getSiteGroupId = jest
+			.fn()
+			.mockReturnValue('21000');
+
+		(ObjectEntryService.getObjectEntry as jest.Mock).mockResolvedValue({
+			data: {
+				contentRawText: 'Japan',
+				keywords: [],
+				scopeId: 555,
+				systemProperties: {
+					objectDefinitionBrief: {classNameId: 30982},
+				},
+				taxonomyCategoryBriefs: [],
+			},
+			error: null,
+		});
+	});
+
+	afterEach(() => {
+		(global as any).Liferay.on = () => {};
+		(global as any).Liferay.fire = () => {};
+		(global as any).Liferay.detach = () => {};
 	});
 
 	it('renders ContentEditorSidePanel', () => {
@@ -211,5 +241,101 @@ describe('ContentEditorSidePanel', () => {
 				screen.getByRole('textbox', {name: 'expiration-date'})
 			).toHaveValue('08/14/2025 12:01 AM');
 		});
+	});
+
+	it('fires the categorize event without opening the categorization panel when requested', async () => {
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn();
+
+		renderComponent();
+
+		await act(async () => {
+			handlers['cms:aiAssistant:requestCategorize']({
+				agent: 'L_AUTO_CATEGORIZE',
+			});
+		});
+
+		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(global.Liferay.fire as jest.Mock).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({
+					agent: 'L_AUTO_CATEGORIZE',
+					classNameId: 30982,
+					cmsGroupId: '21000',
+					content: 'Japan',
+					scopeId: 555,
+				})
+			);
+		});
+	});
+
+	it('persists a tag commit while the categorization panel is closed', async () => {
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn();
+
+		(
+			CategorizationCommitService.createTagNames as jest.Mock
+		).mockResolvedValue(['Culture']);
+
+		await act(async () => {
+			renderComponent();
+		});
+
+		await act(async () => {
+			handlers['cms:aiAssistant:commit']({
+				agent: 'L_GENERATE_TAGS',
+				scopeId: 555,
+				suggestions: [{isNew: true, name: 'Culture'}],
+			});
+		});
+
+		expect(screen.queryByText('categorization')).not.toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(
+				CategorizationCommitService.createTagNames
+			).toHaveBeenCalledWith([{isNew: true, name: 'Culture'}], {
+				assetLibraryId: 555,
+				cmsGroupId: '21000',
+			});
+
+			const tagNamesInput: HTMLInputElement | null =
+				document.querySelector('[name="assetTagNames"]');
+
+			expect(tagNamesInput?.value).toBe('Culture');
+		});
+	});
+
+	it('opens the categorization panel when requested directly', async () => {
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn();
+
+		renderComponent();
+
+		await act(async () => {
+			handlers['cms:aiAssistant:openCategorizationPanel']({});
+		});
+
+		expect(screen.getByText('categorization')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -8,8 +8,8 @@ import {act, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import CategorizationSuggestionService from '../../../../src/main/resources/META-INF/resources/js/common/services/CategorizationSuggestionService';
 import ContentEditorSidePanel from '../../../../src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel';
-import CategorizationCommitService from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService';
 import ObjectEntryService from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/ObjectEntryService';
 import {mockFetch} from '../../__mocks__/frontend-js-web';
 
@@ -28,7 +28,7 @@ jest.mock(
 	'../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/ObjectEntryService'
 );
 jest.mock(
-	'../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/CategorizationCommitService'
+	'../../../../src/main/resources/META-INF/resources/js/common/services/CategorizationSuggestionService'
 );
 
 const renderComponent = ({isSubscribed = false} = {}) => {
@@ -298,7 +298,7 @@ describe('ContentEditorSidePanel', () => {
 		(global as any).Liferay.fire = jest.fn();
 
 		(
-			CategorizationCommitService.createTagNames as jest.Mock
+			CategorizationSuggestionService.createTagNames as jest.Mock
 		).mockResolvedValue(['Culture']);
 
 		await act(async () => {
@@ -317,7 +317,7 @@ describe('ContentEditorSidePanel', () => {
 
 		await waitFor(() => {
 			expect(
-				CategorizationCommitService.createTagNames
+				CategorizationSuggestionService.createTagNames
 			).toHaveBeenCalledWith([{isNew: true, name: 'Culture'}], {
 				assetLibraryId: 555,
 				cmsGroupId: '21000',

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -257,7 +257,7 @@ describe('ContentEditorSidePanel', () => {
 
 		await act(async () => {
 			handlers['cms:aiAssistant:requestCategorize']({
-				agent: 'L_AUTO_CATEGORIZE',
+				actions: [{agent: 'categorize'}],
 			});
 		});
 
@@ -272,9 +272,58 @@ describe('ContentEditorSidePanel', () => {
 					cmsGroupId: '21000',
 					content: 'Japan',
 					scopeId: 555,
+					suppressUserMessage: true,
 				})
 			);
 		});
+	});
+
+	it('fetches the entry once and dispatches a categorize event per action in order', async () => {
+		const fireCalls: Array<{name: string; payload: any}> = [];
+		const handlers: Record<string, (payload: any) => void> = {};
+
+		(global as any).Liferay.on = jest.fn(
+			(name: string, callback: (payload: any) => void) => {
+				handlers[name] = callback;
+			}
+		);
+		(global as any).Liferay.fire = jest.fn((name: string, payload: any) => {
+			fireCalls.push({name, payload});
+		});
+
+		renderComponent();
+
+		(ObjectEntryService.getObjectEntry as jest.Mock).mockClear();
+
+		await act(async () => {
+			handlers['cms:aiAssistant:requestCategorize']({
+				actions: [
+					{agent: 'categorize', count: 5, targets: ['Travel']},
+					{agent: 'tag', targets: ['kayaking']},
+				],
+			});
+		});
+
+		await waitFor(() => {
+			expect(fireCalls).toHaveLength(2);
+		});
+
+		expect(ObjectEntryService.getObjectEntry).toHaveBeenCalledTimes(1);
+		expect(fireCalls[0].payload).toEqual(
+			expect.objectContaining({
+				agent: 'L_AUTO_CATEGORIZE',
+				count: 5,
+				suppressUserMessage: true,
+				targets: ['Travel'],
+			})
+		);
+		expect(fireCalls[1].payload).toEqual(
+			expect.objectContaining({
+				agent: 'L_GENERATE_TAGS',
+				suppressUserMessage: true,
+				targets: ['kayaking'],
+			})
+		);
 	});
 
 	it('persists a tag commit while the categorization panel is closed', async () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -85,7 +85,7 @@ function renderComponent({
 	cmsGroupId?: number;
 	collapsable?: boolean;
 	placeholder?: string;
-	scopeId?: number;
+	scopeId?: number | null;
 	systemVocabularyIds?: number[];
 	taxonomyCategoryBriefs?: ReturnType<typeof buildCategoryBrief>[];
 	title?: string;
@@ -98,7 +98,7 @@ function renderComponent({
 			hasUpdatePermission={true}
 			objectEntry={
 				{
-					scopeId,
+					...(scopeId !== null ? {scopeId} : {}),
 					systemProperties: {
 						objectDefinitionBrief: {classNameId},
 					},
@@ -181,21 +181,7 @@ describe('AssetCategories', () => {
 	});
 
 	it('does not render the category selector before the asset scope is known', () => {
-		render(
-			<AssetCategories
-				cmsGroupId={456}
-				hasUpdatePermission={true}
-				objectEntry={
-					{
-						systemProperties: {
-							objectDefinitionBrief: {classNameId: 1},
-						},
-						taxonomyCategoryBriefs: [],
-					} as any
-				}
-				updateObjectEntry={jest.fn()}
-			/>
-		);
+		renderComponent({scopeId: null});
 
 		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -4,7 +4,13 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen, within} from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import React from 'react';
 
 import AssetCategories from '../../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories';
@@ -74,6 +80,9 @@ function renderComponent({
 	classNameId = 1,
 	cmsGroupId = 456,
 	collapsable,
+	contentRawText,
+	externalReferenceCode,
+	getContent,
 	placeholder,
 	scopeId = 123,
 	systemVocabularyIds,
@@ -84,6 +93,11 @@ function renderComponent({
 	classNameId?: number;
 	cmsGroupId?: number;
 	collapsable?: boolean;
+	contentRawText?: string;
+	externalReferenceCode?: string;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	placeholder?: string;
 	scopeId?: number | null;
 	systemVocabularyIds?: number[];
@@ -95,12 +109,17 @@ function renderComponent({
 		<AssetCategories
 			cmsGroupId={cmsGroupId}
 			collapsable={collapsable}
+			getContent={getContent}
 			hasUpdatePermission={true}
 			objectEntry={
 				{
 					...(scopeId !== null ? {scopeId} : {}),
+					contentRawText,
 					systemProperties: {
-						objectDefinitionBrief: {classNameId},
+						objectDefinitionBrief: {
+							classNameId,
+							externalReferenceCode,
+						},
 					},
 					taxonomyCategoryBriefs,
 				} as any
@@ -186,6 +205,27 @@ describe('AssetCategories', () => {
 		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
 	});
 
+	it('falls back to the persisted content when getContent returns nothing', async () => {
+		const fire = jest.fn();
+		const getContent = jest.fn().mockResolvedValue('');
+
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+		(global as any).Liferay.fire = fire;
+
+		renderComponent({contentRawText: 'persisted content', getContent});
+
+		fireEvent.click(
+			screen.getByRole('button', {name: 'add-categories-with-ai'})
+		);
+
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({content: 'persisted content'})
+			)
+		);
+	});
+
 	it('filters system vocabulary categories out of the generic dropdown', () => {
 		renderComponent({scopeId: 123, systemVocabularyIds: [10]});
 
@@ -196,7 +236,7 @@ describe('AssetCategories', () => {
 		).toBe('10');
 	});
 
-	it('fires the categorize event when the sparkle is clicked', () => {
+	it('fires the categorize event when the sparkle is clicked', async () => {
 		const fire = jest.fn();
 
 		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
@@ -208,14 +248,16 @@ describe('AssetCategories', () => {
 			screen.getByRole('button', {name: 'add-categories-with-ai'})
 		);
 
-		expect(fire).toHaveBeenCalledWith(
-			'cms:aiAssistant:categorize',
-			expect.objectContaining({
-				agent: 'L_AUTO_CATEGORIZE',
-				classNameId: 1,
-				cmsGroupId: 456,
-				scopeId: 123,
-			})
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({
+					agent: 'L_AUTO_CATEGORIZE',
+					classNameId: 1,
+					cmsGroupId: 456,
+					scopeId: 123,
+				})
+			)
 		);
 	});
 
@@ -243,6 +285,33 @@ describe('AssetCategories', () => {
 
 		expect(screen.getByText('vocabulary-b')).toBeInTheDocument();
 		expect(screen.getByText('category-3')).toBeInTheDocument();
+	});
+
+	it('prefers the edited content from getContent over the persisted content', async () => {
+		const fire = jest.fn();
+		const getContent = jest.fn().mockResolvedValue('edited content');
+
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+		(global as any).Liferay.fire = fire;
+
+		renderComponent({
+			contentRawText: 'persisted content',
+			externalReferenceCode: 'C_ARTICLE',
+			getContent,
+		});
+
+		fireEvent.click(
+			screen.getByRole('button', {name: 'add-categories-with-ai'})
+		);
+
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({content: 'edited content'})
+			)
+		);
+
+		expect(getContent).toHaveBeenCalledWith('C_ARTICLE');
 	});
 
 	it('renders categories grouped under their vocabulary names', () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -180,6 +180,26 @@ describe('AssetCategories', () => {
 		).toBe('');
 	});
 
+	it('does not render the category selector before the asset scope is known', () => {
+		render(
+			<AssetCategories
+				cmsGroupId={456}
+				hasUpdatePermission={true}
+				objectEntry={
+					{
+						systemProperties: {
+							objectDefinitionBrief: {classNameId: 1},
+						},
+						taxonomyCategoryBriefs: [],
+					} as any
+				}
+				updateObjectEntry={jest.fn()}
+			/>
+		);
+
+		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
+	});
+
 	it('filters system vocabulary categories out of the generic dropdown', () => {
 		renderComponent({scopeId: 123, systemVocabularyIds: [10]});
 
@@ -188,6 +208,29 @@ describe('AssetCategories', () => {
 				.getByTestId('item-selector')
 				.getAttribute('data-filtered-vocabulary-ids')
 		).toBe('10');
+	});
+
+	it('fires the categorize event when the sparkle is clicked', () => {
+		const fire = jest.fn();
+
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+		(global as any).Liferay.fire = fire;
+
+		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: 123});
+
+		fireEvent.click(
+			screen.getByRole('button', {name: 'add-categories-with-ai'})
+		);
+
+		expect(fire).toHaveBeenCalledWith(
+			'cms:aiAssistant:categorize',
+			expect.objectContaining({
+				agent: 'L_AUTO_CATEGORIZE',
+				classNameId: 1,
+				cmsGroupId: 456,
+				scopeId: 123,
+			})
+		);
 	});
 
 	it('hides categories from system vocabularies', () => {
@@ -214,26 +257,6 @@ describe('AssetCategories', () => {
 
 		expect(screen.getByText('vocabulary-b')).toBeInTheDocument();
 		expect(screen.getByText('category-3')).toBeInTheDocument();
-	});
-
-	it('does not render the category selector before the asset scope is known', () => {
-		render(
-			<AssetCategories
-				cmsGroupId={456}
-				hasUpdatePermission={true}
-				objectEntry={
-					{
-						systemProperties: {
-							objectDefinitionBrief: {classNameId: 1},
-						},
-						taxonomyCategoryBriefs: [],
-					} as any
-				}
-				updateObjectEntry={jest.fn()}
-			/>
-		);
-
-		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
 	});
 
 	it('renders categories grouped under their vocabulary names', () => {
@@ -326,28 +349,5 @@ describe('AssetCategories', () => {
 		).not.toBeInTheDocument();
 
 		expect(screen.getByText('categories')).toBeInTheDocument();
-	});
-
-	it('fires the categorize event when the sparkle is clicked', () => {
-		const fire = jest.fn();
-
-		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
-		(global as any).Liferay.fire = fire;
-
-		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: 123});
-
-		fireEvent.click(
-			screen.getByRole('button', {name: 'add-categories-with-ai'})
-		);
-
-		expect(fire).toHaveBeenCalledWith(
-			'cms:aiAssistant:categorize',
-			expect.objectContaining({
-				agent: 'L_AUTO_CATEGORIZE',
-				classNameId: 1,
-				cmsGroupId: 456,
-				scopeId: 123,
-			})
-		);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
@@ -60,11 +60,17 @@ jest.mock('@liferay/frontend-js-item-selector-web', () => {
 function renderComponent({
 	cmsGroupId = 456,
 	collapsable,
+	contentRawText,
+	getContent,
 	keywords = ['tag1'],
 	scopeId = 123,
 }: {
 	cmsGroupId?: number;
 	collapsable?: boolean;
+	contentRawText?: string;
+	getContent?: (
+		objectDefinitionExternalReferenceCode?: string
+	) => Promise<string>;
 	keywords?: string[];
 	scopeId?: number;
 } = {}) {
@@ -73,9 +79,11 @@ function renderComponent({
 			assetLibraryId={123}
 			cmsGroupId={cmsGroupId}
 			collapsable={collapsable}
+			getContent={getContent}
 			hasUpdatePermission={true}
 			objectEntry={
 				{
+					contentRawText,
 					keywords,
 					scopeId,
 				} as any
@@ -219,7 +227,7 @@ describe('AssetTags', () => {
 		expect(apiURL).toContain("groupIds in ('-1')");
 	});
 
-	it('fires the categorize event when the sparkle is clicked', () => {
+	it('fires the categorize event when the sparkle is clicked', async () => {
 		const fire = jest.fn();
 
 		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
@@ -231,13 +239,57 @@ describe('AssetTags', () => {
 			screen.getByRole('button', {name: 'generate-tags-with-ai'})
 		);
 
-		expect(fire).toHaveBeenCalledWith(
-			'cms:aiAssistant:categorize',
-			expect.objectContaining({
-				agent: 'L_GENERATE_TAGS',
-				cmsGroupId: 456,
-				scopeId: 123,
-			})
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({
+					agent: 'L_GENERATE_TAGS',
+					cmsGroupId: 456,
+					scopeId: 123,
+				})
+			)
+		);
+	});
+
+	it('prefers the edited content from getContent over the persisted content', async () => {
+		const fire = jest.fn();
+		const getContent = jest.fn().mockResolvedValue('edited content');
+
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+		(global as any).Liferay.fire = fire;
+
+		renderComponent({contentRawText: 'persisted content', getContent});
+
+		fireEvent.click(
+			screen.getByRole('button', {name: 'generate-tags-with-ai'})
+		);
+
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({content: 'edited content'})
+			)
+		);
+	});
+
+	it('falls back to the persisted content when getContent returns nothing', async () => {
+		const fire = jest.fn();
+		const getContent = jest.fn().mockResolvedValue('');
+
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+		(global as any).Liferay.fire = fire;
+
+		renderComponent({contentRawText: 'persisted content', getContent});
+
+		fireEvent.click(
+			screen.getByRole('button', {name: 'generate-tags-with-ai'})
+		);
+
+		await waitFor(() =>
+			expect(fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:categorize',
+				expect.objectContaining({content: 'persisted content'})
+			)
 		);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95940

## What Is Being Fixed

The AI Assistant chat could not turn a free-form prompt into content categorization suggestions (tags and categories), and the categorization plumbing and suggestion UI were not available as reusable pieces the chat could drive.

## How It Is Being Fixed

Adds shared categorization chat plumbing and routes free-form assistant prompts to the categorization agents. The categorization flow is extracted into a hook, the suggestion service moves into the common layer, the structure fetch is reused through `ContentStructureUtil`, and suggestions are generated from the edited content of any structure. On the UI side, `SuggestionChip` becomes `SuggestionLabel`, the suggestion label colors move into SCSS variables, the suggestion buttons shrink to the small variant, and the chat loading messages gain an agent-specific gradient state.

This PR carries only the categorization-exclusive files. The shared AI-chat restructure and other cross-cutting files live in the "AI Assistant Improvements" consolidation, and the language keys live in the dedicated language PR, so this PR and its siblings merge in any order without conflicts.

## PR Check

**pr-check: PASS** — tested on `037623b503bf2d86be6b4575469a67d1d6733bf4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

JavaScript unit tests: `ai-hub-cell-js-components-web` 118/118 pass; `site-cms-site-initializer` 810/811 pass. The single failure is `CategorizationSpaces › allows typing in the MultiSelect input…`, a pre-existing flaky test on master (its file is not touched by this branch and it passes in isolation) — not a regression from this change.

<!-- pr-check {"result": "success", "sha": "037623b503bf2d86be6b4575469a67d1d6733bf4"} -->
