### PR TITLE
LPD-98065 Apply AI-generated field values in the content editor

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
@@ -13,8 +13,13 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -201,6 +206,35 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 				Constants.ADD,
 				ParamUtil.getString(httpServletRequest, Constants.CMD))
 		).put(
+			"objectFields",
+			() -> {
+				if (objectDefinition == null) {
+					return null;
+				}
+
+				JSONArray objectFieldsJSONArray =
+					_jsonFactory.createJSONArray();
+
+				for (ObjectField objectField :
+						_objectFieldLocalService.getObjectFields(
+							objectDefinition.getObjectDefinitionId())) {
+
+					if (objectField.isMetadata()) {
+						continue;
+					}
+
+					objectFieldsJSONArray.put(
+						JSONUtil.put(
+							"label",
+							objectField.getLabel(themeDisplay.getLocale())
+						).put(
+							"name", objectField.getName()
+						));
+				}
+
+				return objectFieldsJSONArray;
+			}
+		).put(
 			"title", title
 		).put(
 			"type",
@@ -229,11 +263,17 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 	}
 
 	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private WorkflowDefinitionLinkLocalService

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
@@ -11,9 +11,20 @@ function setControlValue(control: FieldControl, value: string) {
 		return;
 	}
 
-	control.value = value;
+	const prototype =
+		control instanceof HTMLTextAreaElement
+			? HTMLTextAreaElement.prototype
+			: HTMLInputElement.prototype;
+
+	const valueSetter = Object.getOwnPropertyDescriptor(
+		prototype,
+		'value'
+	)?.set;
+
+	valueSetter?.call(control, value);
 
 	control.dispatchEvent(new Event('input', {bubbles: true}));
