### PR TITLE
LPD-99254 LPD-98763 Inject AI images and add the content-gap matrix

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ContentCoverageMatrixComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ContentCoverageMatrixComponentSectionFragmentRenderer.java
@@ -17,6 +17,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cmp.site.initializer.internal.util.ActionUtil;
 import com.liferay.site.cmp.site.initializer.internal.util.ObjectEntryUtil;
@@ -90,6 +91,8 @@ public class ContentCoverageMatrixComponentSectionFragmentRenderer
 				objectEntry.getObjectEntryId(), "?redirect=",
 				themeDisplay.getURLCurrent())
 		).put(
+			"groupId", objectEntry.getGroupId()
+		).put(
 			"hasFunnelStagesOrPersonas",
 			() -> {
 				AssetVocabulary funnelStageAssetVocabulary =
@@ -122,6 +125,8 @@ public class ContentCoverageMatrixComponentSectionFragmentRenderer
 			}
 		).put(
 			"projectId", objectEntry.getObjectEntryId()
+		).put(
+			"projectTitle", MapUtil.getString(objectEntry.getValues(), "title")
 		).build();
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapCell.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapCell.tsx
@@ -14,6 +14,7 @@ interface ContentGapCellProps {
 	funnelStage: TaxonomyTerm;
 	maxRealCount: number;
 	onFilter?: (persona: TaxonomyTerm, funnelStage: TaxonomyTerm) => void;
+	onGenerate?: (persona: TaxonomyTerm, funnelStage: TaxonomyTerm) => void;
 	persona: TaxonomyTerm;
 	selected?: boolean;
 	totalCount: number;
@@ -23,6 +24,7 @@ export default function ContentGapCell({
 	funnelStage,
 	maxRealCount,
 	onFilter,
+	onGenerate,
 	persona,
 	selected,
 	totalCount,
@@ -34,10 +36,6 @@ export default function ContentGapCell({
 	const gap = totalCount === 0;
 
 	const tier = gap ? 0 : getCellTier(totalCount, maxRealCount);
-
-	// Only real persona/funnel-stage cells filter the asset table. The
-	// uncategorized "No Persona" row and "No Funnel" column have no category to
-	// filter by, so they stay static.
 
 	const clickable =
 		Boolean(onFilter) && !isSentinel(persona) && !isSentinel(funnelStage);
@@ -55,8 +53,6 @@ export default function ContentGapCell({
 	const cellCount = (
 		<span className="lfr-cmp__content-gap-cell-count">{totalCount}</span>
 	);
-
-	// Close the action bar when clicking outside the cell.
 
 	useEffect(() => {
 		if (!active) {
@@ -115,6 +111,11 @@ export default function ContentGapCell({
 				<ContentGapCellActions
 					onFilter={() => {
 						onFilter?.(persona, funnelStage);
+
+						setActive(false);
+					}}
+					onGenerate={() => {
+						onGenerate?.(persona, funnelStage);
 
 						setActive(false);
 					}}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapCellActions.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapCellActions.tsx
@@ -9,10 +9,12 @@ import React from 'react';
 
 interface ContentGapCellActionsProps {
 	onFilter: () => void;
+	onGenerate: () => void;
 }
 
 export default function ContentGapCellActions({
 	onFilter,
+	onGenerate,
 }: ContentGapCellActionsProps) {
 	return (
 		<div className="lfr-cmp__content-gap-cell-actions">
@@ -33,20 +35,24 @@ export default function ContentGapCellActions({
 				{Liferay.Language.get('filter')}
 			</ClayButton>
 
-			{/* Placeholder for the future Generate action */}
+			{Liferay.FeatureFlags['LPD-62272'] && (
+				<ClayButton
+					className="lfr-cmp__content-gap-cell-action"
+					displayType="unstyled"
+					onClick={(event) => {
+						event.stopPropagation();
 
-			<ClayButton
-				className="lfr-cmp__content-gap-cell-action"
-				disabled
-				displayType="unstyled"
-			>
-				<ClayIcon
-					className="inline-item inline-item-before"
-					symbol="stars"
-				/>
+						onGenerate();
+					}}
+				>
+					<ClayIcon
+						className="inline-item inline-item-before"
+						symbol="stars"
+					/>
 
-				{Liferay.Language.get('generate')}
-			</ClayButton>
+					{Liferay.Language.get('generate')}
+				</ClayButton>
+			)}
 		</div>
 	);
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrix.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrix.scss
@@ -145,6 +145,9 @@ $content-gap-cell-tiers: (
 }
 
 .lfr-cmp__content-gap-matrix-header {
+	align-items: flex-start;
+	display: flex;
+	justify-content: space-between;
 	margin: 1.5rem;
 }
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixCard.tsx
@@ -21,8 +21,10 @@ import './ContentGapMatrix.scss';
 interface ContentGapMatrixCardProps {
 	assetFDSId: string;
 	editProjectURL?: string;
+	groupId: number;
 	hasFunnelStagesOrPersonas: boolean;
 	projectId: string;
+	projectTitle: string;
 }
 
 const contentCoverageService = ContentCoverageServiceImpl;
@@ -30,8 +32,10 @@ const contentCoverageService = ContentCoverageServiceImpl;
 export default function ContentGapMatrixCard({
 	assetFDSId,
 	editProjectURL,
+	groupId,
 	hasFunnelStagesOrPersonas,
 	projectId,
+	projectTitle,
 }: ContentGapMatrixCardProps) {
 	const [data, setData] = useState<MatrixData | null>(null);
 	const [error, setError] = useState(false);
@@ -73,7 +77,11 @@ export default function ContentGapMatrixCard({
 	if (!hasFunnelStagesOrPersonas) {
 		return (
 			<div className="lfr-cmp__content-gap-matrix-card">
-				<ContentGapMatrixHeader />
+				<ContentGapMatrixHeader
+					groupId={groupId}
+					projectId={projectId}
+					projectTitle={projectTitle}
+				/>
 
 				<div className="lfr-cmp__content-gap-matrix-container">
 					<div className="empty-state">
@@ -121,7 +129,11 @@ export default function ContentGapMatrixCard({
 	if (error || !data) {
 		return (
 			<div className="lfr-cmp__content-gap-matrix-card">
-				<ContentGapMatrixHeader />
+				<ContentGapMatrixHeader
+					groupId={groupId}
+					projectId={projectId}
+					projectTitle={projectTitle}
+				/>
 
 				<div className="lfr-cmp__content-gap-matrix-container">
 					<div className="empty-state">
@@ -136,7 +148,12 @@ export default function ContentGapMatrixCard({
 
 	return (
 		<div className="lfr-cmp__content-gap-matrix-card">
-			<ContentGapMatrixHeader data={data} />
+			<ContentGapMatrixHeader
+				data={data}
+				groupId={groupId}
+				projectId={projectId}
+				projectTitle={projectTitle}
+			/>
 
 			<div className="lfr-cmp__content-gap-matrix-container">
 				<div className="lfr-cmp__content-gap-matrix-intro">

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixGrid.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixGrid.tsx
@@ -4,10 +4,11 @@
  */
 
 import {ClayTooltipProvider} from '@clayui/tooltip';
+import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import ContentGapCell from './ContentGapCell';
-import {MatrixData} from './types';
+import {MatrixData, TaxonomyTerm} from './types';
 import {useCoverageFilter} from './useCoverageFilter';
 import {buildCountsByCellKey, getCellKey, getMaxRealCount} from './utils';
 
@@ -27,6 +28,22 @@ export default function ContentGapMatrixGrid({
 
 	const getCount = (personaId: string, funnelStageId: string) =>
 		countsByCellKey.get(getCellKey(personaId, funnelStageId)) ?? 0;
+
+	const handleGenerate = (
+		persona: TaxonomyTerm,
+		funnelStage: TaxonomyTerm
+	) => {
+		Liferay.fire('openAIAssistantChat', {
+			context: {funnelStage: funnelStage.name, persona: persona.name},
+			message: sub(
+				Liferay.Language.get(
+					'generate-content-for-the-x-persona-and-the-x-funnel-stage'
+				),
+				persona.name,
+				funnelStage.name
+			),
+		});
+	};
 
 	return (
 		<ClayTooltipProvider>
@@ -77,6 +94,7 @@ export default function ContentGapMatrixGrid({
 								key={funnelStage.id}
 								maxRealCount={maxRealCount}
 								onFilter={applyFilter}
+								onGenerate={handleGenerate}
 								persona={persona}
 								selected={
 									selectedCategoryIds.has(persona.id) &&

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixHeader.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixHeader.tsx
@@ -5,13 +5,24 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import {AIAssistantChat} from '@liferay/ai-hub-cell-js-components-web';
 import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {MatrixData} from './types';
 import {computeCoveragePercentage, countCriticalGaps} from './utils';
 
-export default function ContentGapMatrixHeader({data}: {data?: MatrixData}) {
+export default function ContentGapMatrixHeader({
+	data,
+	groupId,
+	projectId,
+	projectTitle,
+}: {
+	data?: MatrixData;
+	groupId?: number;
+	projectId?: string;
+	projectTitle?: string;
+}) {
 	const coveragePercentage = data ? computeCoveragePercentage(data) : 0;
 	const coverageDisplayType =
 		coveragePercentage === 0
@@ -24,35 +35,55 @@ export default function ContentGapMatrixHeader({data}: {data?: MatrixData}) {
 
 	return (
 		<div className="lfr-cmp__content-gap-matrix-header">
-			<h5 className="lfr-cmp__content-gap-matrix-header-title text-uppercase">
-				<ClayIcon symbol="diagram" />
+			<div>
+				<h5 className="lfr-cmp__content-gap-matrix-header-title text-uppercase">
+					<ClayIcon symbol="diagram" />
 
-				{Liferay.Language.get('content-coverage-matrix')}
-			</h5>
+					{Liferay.Language.get('content-coverage-matrix')}
+				</h5>
 
-			{data ? (
-				<div className="lfr-cmp__content-gap-matrix-header-stats">
-					<ClayLabel displayType={coverageDisplayType} inverse>
-						{sub(
-							Liferay.Language.get('x-covered'),
-							`${coveragePercentage}%`
-						)}
-					</ClayLabel>
-
-					{noAssets ? (
-						<ClayLabel displayType="danger" inverse>
-							{Liferay.Language.get('no-assets-found')}
-						</ClayLabel>
-					) : criticalGaps > 0 ? (
-						<ClayLabel displayType="warning" inverse>
+				{data ? (
+					<div className="lfr-cmp__content-gap-matrix-header-stats">
+						<ClayLabel displayType={coverageDisplayType} inverse>
 							{sub(
-								Liferay.Language.get('x-critical-gaps'),
-								String(criticalGaps)
+								Liferay.Language.get('x-covered'),
+								`${coveragePercentage}%`
 							)}
 						</ClayLabel>
-					) : null}
-				</div>
-			) : null}
+
+						{noAssets ? (
+							<ClayLabel displayType="danger" inverse>
+								{Liferay.Language.get('no-assets-found')}
+							</ClayLabel>
+						) : criticalGaps > 0 ? (
+							<ClayLabel displayType="warning" inverse>
+								{sub(
+									Liferay.Language.get('x-critical-gaps'),
+									String(criticalGaps)
+								)}
+							</ClayLabel>
+						) : null}
+					</div>
+				) : null}
+			</div>
+
+			{Liferay.FeatureFlags['LPD-62272'] && (
+				<AIAssistantChat
+					context={{
+						cmsGroupId: groupId,
+						focusScope: 'full-matrix',
+						projectId,
+					}}
+					initialMessage={sub(
+						Liferay.Language.get(
+							'get-ai-insights-for-the-x-content-coverage-matrix'
+						),
+						projectTitle
+					)}
+					instructionDefinitionScope="cms"
+					triggerLabel={Liferay.Language.get('get-ai-insights')}
+				/>
+			)}
 		</div>
 	);
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapCell.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapCell.spec.tsx
@@ -26,6 +26,10 @@ const STAGE: TaxonomyTerm = {
 };
 
 describe('ContentGapCell', () => {
+	afterEach(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+	});
+
 	it('applies the persona and funnel-stage filter when a real cell is clicked', () => {
 		const onFilter = jest.fn();
 
@@ -92,6 +96,29 @@ describe('ContentGapCell', () => {
 		expect(
 			container.querySelector('.lfr-cmp__content-gap-cell--clickable')
 		).toBeNull();
+	});
+
+	it('generates content for the persona and funnel stage when generate is clicked', () => {
+		Liferay.FeatureFlags['LPD-62272'] = true;
+
+		const onGenerate = jest.fn();
+
+		const {getByLabelText} = render(
+			<ContentGapCell
+				funnelStage={STAGE}
+				maxRealCount={40}
+				onFilter={jest.fn()}
+				onGenerate={onGenerate}
+				persona={PERSONA}
+				totalCount={24}
+			/>
+		);
+
+		fireEvent.click(getByLabelText('Champion, Awareness: 24'));
+
+		fireEvent.click(screen.getByText('generate'));
+
+		expect(onGenerate).toHaveBeenCalledWith(PERSONA, STAGE);
 	});
 
 	it('highlights the cell whose filter is applied', () => {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixHeader.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixHeader.spec.tsx
@@ -14,7 +14,16 @@ import {
 	PARTIAL_COVERAGE_MATRIX,
 } from '../../js/components/content_gap_matrix/services/fixtures';
 
+jest.mock('@liferay/ai-hub-cell-js-components-web', () => ({
+	AIAssistantChat: (props: {triggerLabel: string}) =>
+		require('react').createElement('button', null, props.triggerLabel),
+}));
+
 describe('ContentGapMatrixHeader', () => {
+	afterEach(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+	});
+
 	it('colors the coverage badge secondary at partial coverage', () => {
 		const {container} = render(
 			<ContentGapMatrixHeader data={PARTIAL_COVERAGE_MATRIX} />
@@ -84,5 +93,15 @@ describe('ContentGapMatrixHeader', () => {
 			getByText('x-critical-gaps', {exact: false})
 		).toBeInTheDocument();
 		expect(queryByText('no-assets-found')).not.toBeInTheDocument();
+	});
+
+	it('renders the AI insights trigger when the feature flag is enabled', () => {
+		Liferay.FeatureFlags['LPD-62272'] = true;
+
+		const {getByText} = render(
+			<ContentGapMatrixHeader data={PARTIAL_COVERAGE_MATRIX} />
+		);
+
+		expect(getByText('get-ai-insights')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -231,6 +231,11 @@ export default function AssetsFDSPropsTransformer({
 				}${additionalAPIURLParameters}`
 			: otherProps.apiURL;
 
+	const GENERATE_WITH_AI_ACTIONS = [
+		'generateContentWithAI',
+		'generateImageWithAI',
+	];
+
 	return {
 		...otherProps,
 		additionalAPIURLParameters,
@@ -249,7 +254,7 @@ export default function AssetsFDSPropsTransformer({
 				creationMenu.primaryItems,
 				ACTIONS
 			).map((item) =>
-				item.data?.action === 'generateContentWithAI'
+				GENERATE_WITH_AI_ACTIONS.includes(item.data?.action ?? '')
 					? {...item, className: 'cms-generate-content-with-ai'}
 					: item
 			),

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
@@ -231,4 +231,27 @@ describe('AssetsFDSPropsTransformer', () => {
 
 		expect(result.hideManagementBarInEmptyState).toBe(false);
 	});
+
+	it('marks the generate with AI creation menu items with the purple class', () => {
+		const result = AssetsFDSPropsTransformer({
+			additionalProps: mockAdditionalProps,
+			creationMenu: {
+				primaryItems: [
+					{data: {action: 'generateContentWithAI'}, label: 'content'},
+					{data: {action: 'generateImageWithAI'}, label: 'image'},
+					{data: {action: 'addFolder'}, label: 'folder'},
+				],
+			},
+			hideManagementBarInEmptyState: false,
+			id: 'com.liferay.site.cms.site.initializer-allSection',
+			views: [],
+		});
+
+		const [contentItem, imageItem, folderItem] =
+			result.creationMenu.primaryItems;
+
+		expect(contentItem.className).toBe('cms-generate-content-with-ai');
+		expect(imageItem.className).toBe('cms-generate-content-with-ai');
+		expect(folderItem.className).toBeUndefined();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99254
https://liferay.atlassian.net/browse/LPD-98763

## What Is Being Fixed

Two small, independent AI Assistant gaps, both by the same author, combined here to share one review:

- **LPD-99254** — an image generated by the AI Assistant could not be placed into a file upload field.
- **LPD-98763** — the content gap matrix had no entry point to generate content for a gap with the AI Assistant.

## How It Is Being Fixed

For LPD-99254, the assets FDS props transformer injects the generated AI image into the file upload field so the user does not have to download and re-upload it.

For LPD-98763, the content gap matrix components (cell, actions, card, grid, header) and the content coverage matrix fragment renderer surface the AI Assistant in the matrix header and let the user generate content for a gap directly from the matrix.

The cross-cutting pieces each feature touches (the AI Assistant chat and the shared `ViewAllRelatedAssets` view) live in the "AI Assistant Improvements" consolidation, so this PR carries only the feature-exclusive files and merges in any order with its sibling PRs without conflicts.

## PR Check

**pr-check: PASS** — tested on `6e25e6b25d614ad24dd44b8e10307d67369f813b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

`site-cms-site-initializer` (805/805) and `site-cmp-site-initializer` (184/184) both compile standalone with all unit tests passing.

<!-- pr-check {"result": "success", "sha": "6e25e6b25d614ad24dd44b8e10307d67369f813b"} -->
