### PR TITLE
LPD-92741 Add content translation to the AI Assistant chat

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
+
+export async function putAgentInstanceResume({
+	agentInstanceId,
+	context,
+}: {
+	agentInstanceId: number;
+	context: Record<string, unknown>;
+}) {
+	const authorizationToken = await postAuthorizationToken();
+
+	if (!authorizationToken) {
+		return;
+	}
+
+	return await fetch(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/agent-instances/${agentInstanceId}/resume`,
+		{
+			body: JSON.stringify({context}),
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
+				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
+			}),
+			method: 'PUT',
+		}
+	);
+}
+
+async function postAuthorizationToken() {
+	try {
+		const response = await fetch(
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			{
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Unable to generate authorization token: ${response.statusText}`
+			);
+		}
+
+		const data = await response.json();
+
+		if (!data?.accessToken) {
+			throw new Error('Unable to generate authorization token.');
+		}
+
+		if (!data?.userToken) {
+			throw new Error('Unable to generate user token.');
+		}
+
+		if (!data?.serviceURL) {
+			throw new Error('Unable to find service URL.');
+		}
+
+		return data;
+	}
+	catch (error) {
+		console.warn((error as Error).message);
+	}
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function LanguageIdIcon({languageId}: {languageId: string}) {
+	return (
+		<ClayIcon
+			className="mr-2"
+			spritemap={Liferay.Icons.spritemap}
+			symbol={languageId.replace(/_/g, '-').toLowerCase()}
+		/>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+export default function MessageBalloon({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+			{children}
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function MessageHeader({message}: {message: string}) {
+	return (
+		<div className="d-flex flex-row font-weight-semi-bold">
+			<div className="align-items-start d-inline-block ml-2 mt-2 text-2 text-primary">
+				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+			</div>
+
+			<div className="m-2">{message}</div>
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {MutableRefObject} from 'react';
+
+export interface Result {
+	fields?: Record<string, string>;
+	targetLanguageId: string;
+}
+
+export interface TranslateContentMessageBalloonProps {
+	agentInstanceId: number;
+	availableLanguageIds?: string[];
+	requestedLanguageIds?: string[];
+	results?: Result[];
+	setIsGenerating: (isGenerating: boolean) => void;
+	sourceLanguageIdRef: MutableRefObject<string>;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
@@ -1,0 +1,118 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useEffect, useRef, useState} from 'react';
+
+import {putAgentInstanceResume} from './api';
+import {TranslateContentMessageBalloonProps} from './types';
+import {getPageContext} from './utils/getPageContext';
+import {getTranslatedLanguageIds} from './utils/getTranslatedLanguageIds';
+
+export default function useTranslateContentAgent({
+	agentInstanceId,
+	availableLanguageIds,
+	requestedLanguageIds,
+	results,
+	setIsGenerating,
+	sourceLanguageIdRef,
+}: TranslateContentMessageBalloonProps) {
+	const appliedRef = useRef<boolean>(false);
+
+	const [selectedLanguageIds, setSelectedLanguageIds] = useState<string[]>(
+		() =>
+			(requestedLanguageIds ?? []).filter((languageId) =>
+				(availableLanguageIds ?? []).includes(languageId)
+			)
+	);
+	const [step, setStep] = useState<'confirm' | 'review' | 'select'>('select');
+	const [submitted, setSubmitted] = useState<boolean>(false);
+	const [translatedLanguageIds, setTranslatedLanguageIds] = useState<
+		string[]
+	>([]);
+	const [value, setValue] = useState<string>('');
+
+	const submit = (targetLanguageIds: string[]) => {
+		setIsGenerating(true);
+		setSubmitted(true);
+
+		const sourceLanguageId = sourceLanguageIdRef.current;
+
+		const {fields, html} = getPageContext(sourceLanguageId);
+
+		putAgentInstanceResume({
+			agentInstanceId,
+			context: {
+				fields: JSON.stringify(fields),
+				html: JSON.stringify(html),
+				sourceLanguageId,
+				targetLanguageIds: JSON.stringify(targetLanguageIds),
+			},
+		}).catch(() => setIsGenerating(false));
+	};
+
+	const toggleSelectedLanguageId = (languageId: string) => {
+		setSelectedLanguageIds((previousSelectedLanguageIds) =>
+			previousSelectedLanguageIds.includes(languageId)
+				? previousSelectedLanguageIds.filter(
+						(selectedLanguageId) =>
+							selectedLanguageId !== languageId
+					)
+				: [...previousSelectedLanguageIds, languageId]
+		);
+	};
+
+	const onTranslate = () => {
+		const translatedLanguageIds =
+			getTranslatedLanguageIds(selectedLanguageIds);
+
+		if (!translatedLanguageIds.length) {
+			submit(selectedLanguageIds);
+
+			return;
+		}
+
+		setStep('confirm');
+		setTranslatedLanguageIds(translatedLanguageIds);
+	};
+
+	useEffect(() => {
+		if (appliedRef.current || !results?.length) {
+			return;
+		}
+
+		appliedRef.current = true;
+
+		for (const result of results) {
+			const fields: Record<string, string> = {};
+
+			for (const [name, value] of Object.entries(result.fields ?? {})) {
+				fields[name] = Liferay.Util.unescapeHTML(value);
+			}
+
+			if (!Object.keys(fields).length) {
+				continue;
+			}
+
+			Liferay.fire('localizationSelect:autoTranslate', {
+				fields,
+				languageId: result.targetLanguageId,
+			});
+		}
+	}, [results]);
+
+	return {
+		onTranslate,
+		selectedLanguageIds,
+		setSelectedLanguageIds,
+		setStep,
+		setValue,
+		step,
+		submit,
+		submitted,
+		toggleSelectedLanguageId,
+		translatedLanguageIds,
+		value,
+	};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const AUTO_TRANSLATABLE_TYPES = [
+	{isHtml: false, type: 'text'},
+	{isHtml: false, type: 'long-text'},
+	{isHtml: true, type: 'html'},
+];

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getPageContext(sourceLanguageId: string) {
+	const fields: Record<string, string> = {};
+	const html: Record<string, boolean> = {};
+
+	for (const {isHtml, type} of AUTO_TRANSLATABLE_TYPES) {
+		const inputs = document.querySelectorAll<HTMLInputElement>(
+			`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${sourceLanguageId}"]`
+		);
+
+		for (const input of inputs) {
+			const name = input.name.replace(/_[a-z]{2}_[A-Z]{2}$/, '');
+
+			fields[name] = input.value;
+			html[name] = isHtml;
+		}
+	}
+
+	return {fields, html};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getTranslatedLanguageIds(languageIds: string[]): string[] {
+	return languageIds.filter((languageId) =>
+		AUTO_TRANSLATABLE_TYPES.some(({type}) =>
+			Array.from(
+				document.querySelectorAll<HTMLInputElement>(
+					`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${languageId}"]`
+				)
+			).some((input) => Boolean(input.value))
+		)
+	);
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92741
https://liferay.atlassian.net/browse/LPD-92747

## What Is Being Fixed

The AI Assistant chat had no content-translation capability, so a user had to leave the assistant to translate the fields they were editing.

## How It Is Being Fixed

Adds the `TranslateContent` agent that the chat drives to translate content: its API layer, the language components, the translate hook, types, and helper utilities. The chat-side UI integration (the message balloon and its restructured-chat wiring) is cross-cutting and lives in the "AI Assistant Improvements" consolidation, so this PR carries only the translation-exclusive agent files and merges in any order with its sibling PRs without conflicts.

## Why Are There No Tests?

The translation feature's unit test covers `TranslateContentMessageBalloon`, a chat message-balloon UI component that is cross-cutting and ships in the consolidation alongside the component it exercises. This PR contains the agent/service layer only, which is exercised end to end through the consolidation's tests.

## PR Check

**pr-check: PASS** — tested on `2728295bfcf6661c4c13d70d71b7e16877248aab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

`ai-hub-cell-js-components-web` compiles standalone; 102/102 unit tests pass.

<!-- pr-check {"result": "success", "sha": "2728295bfcf6661c4c13d70d71b7e16877248aab"} -->