+	control.dispatchEvent(new Event('change', {bubbles: true}));
 }
 
 export default function applyFieldValues(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
@@ -4,10 +4,33 @@
  */
 
 import getFieldControls, {FieldControl} from './getFieldControls';
-import getRichTextEditor from './getRichTextEditor';
+import getRichTextEditor, {RichTextEditor} from './getRichTextEditor';
+
+function setRichTextEditorData(editor: RichTextEditor, value: string) {
+	const {data, model} = editor;
+
+	if (!data || !model) {
+		editor.setData(value);
+
+		return;
+	}
+
+	const modelFragment = data.toModel(data.processor.toView(value));
+
+	const root = model.document.getRoot();
+
+	model.change((writer) => {
+		writer.remove(writer.createRangeIn(root));
+
+		model.insertContent(modelFragment, root);
+	});
+}
 
 function setControlValue(control: FieldControl, value: string) {
-	if (control instanceof HTMLSelectElement) {
+	if (
+		!(control instanceof HTMLInputElement) &&
+		!(control instanceof HTMLTextAreaElement)
+	) {
 		return;
 	}
 
@@ -27,9 +50,25 @@ function setControlValue(control: FieldControl, value: string) {
 	control.dispatchEvent(new Event('change', {bubbles: true}));
 }
 
+function getLocaleControl(
+	controls: FieldControl[],
+	languageId?: string
+): FieldControl {
+	if (!languageId || controls.length < 2) {
+		return controls[0];
+	}
+
+	return (
+		controls.find((control) =>
+			control.getAttribute('name')?.endsWith(`_${languageId}`)
+		) ?? controls[0]
+	);
+}
+
 export default function applyFieldValues(
 	form: Element,
-	values: Record<string, string>
+	values: Record<string, string>,
+	languageId?: string
 ): void {
 	Object.entries(values).forEach(([name, value]) => {
 		const controls = getFieldControls(form, name);
@@ -41,11 +80,11 @@ export default function applyFieldValues(
 		const editor = getRichTextEditor(controls[0]);
 
 		if (editor) {
-			editor.setData(value);
+			setRichTextEditorData(editor, value);
 
 			return;
 		}
 
-		setControlValue(controls[0], value);
+		setControlValue(getLocaleControl(controls, languageId), value);
 	});
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getFieldControls, {FieldControl} from './getFieldControls';
+import getRichTextEditor from './getRichTextEditor';
+
+function setControlValue(control: FieldControl, value: string) {
+	if (control instanceof HTMLSelectElement) {
+		return;
+	}
+
+	control.value = value;
+
+	control.dispatchEvent(new Event('input', {bubbles: true}));
+}
+
+export default function applyFieldValues(
+	form: Element,
+	values: Record<string, string>
+): void {
+	Object.entries(values).forEach(([name, value]) => {
+		const controls = getFieldControls(form, name);
+
+		if (!controls.length) {
+			return;
+		}
+
+		const editor = getRichTextEditor(controls[0]);
+
+		if (editor) {
+			editor.setData(value);
+
+			return;
+		}
+
+		setControlValue(controls[0], value);
+	});
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldControls.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldControls.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export type FieldControl =
+	| HTMLInputElement
+	| HTMLSelectElement
+	| HTMLTextAreaElement;
+
+const LOCALE_SUFFIX = /^(_[a-z]{2}_[A-Z]{2})?$/;
+
+export default function getFieldControls(
+	form: Element,
+	fieldName: string
+): FieldControl[] {
+	const prefix = `ObjectField_${fieldName}`;
+
+	return Array.from(
+		form.querySelectorAll<FieldControl>(`[name^="${prefix}"]`)
+	).filter((control) =>
+		LOCALE_SUFFIX.test(control.name.slice(prefix.length))
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldControls.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldControls.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export type FieldControl =
-	| HTMLInputElement
-	| HTMLSelectElement
-	| HTMLTextAreaElement;
+export type FieldControl = HTMLElement;
 
 const LOCALE_SUFFIX = /^(_[a-z]{2}_[A-Z]{2})?$/;
 
@@ -16,9 +13,17 @@ export default function getFieldControls(
 ): FieldControl[] {
 	const prefix = `ObjectField_${fieldName}`;
 
-	return Array.from(
-		form.querySelectorAll<FieldControl>(`[name^="${prefix}"]`)
+	const controls = Array.from(
+		form.querySelectorAll<HTMLElement>(`[name^="${prefix}"]`)
 	).filter((control) =>
-		LOCALE_SUFFIX.test(control.name.slice(prefix.length))
+		LOCALE_SUFFIX.test(control.getAttribute('name')!.slice(prefix.length))
+	);
+
+	if (controls.length) {
+		return controls;
+	}
+
+	return Array.from(
+		form.querySelectorAll<HTMLElement>(`[data-field-name="${prefix}"]`)
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldValues.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldValues.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getFieldControls from './getFieldControls';
+import getRichTextEditor from './getRichTextEditor';
+
+export default function getFieldValues(
+	form: Element,
+	objectFields: Array<{name: string}>
+): Record<string, string> {
+	const values: Record<string, string> = {};
+
+	objectFields.forEach(({name}) => {
+		const controls = getFieldControls(form, name);
+
+		if (!controls.length) {
+			return;
+		}
+
+		const editor = getRichTextEditor(controls[0]);
+
+		if (editor) {
+			values[name] = editor.getData();
+
+			return;
+		}
+
+		const filledControl = controls.find((control) => control.value.trim());
+
+		if (filledControl) {
+			values[name] = filledControl.value;
+		}
+	});
+
+	return values;
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldValues.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getFieldValues.ts
@@ -27,7 +27,12 @@ export default function getFieldValues(
 			return;
 		}
 
-		const filledControl = controls.find((control) => control.value.trim());
+		const filledControl = controls.find(
+			(control): control is HTMLInputElement | HTMLTextAreaElement =>
+				(control instanceof HTMLInputElement ||
+					control instanceof HTMLTextAreaElement) &&
+				Boolean(control.value.trim())
+		);
 
 		if (filledControl) {
 			values[name] = filledControl.value;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getRichTextEditor.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getRichTextEditor.ts
@@ -3,19 +3,38 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+interface RichTextEditorModelWriter {
+	createRangeIn: (element: unknown) => unknown;
+	remove: (range: unknown) => void;
+}
+
 export interface RichTextEditor {
+	data?: {
+		processor: {toView: (data: string) => unknown};
+		toModel: (viewFragment: unknown) => unknown;
+	};
 	getData: () => string;
+	model?: {
+		change: (callback: (writer: RichTextEditorModelWriter) => void) => void;
+		document: {getRoot: () => unknown};
+		insertContent: (content: unknown, selectable: unknown) => void;
+	};
 	setData: (data: string) => void;
 }
 
 export default function getRichTextEditor(
 	control: Element
 ): RichTextEditor | null {
-	const editable = control
-		.closest('.lfr-ck')
-		?.querySelector<
-			HTMLElement & {ckeditorInstance?: RichTextEditor}
-		>('.ck-editor__editable');
+	const container =
+		control.closest('[data-field-name]') ??
+		control.closest('.form-group') ??
+		control;
 
-	return editable?.ckeditorInstance ?? null;
+	const host = Array.from(
+		container.querySelectorAll<
+			HTMLElement & {ckeditorInstance?: RichTextEditor}
+		>('*')
+	).find((node) => node.ckeditorInstance);
+
+	return host?.ckeditorInstance ?? null;
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getRichTextEditor.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/utils/getRichTextEditor.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface RichTextEditor {
+	getData: () => string;
+	setData: (data: string) => void;
+}
+
+export default function getRichTextEditor(
+	control: Element
+): RichTextEditor | null {
+	const editable = control
+		.closest('.lfr-ck')
+		?.querySelector<
+			HTMLElement & {ckeditorInstance?: RichTextEditor}
+		>('.ck-editor__editable');
+
+	return editable?.ckeditorInstance ?? null;
+}

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import applyFieldValues from '../../../../src/main/resources/META-INF/resources/js/content_editor/utils/applyFieldValues';
+
+function createForm(html: string): HTMLFormElement {
+	const form = document.createElement('form');
+
+	form.innerHTML = html;
+
+	return form;
+}
+
+describe('applyFieldValues', () => {
+	it('writes a plain field value and fires input and change events', () => {
+		const form = createForm('<input name="ObjectField_title" value="" />');
+
+		const input = form.querySelector('input') as HTMLInputElement;
+
+		const inputListener = jest.fn();
+		const changeListener = jest.fn();
+
+		input.addEventListener('input', inputListener);
+		input.addEventListener('change', changeListener);
+
+		applyFieldValues(form, {title: 'Generated'});
+
+		expect(input.value).toBe('Generated');
+		expect(inputListener).toHaveBeenCalledTimes(1);
+		expect(changeListener).toHaveBeenCalledTimes(1);
+	});
+
+	it('writes through the native setter when a control ignores direct assignment', () => {
+		const form = createForm('<input name="ObjectField_title" value="" />');
+
+		const input = form.querySelector('input') as HTMLInputElement;
+
+		const nativeValueGetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			'value'
+		)?.get;
+
+		Object.defineProperty(input, 'value', {
+			configurable: true,
+			get() {
+				return nativeValueGetter?.call(this);
+			},
+			set() {},
+		});
+
+		applyFieldValues(form, {title: 'Generated'});
+
+		expect(nativeValueGetter?.call(input)).toBe('Generated');
+	});
+
+	it('writes a RichText field through the CKEditor instance', () => {
+		const form = createForm(
+			'<div class="lfr-ck"><div class="ck-editor__editable"></div>' +
+				'<input name="ObjectField_body" type="hidden" /></div>'
+		);
+
+		const editable = form.querySelector('.ck-editor__editable');
+
+		const setData = jest.fn();
+
+		(editable as any).ckeditorInstance = {getData: jest.fn(), setData};
+
+		applyFieldValues(form, {body: '<p>New</p>'});
+
+		expect(setData).toHaveBeenCalledWith('<p>New</p>');
+	});
+
+	it('ignores a field that has no control', () => {
+		const form = createForm('<input name="ObjectField_title" value="" />');
+
+		expect(() => applyFieldValues(form, {missing: 'x'})).not.toThrow();
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
@@ -14,45 +14,45 @@ function createForm(html: string): HTMLFormElement {
 }
 
 describe('applyFieldValues', () => {
-	it('writes a plain field value and fires input and change events', () => {
-		const form = createForm('<input name="ObjectField_title" value="" />');
+	it('falls back to setData when the editor has no model API', () => {
+		const form = createForm(
+			'<div class="rich-text-input" data-field-name="ObjectField_body">' +
+				'<div class="lfr-ck"><div class="ck ck-editor">' +
+				'<div class="ck-editor__editable"></div></div></div></div>'
+		);
 
-		const input = form.querySelector('input') as HTMLInputElement;
+		const editor = form.querySelector('.ck-editor');
 
-		const inputListener = jest.fn();
-		const changeListener = jest.fn();
+		const setData = jest.fn();
 
-		input.addEventListener('input', inputListener);
-		input.addEventListener('change', changeListener);
+		(editor as any).ckeditorInstance = {getData: jest.fn(), setData};
 
-		applyFieldValues(form, {title: 'Generated'});
+		applyFieldValues(form, {body: '<p>New</p>'});
 
-		expect(input.value).toBe('Generated');
-		expect(inputListener).toHaveBeenCalledTimes(1);
-		expect(changeListener).toHaveBeenCalledTimes(1);
+		expect(setData).toHaveBeenCalledWith('<p>New</p>');
 	});
 
-	it('writes through the native setter when a control ignores direct assignment', () => {
+	it('falls back to the first control when the locale is absent', () => {
+		const form = createForm(
+			'<input name="ObjectField_title_en_US" value="" />' +
+				'<input name="ObjectField_title_pt_BR" value="" />'
+		);
+
+		applyFieldValues(form, {title: 'Generated'}, 'fr_FR');
+
+		expect(
+			(
+				form.querySelector(
+					'[name="ObjectField_title_en_US"]'
+				) as HTMLInputElement
+			).value
+		).toBe('Generated');
+	});
+
+	it('ignores a field that has no control', () => {
 		const form = createForm('<input name="ObjectField_title" value="" />');
 
-		const input = form.querySelector('input') as HTMLInputElement;
-
-		const nativeValueGetter = Object.getOwnPropertyDescriptor(
-			HTMLInputElement.prototype,
-			'value'
-		)?.get;
-
-		Object.defineProperty(input, 'value', {
-			configurable: true,
-			get() {
-				return nativeValueGetter?.call(this);
-			},
-			set() {},
-		});
-
-		applyFieldValues(form, {title: 'Generated'});
-
-		expect(nativeValueGetter?.call(input)).toBe('Generated');
+		expect(() => applyFieldValues(form, {missing: 'x'})).not.toThrow();
 	});
 
 	it('replaces a RichText field through the editor model', () => {
@@ -93,22 +93,22 @@ describe('applyFieldValues', () => {
 		expect(insertContent).toHaveBeenCalledWith(modelFragment, root);
 	});
 
-	it('falls back to setData when the editor has no model API', () => {
-		const form = createForm(
-			'<div class="rich-text-input" data-field-name="ObjectField_body">' +
-				'<div class="lfr-ck"><div class="ck ck-editor">' +
-				'<div class="ck-editor__editable"></div></div></div></div>'
-		);
+	it('writes a plain field value and fires input and change events', () => {
+		const form = createForm('<input name="ObjectField_title" value="" />');
 
-		const editor = form.querySelector('.ck-editor');
+		const input = form.querySelector('input') as HTMLInputElement;
 
-		const setData = jest.fn();
+		const inputListener = jest.fn();
+		const changeListener = jest.fn();
 
-		(editor as any).ckeditorInstance = {getData: jest.fn(), setData};
+		input.addEventListener('input', inputListener);
+		input.addEventListener('change', changeListener);
 
-		applyFieldValues(form, {body: '<p>New</p>'});
+		applyFieldValues(form, {title: 'Generated'});
 
-		expect(setData).toHaveBeenCalledWith('<p>New</p>');
+		expect(input.value).toBe('Generated');
+		expect(inputListener).toHaveBeenCalledTimes(1);
+		expect(changeListener).toHaveBeenCalledTimes(1);
 	});
 
 	it('writes only the active locale control for a localized field', () => {
@@ -135,26 +135,26 @@ describe('applyFieldValues', () => {
 		).toBe('Generated');
 	});
 
-	it('falls back to the first control when the locale is absent', () => {
-		const form = createForm(
-			'<input name="ObjectField_title_en_US" value="" />' +
-				'<input name="ObjectField_title_pt_BR" value="" />'
-		);
-
-		applyFieldValues(form, {title: 'Generated'}, 'fr_FR');
-
-		expect(
-			(
-				form.querySelector(
-					'[name="ObjectField_title_en_US"]'
-				) as HTMLInputElement
-			).value
-		).toBe('Generated');
-	});
-
-	it('ignores a field that has no control', () => {
+	it('writes through the native setter when a control ignores direct assignment', () => {
 		const form = createForm('<input name="ObjectField_title" value="" />');
 
-		expect(() => applyFieldValues(form, {missing: 'x'})).not.toThrow();
+		const input = form.querySelector('input') as HTMLInputElement;
+
+		const nativeValueGetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			'value'
+		)?.get;
+
+		Object.defineProperty(input, 'value', {
+			configurable: true,
+			get() {
+				return nativeValueGetter?.call(this);
+			},
+			set() {},
+		});
+
+		applyFieldValues(form, {title: 'Generated'});
+
+		expect(nativeValueGetter?.call(input)).toBe('Generated');
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
@@ -55,21 +55,95 @@ describe('applyFieldValues', () => {
 		expect(nativeValueGetter?.call(input)).toBe('Generated');
 	});
 
-	it('writes a RichText field through the CKEditor instance', () => {
+	it('replaces a RichText field through the editor model', () => {
 		const form = createForm(
-			'<div class="lfr-ck"><div class="ck-editor__editable"></div>' +
-				'<input name="ObjectField_body" type="hidden" /></div>'
+			'<div class="rich-text-input" data-field-name="ObjectField_body">' +
+				'<div class="lfr-ck"><div class="ck ck-editor">' +
+				'<div class="ck-editor__editable"></div></div></div></div>'
 		);
 
-		const editable = form.querySelector('.ck-editor__editable');
+		const editor = form.querySelector('.ck-editor');
+
+		const insertContent = jest.fn();
+		const remove = jest.fn();
+		const createRangeIn = jest.fn(() => 'range');
+
+		const root = {};
+		const modelFragment = {};
+		const viewFragment = {};
+
+		(editor as any).ckeditorInstance = {
+			data: {
+				processor: {toView: jest.fn(() => viewFragment)},
+				toModel: jest.fn(() => modelFragment),
+			},
+			getData: jest.fn(),
+			model: {
+				change: (callback: (writer: unknown) => void) =>
+					callback({createRangeIn, remove}),
+				document: {getRoot: () => root},
+				insertContent,
+			},
+			setData: jest.fn(),
+		};
+
+		applyFieldValues(form, {body: '<p>New</p>'});
+
+		expect(remove).toHaveBeenCalledWith('range');
+		expect(insertContent).toHaveBeenCalledWith(modelFragment, root);
+	});
+
+	it('falls back to setData when the editor has no model API', () => {
+		const form = createForm(
+			'<div class="rich-text-input" data-field-name="ObjectField_body">' +
+				'<div class="lfr-ck"><div class="ck ck-editor">' +
+				'<div class="ck-editor__editable"></div></div></div></div>'
+		);
+
+		const editor = form.querySelector('.ck-editor');
 
 		const setData = jest.fn();
 
-		(editable as any).ckeditorInstance = {getData: jest.fn(), setData};
+		(editor as any).ckeditorInstance = {getData: jest.fn(), setData};
 
 		applyFieldValues(form, {body: '<p>New</p>'});
 
 		expect(setData).toHaveBeenCalledWith('<p>New</p>');
+	});
+
+	it('writes only the active locale control for a localized field', () => {
+		const form = createForm(
+			'<input name="ObjectField_title_en_US" value="" />' +
+				'<input name="ObjectField_title_pt_BR" value="" />'
+		);
+
+		applyFieldValues(form, {title: 'Generated'}, 'pt_BR');
+
+		expect(
+			(form.querySelector(
+				'[name="ObjectField_title_en_US"]'
+			) as HTMLInputElement).value
+		).toBe('');
+		expect(
+			(form.querySelector(
+				'[name="ObjectField_title_pt_BR"]'
+			) as HTMLInputElement).value
+		).toBe('Generated');
+	});
+
+	it('falls back to the first control when the locale is absent', () => {
+		const form = createForm(
+			'<input name="ObjectField_title_en_US" value="" />' +
+				'<input name="ObjectField_title_pt_BR" value="" />'
+		);
+
+		applyFieldValues(form, {title: 'Generated'}, 'fr_FR');
+
+		expect(
+			(form.querySelector(
+				'[name="ObjectField_title_en_US"]'
+			) as HTMLInputElement).value
+		).toBe('Generated');
 	});
 
 	it('ignores a field that has no control', () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/applyFieldValues.test.ts
@@ -120,14 +120,18 @@ describe('applyFieldValues', () => {
 		applyFieldValues(form, {title: 'Generated'}, 'pt_BR');
 
 		expect(
-			(form.querySelector(
-				'[name="ObjectField_title_en_US"]'
-			) as HTMLInputElement).value
+			(
+				form.querySelector(
+					'[name="ObjectField_title_en_US"]'
+				) as HTMLInputElement
+			).value
 		).toBe('');
 		expect(
-			(form.querySelector(
-				'[name="ObjectField_title_pt_BR"]'
-			) as HTMLInputElement).value
+			(
+				form.querySelector(
+					'[name="ObjectField_title_pt_BR"]'
+				) as HTMLInputElement
+			).value
 		).toBe('Generated');
 	});
 
@@ -140,9 +144,11 @@ describe('applyFieldValues', () => {
 		applyFieldValues(form, {title: 'Generated'}, 'fr_FR');
 
 		expect(
-			(form.querySelector(
-				'[name="ObjectField_title_en_US"]'
-			) as HTMLInputElement).value
+			(
+				form.querySelector(
+					'[name="ObjectField_title_en_US"]'
+				) as HTMLInputElement
+			).value
 		).toBe('Generated');
 	});
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
@@ -20,7 +20,7 @@ describe('getFieldControls', () => {
 		const controls = getFieldControls(form, 'title');
 
 		expect(controls).toHaveLength(1);
-		expect(controls[0].name).toBe('ObjectField_title');
+		expect(controls[0].getAttribute('name')).toBe('ObjectField_title');
 	});
 
 	it('returns every locale-suffixed control for a localized field', () => {
@@ -30,7 +30,9 @@ describe('getFieldControls', () => {
 		);
 
 		expect(
-			getFieldControls(form, 'title').map((control) => control.name)
+			getFieldControls(form, 'title').map((control) =>
+				control.getAttribute('name')
+			)
 		).toEqual(['ObjectField_title_en_US', 'ObjectField_title_pt_BR']);
 	});
 
@@ -43,7 +45,21 @@ describe('getFieldControls', () => {
 		const controls = getFieldControls(form, 'title');
 
 		expect(controls).toHaveLength(1);
-		expect(controls[0].name).toBe('ObjectField_title');
+		expect(controls[0].getAttribute('name')).toBe('ObjectField_title');
+	});
+
+	it('falls back to the rich text container when there is no named control', () => {
+		const form = createForm(
+			'<div class="rich-text-input" data-field-name="ObjectField_content">' +
+				'<div class="lfr-ck"></div></div>'
+		);
+
+		const controls = getFieldControls(form, 'content');
+
+		expect(controls).toHaveLength(1);
+		expect(controls[0].getAttribute('data-field-name')).toBe(
+			'ObjectField_content'
+		);
 	});
 
 	it('returns an empty array when the field is absent', () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
@@ -14,28 +14,6 @@ function createForm(html: string): HTMLFormElement {
 }
 
 describe('getFieldControls', () => {
-	it('returns the control for a non-localized field', () => {
-		const form = createForm('<input name="ObjectField_title" />');
-
-		const controls = getFieldControls(form, 'title');
-
-		expect(controls).toHaveLength(1);
-		expect(controls[0].getAttribute('name')).toBe('ObjectField_title');
-	});
-
-	it('returns every locale-suffixed control for a localized field', () => {
-		const form = createForm(
-			'<input name="ObjectField_title_en_US" />' +
-				'<input name="ObjectField_title_pt_BR" />'
-		);
-
-		expect(
-			getFieldControls(form, 'title').map((control) =>
-				control.getAttribute('name')
-			)
-		).toEqual(['ObjectField_title_en_US', 'ObjectField_title_pt_BR']);
-	});
-
 	it('does not match a field that only shares the prefix', () => {
 		const form = createForm(
 			'<input name="ObjectField_title" />' +
@@ -66,5 +44,27 @@ describe('getFieldControls', () => {
 		const form = createForm('<input name="ObjectField_body" />');
 
 		expect(getFieldControls(form, 'title')).toHaveLength(0);
+	});
+
+	it('returns every locale-suffixed control for a localized field', () => {
+		const form = createForm(
+			'<input name="ObjectField_title_en_US" />' +
+				'<input name="ObjectField_title_pt_BR" />'
+		);
+
+		expect(
+			getFieldControls(form, 'title').map((control) =>
+				control.getAttribute('name')
+			)
+		).toEqual(['ObjectField_title_en_US', 'ObjectField_title_pt_BR']);
+	});
+
+	it('returns the control for a non-localized field', () => {
+		const form = createForm('<input name="ObjectField_title" />');
+
+		const controls = getFieldControls(form, 'title');
+
+		expect(controls).toHaveLength(1);
+		expect(controls[0].getAttribute('name')).toBe('ObjectField_title');
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldControls.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getFieldControls from '../../../../src/main/resources/META-INF/resources/js/content_editor/utils/getFieldControls';
+
+function createForm(html: string): HTMLFormElement {
+	const form = document.createElement('form');
+
+	form.innerHTML = html;
+
+	return form;
+}
+
+describe('getFieldControls', () => {
+	it('returns the control for a non-localized field', () => {
+		const form = createForm('<input name="ObjectField_title" />');
+
+		const controls = getFieldControls(form, 'title');
+
+		expect(controls).toHaveLength(1);
+		expect(controls[0].name).toBe('ObjectField_title');
+	});
+
+	it('returns every locale-suffixed control for a localized field', () => {
+		const form = createForm(
+			'<input name="ObjectField_title_en_US" />' +
+				'<input name="ObjectField_title_pt_BR" />'
+		);
+
+		expect(
+			getFieldControls(form, 'title').map((control) => control.name)
+		).toEqual(['ObjectField_title_en_US', 'ObjectField_title_pt_BR']);
+	});
+
+	it('does not match a field that only shares the prefix', () => {
+		const form = createForm(
+			'<input name="ObjectField_title" />' +
+				'<input name="ObjectField_titleImage" />'
+		);
+
+		const controls = getFieldControls(form, 'title');
+
+		expect(controls).toHaveLength(1);
+		expect(controls[0].name).toBe('ObjectField_title');
+	});
+
+	it('returns an empty array when the field is absent', () => {
+		const form = createForm('<input name="ObjectField_body" />');
+
+		expect(getFieldControls(form, 'title')).toHaveLength(0);
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldValues.test.ts
@@ -26,13 +26,14 @@ describe('getFieldValues', () => {
 
 	it('reads a RichText field through the CKEditor instance', () => {
 		const form = createForm(
-			'<div class="lfr-ck"><div class="ck-editor__editable"></div>' +
-				'<input name="ObjectField_body" type="hidden" value="stale" /></div>'
+			'<div class="rich-text-input" data-field-name="ObjectField_body">' +
+				'<div class="lfr-ck"><div class="ck ck-editor">' +
+				'<div class="ck-editor__editable"></div></div></div></div>'
 		);
 
-		const editable = form.querySelector('.ck-editor__editable');
+		const editor = form.querySelector('.ck-editor');
 
-		(editable as any).ckeditorInstance = {
+		(editor as any).ckeditorInstance = {
 			getData: () => '<p>Fresh</p>',
 			setData: jest.fn(),
 		};

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldValues.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/utils/getFieldValues.test.ts
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getFieldValues from '../../../../src/main/resources/META-INF/resources/js/content_editor/utils/getFieldValues';
+
+function createForm(html: string): HTMLFormElement {
+	const form = document.createElement('form');
+
+	form.innerHTML = html;
+
+	return form;
+}
+
+describe('getFieldValues', () => {
+	it('reads a plain field value', () => {
+		const form = createForm(
+			'<input name="ObjectField_title" value="Hello" />'
+		);
+
+		expect(getFieldValues(form, [{name: 'title'}])).toEqual({
+			title: 'Hello',
+		});
+	});
+
+	it('reads a RichText field through the CKEditor instance', () => {
+		const form = createForm(
+			'<div class="lfr-ck"><div class="ck-editor__editable"></div>' +
+				'<input name="ObjectField_body" type="hidden" value="stale" /></div>'
+		);
+
+		const editable = form.querySelector('.ck-editor__editable');
+
+		(editable as any).ckeditorInstance = {
+			getData: () => '<p>Fresh</p>',
+			setData: jest.fn(),
+		};
+
+		expect(getFieldValues(form, [{name: 'body'}])).toEqual({
+			body: '<p>Fresh</p>',
+		});
+	});
+
+	it('skips a field that has no control', () => {
+		const form = createForm(
+			'<input name="ObjectField_title" value="Hi" />'
+		);
+
+		expect(
+			getFieldValues(form, [{name: 'title'}, {name: 'missing'}])
+		).toEqual({title: 'Hi'});
+	});
+
+	it('skips an empty plain field', () => {
+		const form = createForm('<input name="ObjectField_title" value="" />');
+
+		expect(getFieldValues(form, [{name: 'title'}])).toEqual({});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98065
https://liferay.atlassian.net/browse/LPD-97144

## What Is Being Fixed

Field values generated by the AI Assistant could not be written back into the content editor's fields, and the open entry's object fields were not exposed to the content editor toolbar for the editor to act on.

## How It Is Being Fixed

Adds the content-editor field utilities: reading and writing field controls and values, resolving the rich text editor, and applying generated values. Applied values are persisted through the native value setter so the editor's own state updates, and rich text fields are matched through their `data-field-name` container. On the backend, the open entry's object fields are exposed to the content editor toolbar (LPD-97144). The field utilities are covered by unit tests.

The AI Assistant chat-side pieces that preview and apply these values (the field-value message balloon and its chat wiring) are cross-cutting and live in the "AI Assistant Improvements" consolidation, so this PR carries only the content-editor-exclusive files and merges in any order with its sibling PRs without conflicts.

## PR Check

**pr-check: PASS** — tested on `76358212fd79dab75fd4cfe8b3da50418e23336e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

`site-cms-site-initializer` compiles standalone; 819/820 unit tests pass. The single failure is `CategorizationSpaces › allows typing in the MultiSelect input…`, a pre-existing flaky test on master (its file is not touched by this branch) — not a regression.

<!-- pr-check {"result": "success", "sha": "76358212fd79dab75fd4cfe8b3da50418e23336e"} -->
