### PR TITLE
LPD-94145 Restructure the AI Assistant chat into a shell and body

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -3,727 +3,188 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
-import ClayForm from '@clayui/form';
-import ClayIcon from '@clayui/icon';
-import ClayLayout from '@clayui/layout';
-import ClayLoadingIndicator from '@clayui/loading-indicator';
-import classNames from 'classnames';
-import {EventSource} from 'eventsource';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
+import React, {useId, useRef, useState} from 'react';
 
-import {
-	CATEGORIZE_EVENT,
-	CategorizeEventPayload,
-} from '../Categorization/events';
-import {ECategorizationAgent} from '../Categorization/types';
 import ReportFeedbackModal from '../ReportFeedback/ReportFeedbackModal';
-import submitPositiveReportFeedback from '../ReportFeedback/submitPositiveReportFeedback';
-import {
-	ChatContext,
-	createEventSource,
-	postChatByExternalReferenceCodeMessage,
-} from './api';
-import AIAssistantFooterDisclaimer from './components/AIAssistantFooterDisclaimer';
-import AIAssistantMessageBalloon from './components/AIAssistantMessageBalloon';
-import CategorizationMessageBalloon from './components/CategorizationMessageBalloon';
-import ContentTypeSelectorMessageBalloon, {
-	ContentType,
-} from './components/ContentTypeSelectorMessageBalloon';
-import ContentsMessageBalloon from './components/ContentsMessageBalloon';
-import ImageMessageBalloon from './components/ImageMessageBalloon';
-import UserMessageBalloon from './components/UserMessageBalloon';
-import {ChatMessageSentData, Message} from './types';
-import buildAssistantMessage from './utils/buildAssistantMessage';
-import parseContentDraftsMessage from './utils/parseContentDraftsMessage';
+import AIAssistantChatBody from './AIAssistantChatBody';
+import {ChatContext} from './api';
+import AIAssistantTrigger from './components/AIAssistantTrigger';
+import AIAssistantDropdown from './shells/AIAssistantDropdown';
+import AIAssistantSidebar from './shells/AIAssistantSidebar';
+import useAIChat from './useAIChat';
 
 import './chat.scss';
 
-interface ReportContext {
-	agentDefinitionExternalReferenceCodes: string[];
-	index: number;
-}
-
 type AIState = 'focused' | 'result' | 'result-readonly' | 'working';
+
+export type AIAssistantDisplayMode = 'dropdown' | 'sidebar' | 'toggle';
 
 interface AIAssistantChatProps {
 	aiState?: AIState;
 	context?: ChatContext;
-	embedded?: boolean;
+	displayMode?: AIAssistantDisplayMode;
+	enableFreeFormCategorization?: boolean;
 	getContext?: () => ChatContext;
 	hideTriggerLabel?: boolean;
 	initialMessage?: string;
 	instructionDefinitionScope: string;
+	pushContainer?: string;
 	quickActions?: string[];
+	sidebarBehavior?: 'overlay' | 'push';
 	triggerClassName?: string;
 	triggerLabel?: string;
 	triggerRound?: boolean;
 }
 
+// Renders the AI Assistant chat behind a trigger. The chat body is rendered
+// once into a stable node; the active shell (dropdown or sidebar, chosen by
+// displayMode) reparents that node, so switching shells never remounts it.
+
 const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	aiState,
 	context,
-	embedded = false,
+	displayMode = 'toggle',
+	enableFreeFormCategorization = false,
 	getContext,
 	hideTriggerLabel = false,
 	initialMessage,
 	instructionDefinitionScope,
+	pushContainer,
 	quickActions,
-	triggerRound = true,
+	sidebarBehavior,
 	triggerClassName,
-	triggerLabel = Liferay.Language.get('ai-assistant'),
+	triggerLabel,
+	triggerRound = true,
 }) => {
-	const [active, setActive] = useState<boolean>(false);
-	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
-		{}
-	);
-	const [isGenerating, setIsGenerating] = useState<boolean>(false);
-	const [messages, setMessages] = useState<Message[]>([]);
-	const [message, setMessage] = useState<string>('');
-	const [reportContext, setReportContext] = useState<ReportContext | null>(
-		null
-	);
+	const [expanded, setExpanded] = useState<boolean>(false);
+	const [open, setOpen] = useState<boolean>(false);
 
-	const handleThumbsUp = (index: number, item: Message) => {
-		if (feedbackGiven[index]) {
-			return;
-		}
+	const [bodyNode] = useState(() => {
+		const element = document.createElement('div');
 
-		setFeedbackGiven((previousFeedbackGiven) => ({
-			...previousFeedbackGiven,
-			[index]: true,
-		}));
+		element.style.display = 'contents';
 
-		submitPositiveReportFeedback({
-			agentDefinitionExternalReferenceCodes:
-				item.agentDefinitionExternalReferenceCodes ?? [],
-			surface: 'aiAssistant',
-		});
-	};
-	const eventSourceRef = useRef<EventSource | null>(null);
-	const eventSourceReference = useRef<string | null>(null);
-	const contextRef = useRef<ChatContext | undefined>(context);
-	const getContextRef = useRef<(() => ChatContext) | undefined>(getContext);
-	const runtimeContextRef = useRef<ChatContext>({});
-	const initialMessageRef = useRef<string | undefined>(initialMessage);
-	const initialMessageSentRef = useRef<boolean>(false);
-	const instructionDefinitionScopeRef = useRef<string>(
-		instructionDefinitionScope
-	);
-	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+		return element;
+	});
+
+	const sidebarId = useId();
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
-	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
-	const fileUploadSelectorRef = useRef<string | undefined>(undefined);
 
-	useEffect(() => {
-		contextRef.current = context;
-		getContextRef.current = getContext;
-		instructionDefinitionScopeRef.current = instructionDefinitionScope;
-	}, [context, getContext, instructionDefinitionScope]);
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
 
-	useEffect(() => {
-		const fieldElement = triggerRef.current?.closest(
-			'[data-ai-assistant-field-id]'
-		);
-
-		if (fieldElement) {
-			fileUploadSelectorRef.current = `[data-ai-assistant-field-id="${fieldElement.getAttribute(
-				'data-ai-assistant-field-id'
-			)}"]`;
+		if (!nextOpen) {
+			setExpanded(false);
 		}
-	}, []);
+	};
 
-	useEffect(() => {
-		setTimeout(() => {
-			const container = messagesContainerRef.current;
-
-			container?.scrollTo({
-				behavior: 'smooth',
-				top: container.scrollHeight,
-			});
-		}, 0);
-	}, [messages]);
-
-	const sendMessage = useCallback((text: string) => {
-		if (!text.trim()) {
-			return;
-		}
-
-		setMessages((previousMessages) => [
-			...previousMessages,
-			{sender: 'user', text},
-		]);
-
-		setMessage('');
-
-		if (eventSourceReference.current) {
-			setIsGenerating(true);
-
-			postChatByExternalReferenceCodeMessage({
-				chatContext: {
-					...contextRef.current,
-					...getContextRef.current?.(),
-					...runtimeContextRef.current,
-				},
-				eventSourceReference: eventSourceReference.current,
-				instructionDefinitionScope:
-					instructionDefinitionScopeRef.current,
-				message: text,
-			}).catch(() => setIsGenerating(false));
-		}
-	}, []);
-
-	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-
-		sendMessage(message);
-	}
-
-	function adjustTextAreaHeight(element: HTMLTextAreaElement) {
-		const textArea = element ?? textAreaRef.current;
-
-		if (!textArea) {
-			return;
-		}
-
-		const style = window.getComputedStyle(textArea);
-		const lineHeight =
-			parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2;
-		const maxHeight = lineHeight * 4;
-
-		textArea.style.height = 'auto';
-		const newHeight = Math.min(textArea.scrollHeight, maxHeight);
-		textArea.style.height = `${newHeight}px`;
-		textArea.style.overflowY =
-			textArea.scrollHeight > maxHeight ? 'auto' : 'hidden';
-	}
-
-	function handleTextAreaKeyDown(
-		event: React.KeyboardEvent<HTMLTextAreaElement>
-	) {
-		if (event.key !== 'Enter') {
-			event.stopPropagation();
-
-			return;
-		}
-
-		if (event.shiftKey) {
-			setTimeout(
-				() => adjustTextAreaHeight(event.target as HTMLTextAreaElement),
-				0
-			);
-
-			return;
-		}
-
-		event.preventDefault();
-
-		const form = (event.target as HTMLElement).closest(
-			'form'
-		) as HTMLFormElement | null;
-
-		if (form?.requestSubmit) {
-			form.requestSubmit();
-		}
-		else {
-			form?.dispatchEvent(
-				new Event('submit', {
-					bubbles: true,
-					cancelable: true,
-				})
-			);
-		}
-	}
-
-	const openAIAssistantChatConnection = useCallback(() => {
-		createEventSource().then((eventSource) => {
-			if (!eventSource) {
-				return;
+	const chat = useAIChat({
+		context,
+		enableFreeFormCategorization,
+		getContext,
+		initialMessage,
+		instructionDefinitionScope,
+		onCloseRequested: () => handleOpenChange(false),
+		onOpenRequested: (options) => {
+			if (options?.expanded) {
+				setExpanded(true);
 			}
 
-			eventSourceRef.current = eventSource;
+			handleOpenChange(true);
+		},
+		triggerRef,
+	});
 
-			eventSourceRef.current.addEventListener(
-				'Chat Message Sent',
-				(event) => {
-					try {
-						const dataJSON: ChatMessageSentData = JSON.parse(
-							event.data
-						);
-
-						const assistantMessage =
-							buildAssistantMessage(dataJSON);
-
-						setMessages((previousMessages) => {
-							const lastMessage = previousMessages.at(-1);
-							const messages = previousMessages.slice(0, -1);
-
-							if (
-								lastMessage?.images?.length &&
-								assistantMessage?.images?.length
-							) {
-								return [
-									...messages,
-									{
-										...assistantMessage,
-										images: [
-											...lastMessage.images,
-											...assistantMessage.images,
-										],
-									},
-								];
-							}
-
-							return [...previousMessages, assistantMessage];
-						});
-
-						setMessage('');
-					}
-					catch {
-						setMessages((previousMessages) => [
-							...previousMessages,
-							{error: true, sender: 'assistant', text: ''},
-						]);
-
-						return;
-					}
-					finally {
-						setIsGenerating(false);
-					}
-				}
-			);
-
-			eventSourceRef.current.addEventListener('Subscribe', (event) => {
-				eventSourceReference.current = event.data;
-
-				if (
-					initialMessageRef.current &&
-					!initialMessageSentRef.current
-				) {
-					initialMessageSentRef.current = true;
-
-					sendMessage(initialMessageRef.current);
-				}
-			});
-
-			eventSourceRef.current.addEventListener(
-				'Agent Invocation Failed',
-				(event) => {
-					let text = '';
-
-					try {
-						text = JSON.parse(event.data)['data'];
-					}
-					catch {
-						text = '';
-					}
-
-					setMessages((previousMessages) => [
-						...previousMessages,
-						{
-							error: true,
-							sender: 'assistant',
-							text,
-						},
-					]);
-
-					setIsGenerating(false);
-				}
-			);
-		});
-	}, [sendMessage]);
-
-	const closeAIAssistantChatConnection = useCallback(() => {
-		eventSourceRef.current?.close();
-
-		eventSourceRef.current = null;
-	}, []);
-
-	useEffect(() => {
-		openAIAssistantChatConnection();
-
-		return () => {
-			closeAIAssistantChatConnection();
-		};
-	}, [closeAIAssistantChatConnection, openAIAssistantChatConnection]);
-
-	useEffect(() => {
-		const handleOpen = (payload: {
-			contentTypes?: ContentType[];
-			context?: ChatContext;
-			message?: string;
-		}) => {
-			setActive(true);
-
-			runtimeContextRef.current = payload?.context ?? {};
-
-			if (payload?.contentTypes?.length) {
-				setMessages((previousMessages) => [
-					...previousMessages,
-					{
-						sender: 'user',
-						text: Liferay.Language.get('generate-content'),
-					},
-					{
-						contentTypes: payload.contentTypes,
-						sender: 'assistant',
-						text: Liferay.Language.get(
-							'what-type-of-content-do-you-want-to-generate'
-						),
-					},
-				]);
-			}
-			else if (payload?.message) {
-				sendMessage(payload.message);
-			}
-		};
-
-		Liferay.on('openAIAssistantChat', handleOpen);
-
-		return () => {
-			Liferay.detach('openAIAssistantChat', handleOpen);
-		};
-	}, [sendMessage]);
-
-	useEffect(() => {
-		const handleCategorize = (payload: CategorizeEventPayload) => {
-			setActive(true);
-
-			setMessages((previousMessages) => [
-				...previousMessages,
-				{
-					sender: 'user',
-					text:
-						payload.agent === ECategorizationAgent.AUTO_CATEGORIZE
-							? Liferay.Language.get('add-categories')
-							: Liferay.Language.get('generate-tags'),
-				},
-				{categorization: payload, sender: 'assistant', text: ''},
-			]);
-		};
-
-		Liferay.on(CATEGORIZE_EVENT, handleCategorize);
-
-		return () => {
-			Liferay.detach(CATEGORIZE_EVENT, handleCategorize);
-		};
-	}, []);
-
-	useEffect(() => {
-		const handleOpen = (payload: {
-			context?: ChatContext;
-			message?: string;
-		}) => {
-			setActive(true);
-
-			if (payload?.context) {
-				contextRef.current = {
-					...contextRef.current,
-					...payload.context,
-				};
-			}
-
-			if (payload?.message) {
-				sendMessage(payload.message);
-			}
-		};
-
-		Liferay.on('openAIAssistantChat', handleOpen);
-
-		return () => {
-			Liferay.detach('openAIAssistantChat', handleOpen);
-		};
-	}, [sendMessage]);
-
-	const chatSurface = (
-		<>
-			<div
-				className="ai-assistant-chat__messages-container"
-				ref={messagesContainerRef}
-			>
-				{!initialMessage && (
-					<AIAssistantMessageBalloon
-						error={false}
-						message="Hi! I can help you generate content, titles, tags, or
-						translate your work. What would you like to do?"
-					/>
-				)}
-
-				{messages.map((item, index) => {
-					if (item.sender === 'user') {
-						return (
-							<UserMessageBalloon
-								key={index}
-								message={item.text}
-							/>
-						);
-					}
-
-					if (item.categorization) {
-						return (
-							<CategorizationMessageBalloon
-								key={index}
-								{...item.categorization}
-							/>
-						);
-					}
-
-					if (item.contentTypes) {
-						return (
-							<ContentTypeSelectorMessageBalloon
-								contentTypes={item.contentTypes}
-								contextRef={runtimeContextRef}
-								key={index}
-								message={item.text}
-								sendMessage={sendMessage}
-							/>
-						);
-					}
-
-					if (parseContentDraftsMessage(item.text).drafts.length) {
-						return (
-							<ContentsMessageBalloon
-								key={index}
-								message={item.text}
-							/>
-						);
-					}
-
-					if (item.images?.length) {
-						const context = {
-							...contextRef.current,
-							...getContextRef.current?.(),
-						};
-
-						return (
-							<ImageMessageBalloon
-								images={item.images}
-								key={index}
-								saveProps={{
-									fileUploadSelector:
-										context.fileUploadSelector ??
-										fileUploadSelectorRef.current,
-									groupId: context.groupId,
-									objectEntryFolderExternalReferenceCode:
-										context.objectEntryFolderExternalReferenceCode,
-								}}
-							/>
-						);
-					}
-
-					return (
-						<AIAssistantMessageBalloon
-							error={item.error ?? false}
-							feedbackGiven={Boolean(feedbackGiven[index])}
-							key={index}
-							message={item.text}
-							onReport={
-								!item.error
-									? () =>
-											setReportContext({
-												agentDefinitionExternalReferenceCodes:
-													item.agentDefinitionExternalReferenceCodes ??
-													[],
-												index,
-											})
-									: undefined
-							}
-							onThumbsUp={
-								!item.error
-									? () => handleThumbsUp(index, item)
-									: undefined
-							}
-						/>
-					);
-				})}
-
-				{isGenerating && (
-					<div className="ai-assistant-chat__generating-balloon">
-						<div className="ai-assistant-chat__generating-balloon-indicator">
-							<ClayLoadingIndicator />
-						</div>
-
-						<span className="ai-assistant-chat__generating-loading-text">
-							{Liferay.Language.get('generating')}
-						</span>
-					</div>
-				)}
-			</div>
-
-			{!!quickActions?.length && (
-				<div className="ai-assistant-chat__quick-actions">
-					<span className="ai-assistant-chat__quick-actions-title">
-						{Liferay.Language.get('quick-actions')}
-					</span>
-
-					<div className="ai-assistant-chat__quick-actions-list">
-						{quickActions.map((quickAction) => (
-							<ClayButton
-								className="ai-assistant-chat__quick-action"
-								disabled={isGenerating}
-								displayType="secondary"
-								key={quickAction}
-								onClick={() => sendMessage(quickAction)}
-								size="xs"
-							>
-								<ClayIcon
-									className="ai-assistant-chat__quick-action-icon"
-									height={12}
-									spritemap={Liferay.Icons.spritemap}
-									symbol="stars"
-									width={12}
-								/>
-
-								{quickAction}
-							</ClayButton>
-						))}
-					</div>
-				</div>
-			)}
-
-			<ClayForm
-				className="ai-assistant-chat__form"
-				onSubmit={(event) => onSubmit(event)}
-			>
-				<div
-					className="ai-assistant-chat__input-row"
-					data-ai-state={aiState}
-				>
-					<textarea
-						className="ai-assistant-chat__input form-control"
-						id="assistant-user-input"
-						onChange={(event) => {
-							setMessage(event.target.value);
-							adjustTextAreaHeight(event.target);
-						}}
-						onKeyDown={(
-							event: React.KeyboardEvent<HTMLTextAreaElement>
-						) => {
-							handleTextAreaKeyDown(event);
-						}}
-						placeholder="Ask me anything..."
-						readOnly={isGenerating || !!aiState}
-						ref={textAreaRef}
-						rows={1}
-						value={message}
-					/>
-
-					<ClayButton
-						disabled={!message.trim()}
-						displayType="primary"
-						type="submit"
-					>
-						<ClayIcon
-							height={12}
-							spritemap={Liferay.Icons.spritemap}
-							symbol={isGenerating ? 'square' : 'order-arrow-up'}
-							width={12}
-						/>
-					</ClayButton>
-				</div>
-			</ClayForm>
-
-			<AIAssistantFooterDisclaimer />
-		</>
+	const chatBody = (
+		<AIAssistantChatBody
+			aiState={aiState}
+			chat={chat}
+			quickActions={quickActions}
+			showGreeting={!initialMessage}
+		/>
 	);
 
-	if (embedded) {
-		return (
-			<div className="ai-assistant ai-assistant-chat__embedded">
-				{chatSurface}
-			</div>
-		);
-	}
+	const reportFeedbackModal = chat.reportContext !== null && (
+		<ReportFeedbackModal
+			agentDefinitionExternalReferenceCodes={
+				chat.reportContext.agentDefinitionExternalReferenceCodes
+			}
+			onClose={() => chat.setReportContext(null)}
+			onSubmitted={() =>
+				chat.markFeedbackGiven(chat.reportContext!.index)
+			}
+			surface="aiAssistant"
+		/>
+	);
+
+	const trigger = (
+		<AIAssistantTrigger
+			className={triggerClassName}
+			hideLabel={hideTriggerLabel}
+			label={triggerLabel}
+			ref={triggerRef}
+			round={triggerRound}
+		/>
+	);
+
+	const sidebarActive =
+		displayMode === 'sidebar' || (displayMode === 'toggle' && expanded);
+
+	const sidebarEnabled = displayMode !== 'dropdown';
 
 	return (
-		<ClayDropDown
-			active={active}
-			alignmentPosition={4}
-			className="ai-assistant-chat__dropdown"
-			hasRightSymbols={false}
-			menuElementAttrs={{
-				className: 'cadmin',
-				style: {
-					height: 552,
-					maxHeight: 'none',
-					maxWidth: 'none',
-					overflow: 'hidden',
-					width: 448,
-				},
-			}}
-			onActiveChange={setActive}
-			trigger={
-				<ClayButton
-					aria-label={triggerLabel}
-					borderless
-					className={classNames(
-						'ai-assistant-chat__trigger',
-						triggerClassName
-					)}
-					displayType="secondary"
-					monospaced={triggerRound && hideTriggerLabel}
-					ref={triggerRef}
-					rounded={triggerRound}
-				>
-					<ClayIcon
-						height={16}
-						spritemap={Liferay.Icons.spritemap}
-						symbol="stars"
-						width={16}
-					/>
-
-					{!hideTriggerLabel && (
-						<span className="ai-assistant-chat__trigger-label">
-							{triggerLabel}
-						</span>
-					)}
-				</ClayButton>
-			}
-		>
-			<div className="ai-assistant ai-assistant-chat__dropdown-container">
-				<div className="ai-assistant-chat__dropdown-header">
-					<ClayLayout.ContentRow className="ai-assistant-chat__dropdown-header-row">
-						<ClayLayout.ContentCol className="ai-assistant-chat__dropdown-title">
-							{Liferay.Language.get('ai-assistant')}
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol>
-							<ClayButton
-								aria-label={Liferay.Language.get('close')}
-								borderless
-								displayType="unstyled"
-								onClick={() => setActive(false)}
-							>
-								<ClayIcon
-									className="ai-assistant-chat__dropdown-close-button"
-									spritemap={Liferay.Icons.spritemap}
-									symbol="times"
-								/>
-							</ClayButton>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</div>
-
-				{chatSurface}
-			</div>
-
-			{reportContext !== null && (
-				<ReportFeedbackModal
-					agentDefinitionExternalReferenceCodes={
-						reportContext.agentDefinitionExternalReferenceCodes
+		<>
+			{sidebarActive ? (
+				React.cloneElement(trigger, {
+					'aria-controls': sidebarId,
+					'aria-expanded': open,
+					'onClick': () => handleOpenChange(!open),
+				})
+			) : (
+				<AIAssistantDropdown
+					active={open}
+					bodyNode={bodyNode}
+					onActiveChange={handleOpenChange}
+					onExpand={
+						displayMode === 'toggle'
+							? () => setExpanded(true)
+							: undefined
 					}
-					onClose={() => setReportContext(null)}
-					onSubmitted={() =>
-						setFeedbackGiven((previousFeedbackGiven) => ({
-							...previousFeedbackGiven,
-							[reportContext.index]: true,
-						}))
-					}
-					surface="aiAssistant"
+					trigger={trigger}
 				/>
 			)}
-		</ClayDropDown>
+
+			{sidebarEnabled && (
+				<AIAssistantSidebar
+					active={sidebarActive}
+					behavior={sidebarBehavior}
+					bodyNode={bodyNode}
+					id={sidebarId}
+					onCollapse={
+						displayMode === 'toggle'
+							? () => {
+									setExpanded(false);
+
+									requestAnimationFrame(() =>
+										triggerRef.current?.focus()
+									);
+								}
+							: undefined
+					}
+					onOpenChange={handleOpenChange}
+					open={open && sidebarActive}
+					pushContainer={pushContainer}
+					triggerRef={triggerRef}
+				/>
+			)}
+
+			<ReactPortal container={bodyNode} wrapper={false}>
+				{chatBody}
+			</ReactPortal>
+
+			{reportFeedbackModal}
+		</>
 	);
 };
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
@@ -1,0 +1,367 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {autoSize as AutoSize} from 'frontend-js-web';
+import React, {useEffect, useRef} from 'react';
+
+import AIAssistantFooterDisclaimer from './components/AIAssistantFooterDisclaimer';
+import AIAssistantMessageBalloon from './components/AIAssistantMessageBalloon';
+import CategorizationMessageBalloon from './components/CategorizationMessageBalloon';
+import ContentTypeSelectorMessageBalloon from './components/ContentTypeSelectorMessageBalloon';
+import ContentsMessageBalloon from './components/ContentsMessageBalloon';
+import FieldValueMessageBalloon from './components/FieldValueMessageBalloon';
+import ImageMessageBalloon from './components/ImageMessageBalloon';
+import TranslateContentMessageBalloon from './components/TranslateContentMessageBalloon';
+import UserMessageBalloon from './components/UserMessageBalloon';
+import {
+	APPLY_OBJECT_FIELD_VALUES_EVENT,
+	GENERATE_FIELD_VALUE_AGENT_EXTERNAL_REFERENCE_CODE,
+} from './events';
+import {AIChat} from './useAIChat';
+import getGeneratedFieldValues from './utils/getGeneratedFieldValues';
+import parseContentDraftsMessage from './utils/parseContentDraftsMessage';
+
+type AIState = 'focused' | 'result' | 'result-readonly' | 'working';
+
+interface AIAssistantChatBodyProps {
+	aiState?: AIState;
+	chat: AIChat;
+	quickActions?: string[];
+	showGreeting: boolean;
+}
+
+const AIAssistantChatBody: React.FC<AIAssistantChatBodyProps> = ({
+	aiState,
+	chat,
+	quickActions,
+	showGreeting,
+}) => {
+	const {
+		contextRef,
+		feedbackGiven,
+		fileUploadSelectorRef,
+		getContextRef,
+		giveThumbsUp,
+		isGenerating,
+		message,
+		messages,
+		messagesEndRef,
+		runtimeContextRef,
+		sendMessage,
+		setIsGenerating,
+		setMessage,
+		setReportContext,
+		sourceLanguageIdRef,
+	} = chat;
+
+	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+
+	useEffect(() => {
+		if (textAreaRef.current) {
+			new AutoSize(textAreaRef.current);
+		}
+	}, []);
+
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView();
+	}, [messagesEndRef]);
+
+	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		sendMessage(message);
+	}
+
+	function handleTextAreaKeyDown(
+		event: React.KeyboardEvent<HTMLTextAreaElement>
+	) {
+		if (event.key !== 'Enter') {
+			event.stopPropagation();
+
+			return;
+		}
+
+		if (event.shiftKey) {
+			return;
+		}
+
+		event.preventDefault();
+
+		const form = (event.target as HTMLElement).closest(
+			'form'
+		) as HTMLFormElement | null;
+
+		if (form?.requestSubmit) {
+			form.requestSubmit();
+		}
+		else {
+			form?.dispatchEvent(
+				new Event('submit', {
+					bubbles: true,
+					cancelable: true,
+				})
+			);
+		}
+	}
+
+	return (
+		<>
+			<div className="ai-assistant-chat__messages-container">
+				{showGreeting && (
+					<AIAssistantMessageBalloon
+						error={false}
+						message={Liferay.Language.get(
+							'hi-i-can-help-you-generate-content-titles-tags-or-translate-your-work'
+						)}
+					/>
+				)}
+
+				{messages.map((item, index) => {
+					if (item.sender === 'user') {
+						return (
+							<UserMessageBalloon
+								key={index}
+								message={item.text}
+							/>
+						);
+					}
+
+					if (item.categorization) {
+						return (
+							<CategorizationMessageBalloon
+								key={index}
+								{...item.categorization}
+							/>
+						);
+					}
+
+					if (item.images?.length) {
+						const context = {
+							...contextRef.current,
+							...getContextRef.current?.(),
+						};
+
+						return (
+							<ImageMessageBalloon
+								images={item.images}
+								key={index}
+								saveProps={{
+									fileUploadSelector:
+										context.fileUploadSelector ??
+										fileUploadSelectorRef.current,
+									groupId: context.groupId,
+									objectEntryFolderExternalReferenceCode:
+										context.objectEntryFolderExternalReferenceCode,
+								}}
+							/>
+						);
+					}
+
+					if (item.contentTypes) {
+						return (
+							<ContentTypeSelectorMessageBalloon
+								contentTypes={item.contentTypes}
+								contextRef={runtimeContextRef}
+								key={index}
+								message={item.text}
+								sendMessage={sendMessage}
+							/>
+						);
+					}
+
+					if (parseContentDraftsMessage(item.text).drafts.length) {
+						return (
+							<ContentsMessageBalloon
+								key={index}
+								message={item.text}
+							/>
+						);
+					}
+
+					try {
+						const json = JSON.parse(
+							item.text
+								.trim()
+								.replace(/^```(?:json)?/i, '')
+								.replace(/```$/, '')
+								.trim()
+						);
+
+						if (json?.action === 'translate') {
+							const {
+								agentInstanceId,
+								availableLanguageIds,
+								results,
+								targetLanguageIds,
+							} = json;
+
+							return (
+								<TranslateContentMessageBalloon
+									agentInstanceId={agentInstanceId}
+									availableLanguageIds={availableLanguageIds}
+									key={index}
+									requestedLanguageIds={targetLanguageIds}
+									results={results}
+									setIsGenerating={setIsGenerating}
+									sourceLanguageIdRef={sourceLanguageIdRef}
+								/>
+							);
+						}
+					}
+					catch {}
+
+					const fieldValues =
+						!item.error &&
+						item.agentDefinitionExternalReferenceCodes?.includes(
+							GENERATE_FIELD_VALUE_AGENT_EXTERNAL_REFERENCE_CODE
+						)
+							? getGeneratedFieldValues(item.text)
+							: {};
+
+					if (Object.keys(fieldValues).length) {
+						const previousMessage = messages[index - 1];
+
+						return (
+							<FieldValueMessageBalloon
+								key={index}
+								onApply={() =>
+									Liferay.fire(
+										APPLY_OBJECT_FIELD_VALUES_EVENT,
+										{
+											values: fieldValues,
+										}
+									)
+								}
+								onRegenerate={() => {
+									if (previousMessage?.sender === 'user') {
+										sendMessage(previousMessage.text);
+									}
+								}}
+								values={fieldValues}
+							/>
+						);
+					}
+
+					return (
+						<AIAssistantMessageBalloon
+							error={item.error ?? false}
+							feedbackGiven={Boolean(feedbackGiven[index])}
+							key={index}
+							message={item.text}
+							onReport={
+								!item.error
+									? () =>
+											setReportContext({
+												agentDefinitionExternalReferenceCodes:
+													item.agentDefinitionExternalReferenceCodes ??
+													[],
+												index,
+											})
+									: undefined
+							}
+							onThumbsUp={
+								!item.error
+									? () => giveThumbsUp(index, item)
+									: undefined
+							}
+						/>
+					);
+				})}
+
+				{isGenerating && (
+					<div className="ai-assistant-chat__generating-balloon">
+						<div className="ai-assistant-chat__generating-balloon-indicator">
+							<ClayLoadingIndicator />
+						</div>
+
+						<span className="ai-assistant-chat__generating-loading-text">
+							{Liferay.Language.get('generating')}
+						</span>
+					</div>
+				)}
+
+				<div ref={messagesEndRef} />
+			</div>
+
+			{!!quickActions?.length && (
+				<div className="ai-assistant-chat__quick-actions">
+					<span className="ai-assistant-chat__quick-actions-title">
+						{Liferay.Language.get('quick-actions')}
+					</span>
+
+					<div className="ai-assistant-chat__quick-actions-list">
+						{quickActions.map((quickAction) => (
+							<ClayButton
+								className="ai-assistant-chat__quick-action"
+								disabled={isGenerating}
+								displayType="secondary"
+								key={quickAction}
+								onClick={() => sendMessage(quickAction)}
+								size="xs"
+							>
+								<ClayIcon
+									className="ai-assistant-chat__quick-action-icon"
+									height={12}
+									spritemap={Liferay.Icons.spritemap}
+									symbol="stars"
+									width={12}
+								/>
+
+								{quickAction}
+							</ClayButton>
+						))}
+					</div>
+				</div>
+			)}
+
+			<ClayForm
+				className="ai-assistant-chat__form"
+				onSubmit={(event) => onSubmit(event)}
+			>
+				<div
+					className="ai-assistant-chat__input-row"
+					data-ai-state={aiState}
+				>
+					<textarea
+						className="ai-assistant-chat__input form-control"
+						id="assistant-user-input"
+						onChange={(event) => setMessage(event.target.value)}
+						onKeyDown={(
+							event: React.KeyboardEvent<HTMLTextAreaElement>
+						) => {
+							handleTextAreaKeyDown(event);
+						}}
+						placeholder="Ask me anything..."
+						readOnly={isGenerating || !!aiState}
+						ref={textAreaRef}
+						rows={1}
+						value={message}
+					/>
+
+					<ClayButton
+						disabled={!message.trim()}
+						displayType="primary"
+						type="submit"
+					>
+						<ClayIcon
+							height={12}
+							spritemap={Liferay.Icons.spritemap}
+							symbol={isGenerating ? 'square' : 'order-arrow-up'}
+							width={12}
+						/>
+					</ClayButton>
+				</div>
+			</ClayForm>
+
+			<AIAssistantFooterDisclaimer />
+		</>
+	);
+};
+
+export default AIAssistantChatBody;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -1,4 +1,8 @@
-@import 'cadmin-variables';
+@import '../variables';
+
+// Must match SIDEBAR_WIDTH in shells/AIAssistantSidebar.tsx.
+
+$ai-assistant-sidebar-width: 448px;
 
 @mixin ai-assistant-chat-gutter {
 	padding-left: 1rem;
@@ -15,6 +19,10 @@ html#{$cadmin-selector} {
 	.ai-assistant-chat__dropdown {
 		display: flex;
 		padding: 0;
+	}
+
+	.ai-assistant-chat__language-id-icon {
+		margin-right: 0.5rem;
 	}
 
 	.ai-assistant-chat__trigger.btn {
@@ -55,51 +63,95 @@ html#{$cadmin-selector} {
 	}
 }
 
+// The push marker lands on the host page's content container, outside any
+// cadmin scope; two classes outrank Clay's single-class padding rule.
+
+.ai-assistant-sidebar-push.c-slideout-push-end {
+	padding-right: $ai-assistant-sidebar-width;
+
+	// Mirrors Clay's media-breakpoint-down(md) rule on .c-slideout-push-end.
+
+	@media (max-width: 991.98px) {
+		padding-right: 0;
+	}
+}
+
 html#{$cadmin-selector} .cadmin {
-	.ai-assistant-chat__embedded {
-		height: 100%;
-		padding-top: 1rem;
+	&.ai-assistant-chat__panel {
+		height: 552px;
+		max-height: none;
+		max-width: none;
+		overflow: hidden;
+		width: 448px;
+	}
 
-		.ai-assistant-chat__messages-container {
-			min-height: 200px;
-		}
+	&.ai-assistant-sidebar-root > .c-slideout {
+		// SidePanel only writes a valid inline top when it can measure a
+		// container; without one the browser discards the inline value and
+		// this fallback docks the panel below the control menu and any CMS
+		// top bar. Clay's own bottom: 0 stretches it to the viewport bottom.
 
-		.ai-assistant-chat__quick-actions-title {
-			display: block;
-			margin-bottom: 0.5rem;
+		top: calc(
+			var(--control-menu-container-height, 0px) +
+				var(--top-bar-height, 0px)
+		);
+	}
+
+	.ai-assistant-sidebar {
+		border-left: $cadmin-border-width solid $cadmin-border-color;
+		border-radius: 0;
+		max-width: 100vw;
+	}
+
+	.ai-assistant-chat__panel-header {
+		flex-shrink: 0;
+		margin-bottom: 1rem;
+		padding-left: 1.5rem;
+		padding-right: 1.5rem;
+		padding-top: 0.5rem;
+
+		&-row {
+			align-items: center;
+			border-bottom: $cadmin-border-width solid $cadmin-border-color;
+			justify-content: space-between;
+			padding-bottom: 0.5rem;
 		}
 	}
 
+	.ai-assistant-chat__panel-title {
+		color: $cadmin-gray-900;
+		font-weight: 600;
+	}
+
+	.ai-assistant-chat__panel-actions {
+		align-items: center;
+		display: flex;
+	}
+
+	.ai-assistant-chat__panel-actions-separator {
+		align-self: center;
+		background-color: $cadmin-gray-500;
+		height: 16px;
+		margin-left: 0.5rem;
+		margin-right: 0.5rem;
+		width: 1px;
+	}
+
+	.ai-assistant-chat__panel-close-button,
+	.ai-assistant-chat__panel-expand-button {
+		color: $cadmin-gray-600;
+	}
+
+	.ai-assistant-chat__body-slot {
+		display: contents;
+	}
+
 	.ai-assistant-chat__dropdown-container,
-	.ai-assistant-chat__embedded {
+	.ai-assistant-chat__sidebar-container {
 		display: flex;
 		flex-direction: column;
 		height: 100%;
 		width: 100%;
-
-		.ai-assistant-chat__dropdown-close-button {
-			color: $cadmin-gray-600;
-		}
-
-		.ai-assistant-chat__dropdown-header {
-			flex-shrink: 0;
-			margin-bottom: 1rem;
-			padding-left: 1.5rem;
-			padding-right: 1.5rem;
-			padding-top: 0.5rem;
-
-			&-row {
-				align-items: center;
-				border-bottom: $cadmin-border-width solid $cadmin-border-color;
-				justify-content: space-between;
-				padding-bottom: 0.5rem;
-			}
-		}
-
-		.ai-assistant-chat__dropdown-title {
-			color: $cadmin-gray-900;
-			font-weight: 600;
-		}
 
 		.ai-assistant-chat__footer-disclaimer {
 			@include ai-assistant-chat-gutter;
@@ -198,8 +250,12 @@ html#{$cadmin-selector} .cadmin {
 		}
 
 		.ai-assistant-chat__generating-loading-text {
+			-webkit-background-clip: text;
+			-webkit-text-fill-color: transparent;
 			align-self: center;
-			color: $cadmin-primary;
+			background-clip: text;
+			background-image: $ai-loading-gradient;
+			color: transparent;
 			font-weight: 600;
 			margin: 0.5rem;
 		}
@@ -207,51 +263,12 @@ html#{$cadmin-selector} .cadmin {
 			background: $cadmin-danger-l2;
 		}
 		.ai-assistant-chat__ai-assistant-message-balloon {
-			background: $cadmin-gray-100;
-		}
-
-		.ai-assistant-chat__content-generation-balloon {
 			display: flex;
 			flex-direction: column;
 			margin-bottom: 0.5rem;
 
-			&-header {
-				align-items: flex-start;
-				display: flex;
-				gap: 0.5rem;
-				padding: 0.5rem;
-
-				.lexicon-icon {
-					color: $cadmin-primary;
-					flex-shrink: 0;
-					margin-top: 0.125rem;
-				}
-			}
-
-			&-form {
-				display: flex;
-				flex-direction: column;
-				gap: 0.5rem;
-				padding: 0.5rem;
-			}
-
-			&-icon {
-				align-items: center;
-				border: $cadmin-border-width solid $cadmin-border-color;
-				border-radius: 0.25rem;
-				color: $cadmin-gray-900;
-				display: inline-flex;
-				justify-content: center;
-				padding: 0.375rem;
-
-				.lexicon-icon {
-					margin-top: initial;
-				}
-			}
-
-			&-list {
-				background: transparent;
-				margin: 0 0.5rem 0.5rem;
+			p:last-child {
+				margin-bottom: 0;
 			}
 		}
 
@@ -332,8 +349,97 @@ html#{$cadmin-selector} .cadmin {
 			}
 		}
 
+		.ai-assistant-chat__content-generation-balloon {
+			display: flex;
+			flex-direction: column;
+			margin-bottom: 0.5rem;
+
+			&-header {
+				align-items: flex-start;
+				display: flex;
+				gap: 0.5rem;
+				padding: 0.5rem;
+
+				.lexicon-icon {
+					color: $cadmin-primary;
+					flex-shrink: 0;
+					margin-top: 0.125rem;
+				}
+			}
+
+			&-form {
+				display: flex;
+				flex-direction: column;
+				gap: 0.5rem;
+				padding: 0.5rem;
+			}
+
+			&-icon {
+				align-items: center;
+				border: $cadmin-border-width solid $cadmin-border-color;
+				border-radius: 0.25rem;
+				color: $cadmin-gray-900;
+				display: inline-flex;
+				justify-content: center;
+				padding: 0.375rem;
+
+				.lexicon-icon {
+					margin-top: initial;
+				}
+			}
+
+			&-list {
+				background: transparent;
+				margin: 0 0.5rem 0.5rem;
+			}
+		}
+
+		.ai-assistant-chat__language-select {
+			margin: 0.5rem;
+
+			.form-control,
+			input {
+				cursor: pointer;
+			}
+		}
+
+		.ai-assistant-chat__message-header {
+			display: flex;
+			flex-direction: row;
+
+			&-icon {
+				color: $cadmin-primary;
+				display: inline-block;
+				font-size: 12px;
+				margin-left: 0.5rem;
+				margin-top: 0.5rem;
+			}
+
+			&-text {
+				margin: 0.5rem;
+			}
+		}
+
+		.ai-assistant-chat__translation-review {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin: 0.5rem;
+		}
+
 		.ai-feedback-actions-row {
 			gap: 0.375rem;
+		}
+
+		.ai-assistant-chat__user-action {
+			display: flex;
+			gap: 0.5rem;
+			justify-content: flex-end;
+			margin-bottom: 0.5rem;
+
+			.btn {
+				border-radius: 0.5rem;
+			}
 		}
 
 		.ai-assistant-chat__user-image {
@@ -357,12 +463,37 @@ html#{$cadmin-selector} .cadmin {
 		}
 
 		.ai-assistant-chat__user-message {
-			max-width: 70%;
+			align-items: center;
+			display: flex;
+			justify-content: flex-end;
+			margin-bottom: 0.5rem;
+
+			&-avatar {
+				flex-shrink: 0;
+				margin-left: 0.5rem;
+			}
+
+			&-content {
+				background: $cadmin-gray-100;
+				border-radius: 0.5rem;
+				max-width: 70%;
+				overflow-wrap: break-word;
+				padding: 0.5rem;
+			}
 		}
 
 		.ai-assistant-chat__suggestion-hint {
 			color: $cadmin-purple;
 		}
+	}
+
+	// The sidebar container shares the panel height with the header above
+	// it, so it grows into the remaining space instead of the full height.
+
+	.ai-assistant-chat__sidebar-container {
+		flex-grow: 1;
+		height: auto;
+		min-height: 0;
 	}
 
 	.ai-assistant {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloon.tsx
@@ -28,11 +28,11 @@ const AssistantMessageBalloon: React.FC<AssistantMessageBalloonProps> = ({
 }) => {
 	return (
 		<div
-			className={`d-flex flex-column mb-2 rounded ${error ? 'ai-assistant-chat__ai-assistant-error-message-balloon' : 'ai-assistant-chat__ai-assistant-message-balloon'}`}
+			className={`${error ? 'ai-assistant-chat__ai-assistant-error-message-balloon' : 'ai-assistant-chat__ai-assistant-message-balloon'} d-flex flex-column mb-2 rounded`}
 		>
-			<div className="d-flex flex-row font-weight-semi-bold">
+			<div className="d-flex flex-row">
 				<div
-					className={`align-items-start d-inline-block ml-2 mt-2 text-2 ${error ? 'text-danger' : 'text-primary'}`}
+					className={`align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 ${error ? 'text-danger' : 'text-primary'}`}
 				>
 					<ClayIcon
 						spritemap={Liferay.Icons.spritemap}
@@ -47,7 +47,7 @@ const AssistantMessageBalloon: React.FC<AssistantMessageBalloonProps> = ({
 					</span>
 				) : (
 					<div
-						className="m-2"
+						className="flex-grow-1 m-2"
 						dangerouslySetInnerHTML={{
 							__html: renderAIAssistantMessageMarkdown(message),
 						}}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+interface AIAssistantPanelHeaderProps {
+	expanded?: boolean;
+	onClose: () => void;
+	onToggleExpanded?: () => void;
+}
+
+const AIAssistantPanelHeader: React.FC<AIAssistantPanelHeaderProps> = ({
+	expanded = false,
+	onClose,
+	onToggleExpanded,
+}) => {
+	return (
+		<div className="ai-assistant-chat__panel-header">
+			<ClayLayout.ContentRow className="ai-assistant-chat__panel-header-row">
+				<ClayLayout.ContentCol className="ai-assistant-chat__panel-title">
+					{Liferay.Language.get('ai-assistant')}
+				</ClayLayout.ContentCol>
+
+				<ClayLayout.ContentCol>
+					<div className="ai-assistant-chat__panel-actions">
+						{onToggleExpanded && (
+							<>
+								<ClayButton
+									aria-label={
+										expanded
+											? Liferay.Language.get('minimize')
+											: Liferay.Language.get('maximize')
+									}
+									borderless
+									displayType="unstyled"
+									onClick={onToggleExpanded}
+								>
+									<ClayIcon
+										className="ai-assistant-chat__panel-expand-button"
+										spritemap={Liferay.Icons.spritemap}
+										symbol={
+											expanded ? 'compress' : 'full-size'
+										}
+									/>
+								</ClayButton>
+
+								<div className="ai-assistant-chat__panel-actions-separator" />
+							</>
+						)}
+
+						<ClayButton
+							aria-label={Liferay.Language.get('close')}
+							borderless
+							displayType="unstyled"
+							onClick={onClose}
+						>
+							<ClayIcon
+								className="ai-assistant-chat__panel-close-button"
+								spritemap={Liferay.Icons.spritemap}
+								symbol="times"
+							/>
+						</ClayButton>
+					</div>
+				</ClayLayout.ContentCol>
+			</ClayLayout.ContentRow>
+		</div>
+	);
+};
+
+export default AIAssistantPanelHeader;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantTrigger.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantTrigger.tsx
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+interface AIAssistantTriggerProps
+	extends Omit<React.ComponentProps<typeof ClayButton>, 'displayType'> {
+	hideLabel?: boolean;
+	label?: string;
+	round?: boolean;
+}
+
+const AIAssistantTrigger = React.forwardRef<
+	HTMLButtonElement,
+	AIAssistantTriggerProps
+>(({className, hideLabel = false, label, round = true, ...otherProps}, ref) => {
+	const triggerLabel = label ?? Liferay.Language.get('ai-assistant');
+
+	return (
+		<ClayButton
+			aria-label={triggerLabel}
+			borderless
+			{...otherProps}
+			className={classNames('ai-assistant-chat__trigger', className)}
+			displayType="secondary"
+			monospaced={round && hideLabel}
+			ref={ref}
+			rounded={round}
+		>
+			<ClayIcon
+				height={16}
+				spritemap={Liferay.Icons.spritemap}
+				symbol="stars"
+				width={16}
+			/>
+
+			{!hideLabel && (
+				<span className="ai-assistant-chat__trigger-label">
+					{triggerLabel}
+				</span>
+			)}
+		</ClayButton>
+	);
+});
+
+AIAssistantTrigger.displayName = 'AIAssistantTrigger';
+
+export default AIAssistantTrigger;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import CategorizationSuggestions from '../../Categorization/components/CategorizationSuggestions';
@@ -25,12 +28,15 @@ export default function CategorizationMessageBalloon({
 	cmsGroupId,
 	content,
 	count,
+	currentCategoryIds,
+	currentTagNames,
 	scopeId,
+	targets,
 }: CategorizeEventPayload) {
 	const [committed, setCommitted] = useState(false);
 	const [dismissed, setDismissed] = useState<string[]>([]);
 
-	const {regenerate, run, status, suggestions} =
+	const {regenerate, resolveTargets, run, status, suggestions} =
 		useCategorizationAgent(agent);
 
 	useEffect(() => {
@@ -72,7 +78,14 @@ export default function CategorizationMessageBalloon({
 					? await fetchCandidateCategories()
 					: await fetchExistingTags();
 
-			if (active) {
+			if (!active) {
+				return;
+			}
+
+			if (targets?.length) {
+				resolveTargets({content, count, ...data}, targets);
+			}
+			else {
 				run({content, count, ...data});
 			}
 		})();
@@ -80,44 +93,117 @@ export default function CategorizationMessageBalloon({
 		return () => {
 			active = false;
 		};
-	}, [agent, classNameId, cmsGroupId, content, count, run, scopeId]);
+	}, [
+		agent,
+		classNameId,
+		cmsGroupId,
+		content,
+		count,
+		resolveTargets,
+		run,
+		scopeId,
+		targets,
+	]);
 
 	const visibleSuggestions = suggestions.filter(
 		(suggestion) => !dismissed.includes(getKey(suggestion))
 	);
 
+	const isCategories = agent === ECategorizationAgent.AUTO_CATEGORIZE;
+
+	const newCategoryCount = visibleSuggestions.filter(
+		(suggestion) =>
+			typeof suggestion.id === 'number' &&
+			!(currentCategoryIds ?? []).includes(suggestion.id)
+	).length;
+
+	const lowerCaseCurrentTagNames = (currentTagNames ?? []).map((name) =>
+		name.toLowerCase()
+	);
+
+	const newTagCount = visibleSuggestions.filter(
+		(suggestion) =>
+			!lowerCaseCurrentTagNames.includes(suggestion.name.toLowerCase())
+	).length;
+
+	const committedCount = isCategories ? newCategoryCount : newTagCount;
+
+	const confirmationMessage = sub(
+		isCategories
+			? Liferay.Language.get(
+					'great-i-have-added-x-categories-to-your-content'
+				)
+			: Liferay.Language.get('great-i-have-added-x-tags-to-your-content'),
+		`${committedCount}`
+	);
+
+	const isLoading = status === 'idle' || status === 'loading';
+
 	return (
-		<div className="ai-assistant-chat__ai-assistant-message-balloon mb-2 p-2 rounded">
-			<CategorizationSuggestions
-				committed={committed}
-				kind={
-					agent === ECategorizationAgent.AUTO_CATEGORIZE
-						? 'categories'
-						: 'tags'
-				}
-				onCommit={(committedSuggestions) => {
-					Liferay.fire(COMMIT_EVENT, {
-						agent,
-						suggestions: committedSuggestions,
-					});
+		<>
+			<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+				<div className="d-flex flex-row">
+					<div
+						className={`align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 ${isLoading ? '' : 'text-primary'}`}
+					>
+						{isLoading ? (
+							<ClayLoadingIndicator size="sm" />
+						) : (
+							<ClayIcon
+								spritemap={Liferay.Icons.spritemap}
+								symbol="stars"
+							/>
+						)}
+					</div>
 
-					setCommitted(true);
-				}}
-				onDismiss={(suggestion) =>
-					setDismissed((previousDismissed) => [
-						...previousDismissed,
-						getKey(suggestion),
-					])
-				}
-				onRegenerate={() => {
-					setCommitted(false);
-					setDismissed([]);
+					<div className="flex-grow-1 m-2">
+						<CategorizationSuggestions
+							committed={committed}
+							kind={isCategories ? 'categories' : 'tags'}
+							onCommit={(committedSuggestions) => {
+								Liferay.fire(COMMIT_EVENT, {
+									agent,
+									scopeId,
+									suggestions: committedSuggestions,
+								});
 
-					regenerate();
-				}}
-				status={status === 'idle' ? 'loading' : status}
-				suggestions={visibleSuggestions}
-			/>
-		</div>
+								setCommitted(true);
+							}}
+							onDismiss={(suggestion) =>
+								setDismissed((previousDismissed) => [
+									...previousDismissed,
+									getKey(suggestion),
+								])
+							}
+							onRegenerate={() => {
+								setCommitted(false);
+								setDismissed([]);
+
+								regenerate();
+							}}
+							status={status === 'idle' ? 'loading' : status}
+							suggestions={visibleSuggestions}
+						/>
+					</div>
+				</div>
+			</div>
+
+			{committed && committedCount > 0 ? (
+				<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+					<div className="d-flex flex-row">
+						<div className="align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 text-primary">
+							<ClayIcon
+								spritemap={Liferay.Icons.spritemap}
+								symbol="stars"
+							/>
+						</div>
+
+						<div className="flex-grow-1 m-2">
+							{confirmationMessage}
+						</div>
+					</div>
+				</div>
+			) : null}
+		</>
 	);
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import React, {useState} from 'react';
+
+import '../chat.scss';
+import renderAIAssistantMessageMarkdown from '../utils/renderAIAssistantMessageMarkdown';
+
+interface FieldValueMessageBalloonProps {
+	onApply: () => void;
+	onRegenerate: () => void;
+	values: Record<string, string>;
+}
+
+const FieldValueMessageBalloon: React.FC<FieldValueMessageBalloonProps> = ({
+	onApply,
+	onRegenerate,
+	values,
+}) => {
+	const [applied, setApplied] = useState(false);
+
+	return (
+		<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
+			<div className="d-flex flex-row font-weight-semi-bold">
+				<div className="align-items-start d-inline-block ml-2 mt-2 text-2 text-primary">
+					<ClayIcon
+						spritemap={Liferay.Icons.spritemap}
+						symbol="stars"
+					/>
+				</div>
+
+				<div
+					className="m-2"
+					dangerouslySetInnerHTML={{
+						__html: renderAIAssistantMessageMarkdown(
+							Object.values(values).join('\n\n')
+						),
+					}}
+				/>
+			</div>
+
+			<div className="d-flex justify-content-end mb-2 mr-2">
+				<ClayButton
+					className="mr-2"
+					disabled={applied}
+					displayType="secondary"
+					onClick={onRegenerate}
+					size="sm"
+				>
+					<ClayIcon
+						className="mr-2"
+						spritemap={Liferay.Icons.spritemap}
+						symbol="reload"
+					/>
+
+					{Liferay.Language.get('regenerate')}
+				</ClayButton>
+
+				<ClayButton
+					disabled={applied}
+					displayType="primary"
+					onClick={() => {
+						setApplied(true);
+
+						onApply();
+					}}
+					size="sm"
+				>
+					{Liferay.Language.get('apply')}
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default FieldValueMessageBalloon;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon.tsx
@@ -1,0 +1,198 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {ClayCheckbox} from '@clayui/form';
+import ClayMultiSelect from '@clayui/multi-select';
+import React from 'react';
+
+import LanguageIdIcon from '../../TranslateContent/components/LanguageIdIcon';
+import MessageBalloon from '../../TranslateContent/components/MessageBalloon';
+import MessageHeader from '../../TranslateContent/components/MessageHeader';
+import {TranslateContentMessageBalloonProps} from '../../TranslateContent/types';
+import useTranslateContentAgent from '../../TranslateContent/useTranslateContentAgent';
+
+import '../chat.scss';
+
+const TranslateContentMessageBalloon: React.FC<
+	TranslateContentMessageBalloonProps
+> = (props) => {
+	const {availableLanguageIds, results} = props;
+
+	const {
+		confirmDisabled,
+		onTranslate,
+		overwrite,
+		overwriteAll,
+		overwriteDisabled,
+		overwriteLanguageIds,
+		review,
+		selectDisabled,
+		selectedLanguageIds,
+		setSelectedLanguageIds,
+		setValue,
+		showConfirm,
+		showReview,
+		submitted,
+		toggleOverwriteLanguageId,
+		toggleSelectedLanguageId,
+		translatedLanguageIds,
+		value,
+	} = useTranslateContentAgent(props);
+
+	if (results?.length) {
+		return (
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'the-content-has-been-translated'
+					)}
+				/>
+			</MessageBalloon>
+		);
+	}
+
+	return (
+		<>
+			<MessageBalloon>
+				<MessageHeader
+					message={Liferay.Language.get(
+						'which-languages-would-you-like-to-translate-into'
+					)}
+				/>
+
+				<div className="ai-assistant-chat__language-select">
+					<ClayMultiSelect
+						disabled={selectDisabled}
+						items={selectedLanguageIds.map((languageId) => ({
+							label: languageId,
+							value: languageId,
+						}))}
+						onChange={setValue}
+						onItemsChange={(newItems) =>
+							setSelectedLanguageIds(
+								newItems.map((item) => item.value)
+							)
+						}
+						placeholder={Liferay.Language.get('select-languages')}
+						sourceItems={(availableLanguageIds ?? []).map(
+							(languageId) => ({
+								label: languageId,
+								value: languageId,
+							})
+						)}
+						spritemap={Liferay.Icons.spritemap}
+						value={value}
+					>
+						{(item) => (
+							<ClayMultiSelect.Item
+								key={item.value}
+								onClick={(event) => {
+									event.preventDefault();
+
+									toggleSelectedLanguageId(item.value);
+
+									setValue('');
+								}}
+								style={{cursor: 'pointer'}}
+								textValue={item.label}
+							>
+								<LanguageIdIcon languageId={item.value} />
+
+								{item.label}
+							</ClayMultiSelect.Item>
+						)}
+					</ClayMultiSelect>
+				</div>
+			</MessageBalloon>
+
+			{!!selectedLanguageIds.length && (
+				<div className="ai-assistant-chat__user-action">
+					<ClayButton
+						disabled={selectDisabled}
+						displayType="primary"
+						onClick={onTranslate}
+						size="sm"
+					>
+						{Liferay.Language.get('translate')}
+					</ClayButton>
+				</div>
+			)}
+
+			{showConfirm && (
+				<>
+					<MessageBalloon>
+						<MessageHeader
+							message={Liferay.Language.get(
+								'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+							)}
+						/>
+					</MessageBalloon>
+
+					<div className="ai-assistant-chat__user-action">
+						<ClayButton
+							disabled={confirmDisabled}
+							displayType="secondary"
+							onClick={review}
+							size="sm"
+						>
+							{Liferay.Language.get('review')}
+						</ClayButton>
+
+						<ClayButton
+							disabled={confirmDisabled}
+							displayType="primary"
+							onClick={overwriteAll}
+							size="sm"
+						>
+							{Liferay.Language.get('overwrite-all')}
+						</ClayButton>
+					</div>
+				</>
+			)}
+
+			{showReview && (
+				<>
+					<MessageBalloon>
+						<MessageHeader
+							message={Liferay.Language.get(
+								'select-the-translations-you-want-to-overwrite'
+							)}
+						/>
+
+						<div className="ai-assistant-chat__translation-review">
+							{translatedLanguageIds.map((languageId) => (
+								<ClayCheckbox
+									checked={overwriteLanguageIds.includes(
+										languageId
+									)}
+									disabled={submitted}
+									key={languageId}
+									label={languageId}
+									onChange={() =>
+										toggleOverwriteLanguageId(languageId)
+									}
+								/>
+							))}
+						</div>
+					</MessageBalloon>
+
+					<div className="ai-assistant-chat__user-action">
+						<ClayButton
+							disabled={overwriteDisabled}
+							displayType="primary"
+							onClick={overwrite}
+							size="sm"
+						>
+							{Liferay.Language.get('overwrite')}
+						</ClayButton>
+					</div>
+				</>
+			)}
+		</>
+	);
+};
+
+export default TranslateContentMessageBalloon;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/UserMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/UserMessageBalloon.tsx
@@ -29,12 +29,12 @@ const UserChatItem: React.FC<{message: string}> = ({message}) => {
 	}, []);
 
 	return (
-		<div className="align-items-center d-flex justify-content-end mb-2">
-			<span className="ai-assistant-chat__user-message col-auto p-2 text-break">
+		<div className="ai-assistant-chat__user-message">
+			<span className="ai-assistant-chat__user-message-content">
 				{message}
 			</span>
 
-			<div className="flex-shrink-0 ml-2">
+			<div className="ai-assistant-chat__user-message-avatar">
 				<Avatar image={userAccount?.image} name={userAccount?.name} />
 			</div>
 		</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/events.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/events.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const APPLY_OBJECT_FIELD_VALUES_EVENT =
+	'cms:aiAssistant:applyObjectFieldValues';
+
+export const GENERATE_FIELD_VALUE_AGENT_EXTERNAL_REFERENCE_CODE =
+	'L_GENERATE_FIELD_VALUE';
+
+export interface ApplyObjectFieldValuesPayload {
+	values: Record<string, string>;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/shells/AIAssistantDropdown.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/shells/AIAssistantDropdown.tsx
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import React, {useCallback} from 'react';
+
+import AIAssistantPanelHeader from '../components/AIAssistantPanelHeader';
+
+interface AIAssistantDropdownProps {
+	active: boolean;
+	bodyNode: HTMLElement;
+	onActiveChange: (active: boolean) => void;
+	onExpand?: () => void;
+	trigger: React.ReactElement;
+}
+
+const AIAssistantDropdown: React.FC<AIAssistantDropdownProps> = ({
+	active,
+	bodyNode,
+	onActiveChange,
+	onExpand,
+	trigger,
+}) => {
+	const mountBodyNode = useCallback(
+		(node: HTMLDivElement | null) => {
+			node?.appendChild(bodyNode);
+		},
+		[bodyNode]
+	);
+
+	return (
+		<ClayDropDown
+			active={active}
+			alignmentPosition={4}
+			className="ai-assistant-chat__dropdown"
+			hasRightSymbols={false}
+			menuElementAttrs={{
+				className: 'ai-assistant-chat__panel cadmin',
+			}}
+			onActiveChange={onActiveChange}
+			trigger={trigger}
+		>
+			<div className="ai-assistant ai-assistant-chat__dropdown-container">
+				<AIAssistantPanelHeader
+					onClose={() => onActiveChange(false)}
+					onToggleExpanded={onExpand}
+				/>
+
+				<div
+					className="ai-assistant-chat__body-slot"
+					ref={mountBodyNode}
+				/>
+			</div>
+		</ClayDropDown>
+	);
+};
+
+export default AIAssistantDropdown;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/shells/AIAssistantSidebar.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/shells/AIAssistantSidebar.tsx
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {SidePanel} from '@clayui/core';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
+import React, {useCallback, useEffect, useMemo} from 'react';
+
+import AIAssistantPanelHeader from '../components/AIAssistantPanelHeader';
+
+const SIDEBAR_WIDTH = 448;
+
+interface AIAssistantSidebarProps {
+	active: boolean;
+	behavior?: 'overlay' | 'push';
+	bodyNode: HTMLElement;
+	id?: string;
+	onCollapse?: () => void;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	pushContainer?: string;
+	triggerRef?: React.RefObject<HTMLElement>;
+}
+
+const AIAssistantSidebar: React.FC<AIAssistantSidebarProps> = ({
+	active,
+	behavior = 'push',
+	bodyNode,
+	id,
+	onCollapse,
+	onOpenChange,
+	open,
+	pushContainer = '#wrapper',
+	triggerRef,
+}) => {
+	const containerRef = useMemo<React.RefObject<HTMLElement>>(
+		() => ({
+			current:
+				behavior === 'push'
+					? document.querySelector<HTMLElement>(pushContainer)
+					: null,
+		}),
+		[behavior, pushContainer]
+	);
+
+	useEffect(() => {
+		const container = containerRef.current;
+
+		if (!container || !open) {
+			return;
+		}
+
+		container.classList.add('ai-assistant-sidebar-push');
+
+		return () => {
+			container.classList.remove('ai-assistant-sidebar-push');
+		};
+	}, [containerRef, open]);
+
+	const mountBodyNode = useCallback(
+		(node: HTMLDivElement | null) => {
+			if (node && active) {
+				node.appendChild(bodyNode);
+			}
+		},
+		[active, bodyNode]
+	);
+
+	return (
+		<ReactPortal className="ai-assistant-sidebar-root cadmin">
+			<SidePanel
+				aria-label={Liferay.Language.get('ai-assistant')}
+				as="aside"
+				className="ai-assistant-sidebar"
+				containerRef={containerRef}
+				id={id}
+				onOpenChange={onOpenChange}
+				open={open}
+				panelWidth={SIDEBAR_WIDTH}
+				position="fixed"
+				triggerRef={triggerRef}
+			>
+				<AIAssistantPanelHeader
+					expanded
+					onClose={() => onOpenChange(false)}
+					onToggleExpanded={onCollapse}
+				/>
+
+				<div
+					className="ai-assistant ai-assistant-chat__sidebar-container"
+					ref={mountBodyNode}
+				/>
+			</SidePanel>
+		</ReactPortal>
+	);
+};
+
+export default AIAssistantSidebar;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -1,0 +1,448 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EventSource} from 'eventsource';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {
+	CATEGORIZE_EVENT,
+	CategorizeEventPayload,
+	REQUEST_CATEGORIZE_EVENT,
+} from '../Categorization/events';
+import {classifyCategorizationIntent} from '../Categorization/services/classifyCategorizationIntent';
+import {ECategorizationAgent} from '../Categorization/types';
+import submitPositiveReportFeedback from '../ReportFeedback/submitPositiveReportFeedback';
+import {
+	ChatContext,
+	createEventSource,
+	postChatByExternalReferenceCodeMessage,
+} from './api';
+import {ContentType} from './components/ContentTypeSelectorMessageBalloon';
+import {ChatMessageSentData, Message} from './types';
+import buildAssistantMessage from './utils/buildAssistantMessage';
+
+export interface AIChatReportContext {
+	agentDefinitionExternalReferenceCodes: string[];
+	index: number;
+}
+
+export interface AIChat {
+	contextRef: React.MutableRefObject<ChatContext | undefined>;
+	feedbackGiven: Record<number, boolean>;
+	fileUploadSelectorRef: React.MutableRefObject<string | undefined>;
+	getContextRef: React.MutableRefObject<(() => ChatContext) | undefined>;
+	giveThumbsUp: (index: number, item: Message) => void;
+	isGenerating: boolean;
+	markFeedbackGiven: (index: number) => void;
+	message: string;
+	messages: Message[];
+	messagesEndRef: React.RefObject<HTMLDivElement>;
+	reportContext: AIChatReportContext | null;
+	runtimeContextRef: React.MutableRefObject<ChatContext>;
+	sendMessage: (text: string) => void;
+	setIsGenerating: React.Dispatch<React.SetStateAction<boolean>>;
+	setMessage: (message: string) => void;
+	setReportContext: (reportContext: AIChatReportContext | null) => void;
+	sourceLanguageIdRef: React.MutableRefObject<string>;
+}
+
+interface UseAIChatProps {
+	context?: ChatContext;
+	enableFreeFormCategorization?: boolean;
+	getContext?: () => ChatContext;
+	initialMessage?: string;
+	instructionDefinitionScope: string;
+	onCloseRequested?: () => void;
+	onOpenRequested?: (options?: {expanded?: boolean}) => void;
+	triggerRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+export default function useAIChat({
+	context,
+	enableFreeFormCategorization = false,
+	getContext,
+	initialMessage,
+	instructionDefinitionScope,
+	onCloseRequested,
+	onOpenRequested,
+	triggerRef,
+}: UseAIChatProps): AIChat {
+	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
+		{}
+	);
+	const [isGenerating, setIsGenerating] = useState<boolean>(false);
+	const [messages, setMessages] = useState<Message[]>([]);
+	const [message, setMessage] = useState<string>('');
+	const [reportContext, setReportContext] =
+		useState<AIChatReportContext | null>(null);
+
+	const enableFreeFormCategorizationRef = useRef<boolean>(
+		enableFreeFormCategorization
+	);
+	const eventSourceRef = useRef<EventSource | null>(null);
+	const eventSourceReference = useRef<string | null>(null);
+	const contextRef = useRef<ChatContext | undefined>(context);
+	const getContextRef = useRef<(() => ChatContext) | undefined>(getContext);
+	const runtimeContextRef = useRef<ChatContext>({});
+	const initialMessageRef = useRef<string | undefined>(initialMessage);
+	const initialMessageSentRef = useRef<boolean>(false);
+	const instructionDefinitionScopeRef = useRef<string>(
+		instructionDefinitionScope
+	);
+	const messagesEndRef = useRef<HTMLDivElement | null>(null);
+	const sourceLanguageIdRef = useRef<string>(
+		Liferay.ThemeDisplay.getLanguageId()
+	);
+	const fileUploadSelectorRef = useRef<string | undefined>(undefined);
+	const onCloseRequestedRef = useRef<(() => void) | undefined>(
+		onCloseRequested
+	);
+	const onOpenRequestedRef = useRef<
+		((options?: {expanded?: boolean}) => void) | undefined
+	>(onOpenRequested);
+
+	useEffect(() => {
+		contextRef.current = context;
+		enableFreeFormCategorizationRef.current = enableFreeFormCategorization;
+		getContextRef.current = getContext;
+		instructionDefinitionScopeRef.current = instructionDefinitionScope;
+		onCloseRequestedRef.current = onCloseRequested;
+		onOpenRequestedRef.current = onOpenRequested;
+	}, [
+		context,
+		enableFreeFormCategorization,
+		getContext,
+		instructionDefinitionScope,
+		onCloseRequested,
+		onOpenRequested,
+	]);
+
+	useEffect(() => {
+		const fieldElement = triggerRef?.current?.closest(
+			'[data-ai-assistant-field-id]'
+		);
+
+		if (fieldElement) {
+			fileUploadSelectorRef.current = `[data-ai-assistant-field-id="${fieldElement.getAttribute(
+				'data-ai-assistant-field-id'
+			)}"]`;
+		}
+	}, [triggerRef]);
+
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({behavior: 'smooth'});
+	}, [messages]);
+
+	useEffect(() => {
+		const onLocaleChanged = ({languageId}: {languageId: string}) => {
+			sourceLanguageIdRef.current = languageId;
+		};
+
+		Liferay.on('localizationSelect:localeChanged', onLocaleChanged);
+
+		return () => {
+			Liferay.detach('localizationSelect:localeChanged', onLocaleChanged);
+		};
+	}, []);
+
+	const sendMessage = useCallback((text: string) => {
+		if (!text.trim()) {
+			return;
+		}
+
+		setMessages((previousMessages) => [
+			...previousMessages,
+			{sender: 'user', text},
+		]);
+
+		setMessage('');
+
+		if (!eventSourceReference.current) {
+			return;
+		}
+
+		setIsGenerating(true);
+
+		const postToChat = () => {
+			postChatByExternalReferenceCodeMessage({
+				chatContext: {
+					...contextRef.current,
+					...getContextRef.current?.(),
+					...runtimeContextRef.current,
+				},
+				eventSourceReference: eventSourceReference.current as string,
+				instructionDefinitionScope:
+					instructionDefinitionScopeRef.current,
+				message: text,
+			}).catch(() => setIsGenerating(false));
+		};
+
+		if (!enableFreeFormCategorizationRef.current) {
+			postToChat();
+
+			return;
+		}
+
+		classifyCategorizationIntent(text)
+			.then((verdict) => {
+				if (verdict.passthrough || !verdict.actions.length) {
+					postToChat();
+
+					return;
+				}
+
+				setIsGenerating(false);
+
+				Liferay.fire(REQUEST_CATEGORIZE_EVENT, {
+					actions: verdict.actions,
+				});
+			})
+			.catch(() => postToChat());
+	}, []);
+
+	const giveThumbsUp = useCallback(
+		(index: number, item: Message) => {
+			if (feedbackGiven[index]) {
+				return;
+			}
+
+			setFeedbackGiven((previousFeedbackGiven) => ({
+				...previousFeedbackGiven,
+				[index]: true,
+			}));
+
+			submitPositiveReportFeedback({
+				agentDefinitionExternalReferenceCodes:
+					item.agentDefinitionExternalReferenceCodes ?? [],
+				surface: 'aiAssistant',
+			});
+		},
+		[feedbackGiven]
+	);
+
+	const markFeedbackGiven = useCallback((index: number) => {
+		setFeedbackGiven((previousFeedbackGiven) => ({
+			...previousFeedbackGiven,
+			[index]: true,
+		}));
+	}, []);
+
+	const openAIAssistantChatConnection = useCallback(() => {
+		createEventSource().then((eventSource) => {
+			if (!eventSource) {
+				return;
+			}
+
+			eventSourceRef.current = eventSource;
+
+			eventSourceRef.current.addEventListener(
+				'Chat Message Sent',
+				(event) => {
+					try {
+						const dataJSON: ChatMessageSentData = JSON.parse(
+							event.data
+						);
+
+						const assistantMessage =
+							buildAssistantMessage(dataJSON);
+
+						setMessages((previousMessages) => {
+							const lastMessage = previousMessages.at(-1);
+							const messages = previousMessages.slice(0, -1);
+
+							if (
+								lastMessage?.images?.length &&
+								assistantMessage?.images?.length
+							) {
+								return [
+									...messages,
+									{
+										...assistantMessage,
+										images: [
+											...lastMessage.images,
+											...assistantMessage.images,
+										],
+									},
+								];
+							}
+
+							return [...previousMessages, assistantMessage];
+						});
+
+						setMessage('');
+					}
+					catch {
+						setMessages((previousMessages) => [
+							...previousMessages,
+							{error: true, sender: 'assistant', text: ''},
+						]);
+
+						return;
+					}
+					finally {
+						setIsGenerating(false);
+					}
+				}
+			);
+
+			eventSourceRef.current.addEventListener('Subscribe', (event) => {
+				eventSourceReference.current = event.data;
+
+				if (
+					initialMessageRef.current &&
+					!initialMessageSentRef.current
+				) {
+					initialMessageSentRef.current = true;
+
+					sendMessage(initialMessageRef.current);
+				}
+			});
+
+			eventSourceRef.current.addEventListener(
+				'Agent Invocation Failed',
+				(event) => {
+					let text = '';
+
+					try {
+						text = JSON.parse(event.data)['data'];
+					}
+					catch {
+						text = '';
+					}
+
+					setMessages((previousMessages) => [
+						...previousMessages,
+						{
+							error: true,
+							sender: 'assistant',
+							text,
+						},
+					]);
+
+					setIsGenerating(false);
+				}
+			);
+		});
+	}, [sendMessage]);
+
+	const closeAIAssistantChatConnection = useCallback(() => {
+		eventSourceRef.current?.close();
+
+		eventSourceRef.current = null;
+	}, []);
+
+	useEffect(() => {
+		openAIAssistantChatConnection();
+
+		return () => {
+			closeAIAssistantChatConnection();
+		};
+	}, [closeAIAssistantChatConnection, openAIAssistantChatConnection]);
+
+	useEffect(() => {
+		const handleOpen = (payload: {
+			contentTypes?: ContentType[];
+			context?: ChatContext;
+			expanded?: boolean;
+			message?: string;
+		}) => {
+			onOpenRequestedRef.current?.({
+				expanded: payload?.expanded ?? true,
+			});
+
+			runtimeContextRef.current = payload?.context ?? {};
+
+			if (payload?.context) {
+				contextRef.current = {
+					...contextRef.current,
+					...payload.context,
+				};
+			}
+
+			if (payload?.contentTypes?.length) {
+				setMessages((previousMessages) => [
+					...previousMessages,
+					{
+						sender: 'user',
+						text: Liferay.Language.get('generate-content'),
+					},
+					{
+						contentTypes: payload.contentTypes,
+						sender: 'assistant',
+						text: Liferay.Language.get(
+							'what-type-of-content-do-you-want-to-generate'
+						),
+					},
+				]);
+			}
+			else if (payload?.message) {
+				sendMessage(payload.message);
+			}
+		};
+
+		Liferay.on('openAIAssistantChat', handleOpen);
+
+		return () => {
+			Liferay.detach('openAIAssistantChat', handleOpen);
+		};
+	}, [sendMessage]);
+
+	useEffect(() => {
+		const handleCategorize = (payload: CategorizeEventPayload) => {
+			onOpenRequestedRef.current?.();
+
+			setMessages((previousMessages) => {
+				const categorizationMessage = {
+					categorization: payload,
+					sender: 'assistant',
+					text: '',
+				};
+
+				if (payload.suppressUserMessage) {
+					return [...previousMessages, categorizationMessage];
+				}
+
+				return [
+					...previousMessages,
+					{
+						sender: 'user',
+						text:
+							payload.agent ===
+							ECategorizationAgent.AUTO_CATEGORIZE
+								? Liferay.Language.get('add-categories')
+								: Liferay.Language.get('generate-tags'),
+					},
+					categorizationMessage,
+				];
+			});
+		};
+
+		Liferay.on(CATEGORIZE_EVENT, handleCategorize);
+
+		return () => {
+			Liferay.detach(CATEGORIZE_EVENT, handleCategorize);
+		};
+	}, []);
+
+	return {
+		contextRef,
+		feedbackGiven,
+		fileUploadSelectorRef,
+		getContextRef,
+		giveThumbsUp,
+		isGenerating,
+		markFeedbackGiven,
+		message,
+		messages,
+		messagesEndRef,
+		reportContext,
+		runtimeContextRef,
+		sendMessage,
+		setIsGenerating,
+		setMessage,
+		setReportContext,
+		sourceLanguageIdRef,
+	};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/getGeneratedFieldValues.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/utils/getGeneratedFieldValues.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function getGeneratedFieldValues(
+	message: string
+): Record<string, string> {
+	try {
+		const values = JSON.parse(message);
+
+		if (values && typeof values === 'object' && !Array.isArray(values)) {
+			return values;
+		}
+	}
+	catch {
+		return {};
+	}
+
+	return {};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/api.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
+
+export async function putAgentInstanceResume({
+	agentInstanceId,
+	context,
+}: {
+	agentInstanceId: number;
+	context: Record<string, unknown>;
+}) {
+	const authorizationToken = await postAuthorizationToken();
+
+	if (!authorizationToken) {
+		return;
+	}
+
+	return await fetch(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/agent-instances/${agentInstanceId}/resume`,
+		{
+			body: JSON.stringify({context}),
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
+				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
+			}),
+			method: 'PUT',
+		}
+	);
+}
+
+async function postAuthorizationToken() {
+	try {
+		const response = await fetch(
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			{
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Unable to generate authorization token: ${response.statusText}`
+			);
+		}
+
+		const data = await response.json();
+
+		if (!data?.accessToken) {
+			throw new Error('Unable to generate authorization token.');
+		}
+
+		if (!data?.userToken) {
+			throw new Error('Unable to generate user token.');
+		}
+
+		if (!data?.serviceURL) {
+			throw new Error('Unable to find service URL.');
+		}
+
+		return data;
+	}
+	catch (error) {
+		console.warn((error as Error).message);
+	}
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/LanguageIdIcon.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function LanguageIdIcon({languageId}: {languageId: string}) {
+	return (
+		<ClayIcon
+			className="ai-assistant-chat__language-id-icon"
+			spritemap={Liferay.Icons.spritemap}
+			symbol={languageId.replace(/_/g, '-').toLowerCase()}
+		/>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageBalloon.tsx
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+export default function MessageBalloon({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="ai-assistant-chat__ai-assistant-message-balloon">
+			{children}
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function MessageHeader({message}: {message: string}) {
+	return (
+		<div className="ai-assistant-chat__message-header">
+			<div className="ai-assistant-chat__message-header-icon">
+				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+			</div>
+
+			<div className="ai-assistant-chat__message-header-text">
+				{message}
+			</div>
+		</div>
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/types.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {MutableRefObject} from 'react';
+
+export interface Result {
+	fields?: Record<string, string>;
+	targetLanguageId: string;
+}
+
+export interface TranslateContentMessageBalloonProps {
+	agentInstanceId: number;
+	availableLanguageIds?: string[];
+	requestedLanguageIds?: string[];
+	results?: Result[];
+	setIsGenerating: (isGenerating: boolean) => void;
+	sourceLanguageIdRef: MutableRefObject<string>;
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/useTranslateContentAgent.ts
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Dispatch, SetStateAction, useEffect, useRef, useState} from 'react';
+
+import {putAgentInstanceResume} from './api';
+import {TranslateContentMessageBalloonProps} from './types';
+import {getPageContext} from './utils/getPageContext';
+import {getTranslatedLanguageIds} from './utils/getTranslatedLanguageIds';
+
+export default function useTranslateContentAgent({
+	agentInstanceId,
+	availableLanguageIds,
+	requestedLanguageIds,
+	results,
+	setIsGenerating,
+	sourceLanguageIdRef,
+}: TranslateContentMessageBalloonProps) {
+	const appliedRef = useRef<boolean>(false);
+
+	const [overwriteLanguageIds, setOverwriteLanguageIds] = useState<string[]>(
+		[]
+	);
+	const [selectedLanguageIds, setSelectedLanguageIds] = useState<string[]>(
+		() =>
+			(requestedLanguageIds ?? []).filter((languageId) =>
+				(availableLanguageIds ?? []).includes(languageId)
+			)
+	);
+	const [step, setStep] = useState<'confirm' | 'review' | 'select'>('select');
+	const [submitted, setSubmitted] = useState<boolean>(false);
+	const [translatedLanguageIds, setTranslatedLanguageIds] = useState<
+		string[]
+	>([]);
+	const [value, setValue] = useState<string>('');
+
+	const submit = (targetLanguageIds: string[]) => {
+		setIsGenerating(true);
+		setSubmitted(true);
+
+		const sourceLanguageId = sourceLanguageIdRef.current;
+
+		const {fields, html} = getPageContext(sourceLanguageId);
+
+		putAgentInstanceResume({
+			agentInstanceId,
+			context: {
+				fields: JSON.stringify(fields),
+				html: JSON.stringify(html),
+				sourceLanguageId,
+				targetLanguageIds: JSON.stringify(targetLanguageIds),
+			},
+		}).catch(() => setIsGenerating(false));
+	};
+
+	const toggleLanguageId = (
+		setLanguageIds: Dispatch<SetStateAction<string[]>>,
+		languageId: string
+	) => {
+		setLanguageIds((previousLanguageIds) =>
+			previousLanguageIds.includes(languageId)
+				? previousLanguageIds.filter(
+						(previousLanguageId) =>
+							previousLanguageId !== languageId
+					)
+				: [...previousLanguageIds, languageId]
+		);
+	};
+
+	const onTranslate = () => {
+		const translatedLanguageIds =
+			getTranslatedLanguageIds(selectedLanguageIds);
+
+		if (!translatedLanguageIds.length) {
+			submit(selectedLanguageIds);
+
+			return;
+		}
+
+		setStep('confirm');
+		setTranslatedLanguageIds(translatedLanguageIds);
+	};
+
+	const review = () => {
+		setOverwriteLanguageIds(translatedLanguageIds);
+		setStep('review');
+	};
+
+	const overwriteAll = () => submit(selectedLanguageIds);
+
+	const overwriteTargetLanguageIds = selectedLanguageIds.filter(
+		(languageId) =>
+			!translatedLanguageIds.includes(languageId) ||
+			overwriteLanguageIds.includes(languageId)
+	);
+
+	const overwrite = () => submit(overwriteTargetLanguageIds);
+
+	useEffect(() => {
+		if (appliedRef.current || !results?.length) {
+			return;
+		}
+
+		appliedRef.current = true;
+
+		for (const result of results) {
+			const fields: Record<string, string> = {};
+
+			for (const [name, value] of Object.entries(result.fields ?? {})) {
+				fields[name] = Liferay.Util.unescapeHTML(value);
+			}
+
+			if (!Object.keys(fields).length) {
+				continue;
+			}
+
+			Liferay.fire('localizationSelect:autoTranslate', {
+				fields,
+				languageId: result.targetLanguageId,
+			});
+		}
+	}, [results]);
+
+	return {
+		confirmDisabled: submitted || step === 'review',
+		onTranslate,
+		overwrite,
+		overwriteAll,
+		overwriteDisabled: submitted || !overwriteTargetLanguageIds.length,
+		overwriteLanguageIds,
+		review,
+		selectDisabled: submitted || step !== 'select',
+		selectedLanguageIds,
+		setSelectedLanguageIds,
+		setValue,
+		showConfirm: step === 'confirm' || step === 'review',
+		showReview: step === 'review',
+		submitted,
+		toggleOverwriteLanguageId: (languageId: string) =>
+			toggleLanguageId(setOverwriteLanguageIds, languageId),
+		toggleSelectedLanguageId: (languageId: string) =>
+			toggleLanguageId(setSelectedLanguageIds, languageId),
+		translatedLanguageIds,
+		value,
+	};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const AUTO_TRANSLATABLE_TYPES = [
+	{isHtml: false, type: 'text'},
+	{isHtml: false, type: 'long-text'},
+	{isHtml: true, type: 'html'},
+];

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getPageContext.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getPageContext(sourceLanguageId: string) {
+	const fields: Record<string, string> = {};
+	const html: Record<string, boolean> = {};
+
+	for (const {isHtml, type} of AUTO_TRANSLATABLE_TYPES) {
+		const inputs = document.querySelectorAll<HTMLInputElement>(
+			`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${sourceLanguageId}"]`
+		);
+
+		for (const input of inputs) {
+			const name = input.name.replace(/_[a-z]{2}_[A-Z]{2}$/, '');
+
+			fields[name] = input.value;
+			html[name] = isHtml;
+		}
+	}
+
+	return {fields, html};
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/utils/getTranslatedLanguageIds.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AUTO_TRANSLATABLE_TYPES} from './constants';
+
+export function getTranslatedLanguageIds(languageIds: string[]): string[] {
+	return languageIds.filter((languageId) =>
+		AUTO_TRANSLATABLE_TYPES.some(({type}) =>
+			Array.from(
+				document.querySelectorAll<HTMLInputElement>(
+					`[data-localizable="true"][data-field-type="${type}"] [type="hidden"][name$="_${languageId}"]`
+				)
+			).some((input) => Boolean(input.value))
+		)
+	);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantChat.test.tsx
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {act, fireEvent, render, screen} from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom';
@@ -13,6 +20,9 @@ import {
 	createEventSource,
 	postChatByExternalReferenceCodeMessage,
 } from '../../../src/main/resources/META-INF/resources/js/AIAssistantChat/api';
+import {CATEGORIZE_EVENT} from '../../../src/main/resources/META-INF/resources/js/Categorization/events';
+import {classifyCategorizationIntent} from '../../../src/main/resources/META-INF/resources/js/Categorization/services/classifyCategorizationIntent';
+import {ECategorizationAgent} from '../../../src/main/resources/META-INF/resources/js/Categorization/types';
 import {postAIIssueReport} from '../../../src/main/resources/META-INF/resources/js/ReportFeedback/api';
 
 jest.mock(
@@ -26,9 +36,24 @@ jest.mock(
 );
 
 jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon',
+	() => ({
+		__esModule: true,
+		default: () => 'categorization-balloon',
+	})
+);
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/Categorization/services/classifyCategorizationIntent'
+);
+
+jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/ReportFeedback/api'
 );
 
+const mockClassify = classifyCategorizationIntent as jest.MockedFunction<
+	typeof classifyCategorizationIntent
+>;
 const mockCreateEventSource = createEventSource as jest.MockedFunction<
 	typeof createEventSource
 >;
@@ -61,9 +86,11 @@ function createFakeEventSource() {
 	};
 }
 
-async function renderAndOpen() {
+async function renderAndOpen(
+	props: Partial<React.ComponentProps<typeof AIAssistantChat>> = {}
+) {
 	await act(async () => {
-		render(<AIAssistantChat {...defaultProps} />);
+		render(<AIAssistantChat {...defaultProps} {...props} />);
 	});
 
 	await act(async () => {
@@ -73,9 +100,33 @@ async function renderAndOpen() {
 	});
 }
 
+function getLiferayHandler(eventName: string) {
+	return (Liferay.on as jest.Mock).mock.calls
+		.filter(([name]) => name === eventName)
+		.at(-1)?.[1];
+}
+
+function fireCategorizeEvent(payload: unknown) {
+	getLiferayHandler(CATEGORIZE_EVENT)?.(payload);
+}
+
+function getSidebar() {
+	return screen.getByRole('complementary', {name: 'ai-assistant'});
+}
+
 describe('AIAssistantChat', () => {
 	beforeEach(() => {
-		window.HTMLElement.prototype.scrollTo = jest.fn();
+
+		// Clay's SidePanel derives its mobile behavior (focus trap that
+		// aria-hides the rest of the page) from the body width, which is
+		// always 0 in jsdom; report a desktop width instead.
+
+		Object.defineProperty(document.body, 'clientWidth', {
+			configurable: true,
+			value: 1440,
+		});
+
+		window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 		mockCreateEventSource.mockReset();
 		mockCreateEventSource.mockResolvedValue(null);
@@ -93,20 +144,82 @@ describe('AIAssistantChat', () => {
 		};
 	});
 
-	it('shows the chat input immediately on open', async () => {
+	it('accumulates several image events into a single balloon', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
 		await renderAndOpen();
 
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({
+					data: 'AAA',
+					mimeType: 'image/png',
+					type: 'image',
+				})
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({
+					data: 'BBB',
+					mimeType: 'image/png',
+					type: 'image',
+				})
+			);
+		});
+
+		const images = screen.getAllByAltText('generated-image');
+
+		expect(images).toHaveLength(2);
+		expect(images[0]).toHaveAttribute('src', 'data:image/png;base64,AAA');
+		expect(images[1]).toHaveAttribute('src', 'data:image/png;base64,BBB');
+
 		expect(
-			screen.getByPlaceholderText('Ask me anything...')
-		).toBeInTheDocument();
+			screen.getAllByRole('checkbox', {name: 'generated-image'})
+		).toHaveLength(2);
 	});
 
-	it('shows the footer disclaimer', async () => {
-		await renderAndOpen();
+	it('closes the sidebar on Escape', async () => {
+		await renderAndOpen({displayMode: 'sidebar'});
+
+		const sidebar = getSidebar();
+
+		await waitFor(() => expect(sidebar).not.toHaveAttribute('inert'));
+
+		await act(async () => {
+			fireEvent.keyDown(document, {key: 'Escape'});
+		});
+
+		await waitFor(() => expect(sidebar).toHaveAttribute('inert'));
 
 		expect(
-			screen.getByText('ai-generated-responses-may-be-inaccurate')
-		).toBeInTheDocument();
+			screen.getByRole('button', {name: 'ai-assistant'})
+		).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	it('defaults the mime type to image/png when the image event omits it', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		await renderAndOpen();
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({data: 'CCC', type: 'image'})
+			);
+		});
+
+		expect(screen.getByAltText('generated-image')).toHaveAttribute(
+			'src',
+			'data:image/png;base64,CCC'
+		);
 	});
 
 	it('exposes the feedback row on a successful message and wires the codes', async () => {
@@ -145,6 +258,117 @@ describe('AIAssistantChat', () => {
 		});
 	});
 
+	describe('free-form categorization', () => {
+		beforeEach(() => {
+			mockClassify.mockReset();
+			mockPostChat.mockClear();
+			(Liferay.fire as jest.Mock).mockClear();
+		});
+
+		it('does not classify when the feature is disabled', async () => {
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+			await act(async () => {
+				render(
+					<AIAssistantChat
+						{...defaultProps}
+						initialMessage="tag this article"
+					/>
+				);
+			});
+
+			await act(async () => {
+				fakeEventSource.emit('Subscribe', 'ref-1');
+			});
+
+			expect(mockClassify).not.toHaveBeenCalled();
+			expect(mockPostChat).toHaveBeenCalled();
+		});
+
+		it('fires a single request event for a categorization message', async () => {
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+			mockClassify.mockResolvedValue({
+				actions: [{agent: 'tag', count: 3, targets: []}],
+				passthrough: false,
+			});
+
+			await act(async () => {
+				render(
+					<AIAssistantChat
+						{...defaultProps}
+						enableFreeFormCategorization
+						initialMessage="tag this article"
+					/>
+				);
+			});
+
+			await act(async () => {
+				fakeEventSource.emit('Subscribe', 'ref-1');
+			});
+
+			expect(mockClassify).toHaveBeenCalledWith('tag this article');
+			expect(Liferay.fire).toHaveBeenCalledWith(
+				'cms:aiAssistant:requestCategorize',
+				{actions: [{agent: 'tag', count: 3, targets: []}]}
+			);
+			expect(mockPostChat).not.toHaveBeenCalled();
+		});
+
+		it('posts a passthrough message to the chat', async () => {
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+			mockClassify.mockResolvedValue({actions: [], passthrough: true});
+
+			await act(async () => {
+				render(
+					<AIAssistantChat
+						{...defaultProps}
+						enableFreeFormCategorization
+						initialMessage="what can you do?"
+					/>
+				);
+			});
+
+			await act(async () => {
+				fakeEventSource.emit('Subscribe', 'ref-1');
+			});
+
+			expect(mockClassify).toHaveBeenCalledWith('what can you do?');
+			expect(mockPostChat).toHaveBeenCalled();
+			expect(Liferay.fire).not.toHaveBeenCalledWith(
+				'cms:aiAssistant:requestCategorize',
+				expect.anything()
+			);
+		});
+
+		it('renders only the balloon when the categorization event suppresses the user message', async () => {
+			await act(async () => {
+				render(<AIAssistantChat {...defaultProps} />);
+			});
+
+			await act(async () => {
+				getLiferayHandler(CATEGORIZE_EVENT)?.({
+					agent: 'L_GENERATE_TAGS',
+					cmsGroupId: 1,
+					content: 'x',
+					scopeId: 1,
+					suppressUserMessage: true,
+					targets: ['kayaking'],
+				});
+			});
+
+			expect(
+				screen.getByText('categorization-balloon')
+			).toBeInTheDocument();
+			expect(screen.queryByText('generate-tags')).not.toBeInTheDocument();
+		});
+	});
+
 	it('hides the feedback row on an error message', async () => {
 		const fakeEventSource = createFakeEventSource();
 
@@ -168,6 +392,36 @@ describe('AIAssistantChat', () => {
 				name: 'send-negative-feedback-or-report-legal-concern',
 			})
 		).not.toBeInTheDocument();
+	});
+
+	it('keeps the live connection across shell switches', async () => {
+		await renderAndOpen();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'maximize'}));
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'minimize'}));
+		});
+
+		expect(mockCreateEventSource).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the message draft when switching shells', async () => {
+		await renderAndOpen();
+
+		fireEvent.change(screen.getByPlaceholderText('Ask me anything...'), {
+			target: {value: 'Draft in progress'},
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'maximize'}));
+		});
+
+		expect(
+			within(getSidebar()).getByPlaceholderText('Ask me anything...')
+		).toHaveValue('Draft in progress');
 	});
 
 	it('merges the static context and the getContext snapshot when sending', async () => {
@@ -212,6 +466,159 @@ describe('AIAssistantChat', () => {
 		);
 	});
 
+	it('moves the conversation into the sidebar when maximized', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		await renderAndOpen();
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'Chat Message Sent',
+				JSON.stringify({data: 'Here is your answer'})
+			);
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'maximize'}));
+		});
+
+		expect(
+			within(getSidebar()).getByText('Here is your answer')
+		).toBeInTheDocument();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'minimize'}));
+		});
+
+		expect(
+			screen.getByRole('button', {name: 'maximize'})
+		).toBeInTheDocument();
+		expect(screen.getByText('Here is your answer')).toBeInTheDocument();
+	});
+
+	it('offers no maximize toggle in the dropdown display mode', async () => {
+		await renderAndOpen({displayMode: 'dropdown'});
+
+		expect(
+			screen.getByPlaceholderText('Ask me anything...')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {name: 'maximize'})
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('complementary', {name: 'ai-assistant'})
+		).not.toBeInTheDocument();
+	});
+
+	it('offers the maximize toggle in the default display mode', async () => {
+		await renderAndOpen();
+
+		expect(
+			screen.getByRole('button', {name: 'maximize'})
+		).toBeInTheDocument();
+	});
+
+	it('opens the dropdown for an open event that opts out of expanding', async () => {
+		await act(async () => {
+			render(<AIAssistantChat {...defaultProps} />);
+		});
+
+		await act(async () => {
+			getLiferayHandler('openAIAssistantChat')?.({
+				expanded: false,
+				message: 'Generate content',
+			});
+		});
+
+		expect(
+			screen.getByRole('button', {name: 'maximize'})
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {name: 'minimize'})
+		).not.toBeInTheDocument();
+	});
+
+	it('opens the dropdown when a categorize event fires in the default display mode', async () => {
+		await act(async () => {
+			render(<AIAssistantChat {...defaultProps} />);
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({
+				agent: ECategorizationAgent.GENERATE_TAGS,
+				content: 'Body',
+			});
+		});
+
+		expect(screen.getByText('generate-tags')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', {name: 'maximize'})
+		).toBeInTheDocument();
+	});
+
+	it('opens the sidebar by default for an open event', async () => {
+		await act(async () => {
+			render(<AIAssistantChat {...defaultProps} />);
+		});
+
+		await act(async () => {
+			getLiferayHandler('openAIAssistantChat')?.({
+				message: 'Translate Content',
+			});
+		});
+
+		const sidebar = getSidebar();
+
+		await waitFor(() => expect(sidebar).not.toHaveAttribute('inert'));
+
+		expect(
+			within(sidebar).getByPlaceholderText('Ask me anything...')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {name: 'maximize'})
+		).not.toBeInTheDocument();
+	});
+
+	it('opens the sidebar from the trigger in the sidebar display mode', async () => {
+		await renderAndOpen({displayMode: 'sidebar'});
+
+		expect(
+			screen.getByRole('button', {name: 'ai-assistant'})
+		).toHaveAttribute('aria-expanded', 'true');
+
+		const sidebar = getSidebar();
+
+		await waitFor(() => expect(sidebar).not.toHaveAttribute('inert'));
+
+		expect(
+			within(sidebar).getByPlaceholderText('Ask me anything...')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {name: 'minimize'})
+		).not.toBeInTheDocument();
+	});
+
+	it('opens the sidebar when a categorize event fires in the sidebar display mode', async () => {
+		await act(async () => {
+			render(<AIAssistantChat {...defaultProps} displayMode="sidebar" />);
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({
+				agent: ECategorizationAgent.GENERATE_TAGS,
+				content: 'Body',
+			});
+		});
+
+		const sidebar = getSidebar();
+
+		await waitFor(() => expect(sidebar).not.toHaveAttribute('inert'));
+
+		expect(within(sidebar).getByText('generate-tags')).toBeInTheDocument();
+	});
+
 	it('renders a generated image from an image event', async () => {
 		const fakeEventSource = createFakeEventSource();
 
@@ -237,63 +644,65 @@ describe('AIAssistantChat', () => {
 		);
 	});
 
-	it('accumulates several image events into a single balloon', async () => {
-		const fakeEventSource = createFakeEventSource();
-
-		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
-
+	it('reopens as a dropdown after the expanded chat is closed', async () => {
 		await renderAndOpen();
 
 		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({
-					data: 'AAA',
-					mimeType: 'image/png',
-					type: 'image',
-				})
+			fireEvent.click(screen.getByRole('button', {name: 'maximize'}));
+		});
+
+		const sidebar = getSidebar();
+
+		await waitFor(() => expect(sidebar).not.toHaveAttribute('inert'));
+
+		await act(async () => {
+			fireEvent.click(
+				within(sidebar).getByRole('button', {name: 'close'})
 			);
 		});
 
 		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({
-					data: 'BBB',
-					mimeType: 'image/png',
-					type: 'image',
-				})
-			);
+			screen
+				.getByRole('button', {name: 'ai-assistant'})
+				.dispatchEvent(new MouseEvent('click', {bubbles: true}));
 		});
-
-		const images = screen.getAllByAltText('generated-image');
-
-		expect(images).toHaveLength(2);
-		expect(images[0]).toHaveAttribute('src', 'data:image/png;base64,AAA');
-		expect(images[1]).toHaveAttribute('src', 'data:image/png;base64,BBB');
 
 		expect(
-			screen.getAllByRole('checkbox', {name: 'generated-image'})
-		).toHaveLength(2);
+			screen.getByRole('button', {name: 'maximize'})
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {name: 'minimize'})
+		).not.toBeInTheDocument();
 	});
 
-	it('defaults the mime type to image/png when the image event omits it', async () => {
-		const fakeEventSource = createFakeEventSource();
-
-		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
-
+	it('reuses the same body DOM across shell switches', async () => {
 		await renderAndOpen();
 
+		const inputBeforeExpand =
+			screen.getByPlaceholderText('Ask me anything...');
+
 		await act(async () => {
-			fakeEventSource.emit(
-				'Chat Message Sent',
-				JSON.stringify({data: 'CCC', type: 'image'})
-			);
+			fireEvent.click(screen.getByRole('button', {name: 'maximize'}));
 		});
 
-		expect(screen.getByAltText('generated-image')).toHaveAttribute(
-			'src',
-			'data:image/png;base64,CCC'
-		);
+		expect(
+			within(getSidebar()).getByPlaceholderText('Ask me anything...')
+		).toBe(inputBeforeExpand);
+	});
+
+	it('shows the chat input immediately on open', async () => {
+		await renderAndOpen();
+
+		expect(
+			screen.getByPlaceholderText('Ask me anything...')
+		).toBeInTheDocument();
+	});
+
+	it('shows the footer disclaimer', async () => {
+		await renderAndOpen();
+
+		expect(
+			screen.getByText('ai-generated-responses-may-be-inaccurate')
+		).toBeInTheDocument();
 	});
 });

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -77,6 +77,154 @@ describe('CategorizationMessageBalloon', () => {
 		} as never;
 	});
 
+	afterEach(() => {
+		(Liferay.Language.get as jest.Mock).mockImplementation(
+			(key: string) => key
+		);
+	});
+
+	it('counts only the tags not already on the content in the confirmation', async () => {
+		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
+			key === 'great-i-have-added-x-tags-to-your-content'
+				? 'Great! I have added {0} tags to your content.'
+				: key
+		);
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue(['Japan']);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					currentTagNames={['Japan']}
+					scopeId={555}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-3');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Japan","isNew":false},{"name":"Culture","isNew":true},{"name":"Tradition","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		fireEvent.click(screen.getByRole('button', {name: 'add-tags'}));
+
+		expect(
+			screen.getByText(/Great! I have added 2 tags/)
+		).toBeInTheDocument();
+		expect(screen.queryByText(/added 3 tags/)).not.toBeInTheDocument();
+	});
+
+	it('does not show a confirmation when no new categories are added', async () => {
+		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
+			key === 'great-i-have-added-x-categories-to-your-content'
+				? 'Great! I have added {0} categories to your content.'
+				: key
+		);
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetCandidateCategories.mockResolvedValue([
+			{id: 39001, name: 'International', vocabulary: 'Travel'},
+			{id: 39002, name: 'Roadtrip', vocabulary: 'Travel'},
+		]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.AUTO_CATEGORIZE}
+					cmsGroupId={20124}
+					content="Japan"
+					currentCategoryIds={[39001, 39002]}
+					scopeId={555}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-5');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_AUTO_CATEGORIZE',
+				JSON.stringify({
+					data: '{"suggestions":[{"id":39001,"confidence":0.9},{"id":39002,"confidence":0.8}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+
+		expect(
+			screen.queryByText(/Great! I have added/)
+		).not.toBeInTheDocument();
+	});
+
+	it('excludes already-attached categories from the confirmation count', async () => {
+		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
+			key === 'great-i-have-added-x-categories-to-your-content'
+				? 'Great! I have added {0} categories to your content.'
+				: key
+		);
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetCandidateCategories.mockResolvedValue([
+			{id: 39001, name: 'International', vocabulary: 'Travel'},
+			{id: 39002, name: 'Roadtrip', vocabulary: 'Travel'},
+		]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.AUTO_CATEGORIZE}
+					cmsGroupId={20124}
+					content="Japan"
+					currentCategoryIds={[39001]}
+					scopeId={555}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-4');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_AUTO_CATEGORIZE',
+				JSON.stringify({
+					data: '{"suggestions":[{"id":39001,"confidence":0.9},{"id":39002,"confidence":0.8}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+
+		expect(
+			screen.getByText(/Great! I have added 1 categories/)
+		).toBeInTheDocument();
+	});
+
 	it('fetches candidates, renders suggestions, and fires the commit event', async () => {
 		const fakeEventSource = createFakeEventSource();
 
@@ -125,10 +273,132 @@ describe('CategorizationMessageBalloon', () => {
 
 		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
 
-		expect(mockFire).toHaveBeenCalledWith('cms:aiAssistant:commit', {
-			agent: 'L_AUTO_CATEGORIZE',
-			suggestions: [{id: 39001, name: 'International'}],
+		expect(mockFire).toHaveBeenCalledWith(
+			'cms:aiAssistant:commit',
+			expect.objectContaining({
+				agent: 'L_AUTO_CATEGORIZE',
+				scopeId: 555,
+				suggestions: [{id: 39001, name: 'International'}],
+			})
+		);
+	});
+
+	it('ignores case when counting new tags in the confirmation', async () => {
+		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
+			key === 'great-i-have-added-x-tags-to-your-content'
+				? 'Great! I have added {0} tags to your content.'
+				: key
+		);
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue(['japan']);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					currentTagNames={['japan']}
+					scopeId={555}
+				/>
+			);
 		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-6');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Japan","isNew":false},{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		fireEvent.click(screen.getByRole('button', {name: 'add-tags'}));
+
+		expect(
+			screen.getByText(/Great! I have added 1 tags/)
+		).toBeInTheDocument();
+	});
+
+	it('marks unknown tag targets as new and known ones as existing', async () => {
+		mockGetExistingTags.mockResolvedValue(['japan']);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					targets={['kayaking', 'Japan']}
+				/>
+			);
+		});
+
+		expect(screen.getByText('kayaking')).toBeInTheDocument();
+		expect(screen.getByText('japan')).toBeInTheDocument();
+		expect(screen.queryByText('Japan')).not.toBeInTheDocument();
+		expect(
+			screen.getByText('i-found-x-existing-tags-and-suggest-x-new-tags')
+		).toBeInTheDocument();
+		expect(mockCreateEventSource).not.toHaveBeenCalled();
+	});
+
+	it('resolves a named category target without invoking the model', async () => {
+		mockGetCandidateCategories.mockResolvedValue([
+			{id: 39001, name: 'Fishing', vocabulary: 'Topic'},
+			{id: 39002, name: 'Travel', vocabulary: 'Topic'},
+		]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.AUTO_CATEGORIZE}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					targets={['fishing']}
+				/>
+			);
+		});
+
+		expect(screen.getByText('Fishing')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', {name: 'save-categories'})
+		).toBeInTheDocument();
+		expect(mockCreateEventSource).not.toHaveBeenCalled();
+	});
+
+	it('shows the empty state when a category target does not match', async () => {
+		mockGetCandidateCategories.mockResolvedValue([
+			{id: 39002, name: 'Travel', vocabulary: 'Topic'},
+		]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.AUTO_CATEGORIZE}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					targets={['Fishing']}
+				/>
+			);
+		});
+
+		expect(
+			screen.getByText(
+				'i-have-not-found-any-matching-categories-what-would-you-like-to-do'
+			)
+		).toBeInTheDocument();
 	});
 
 	it('uses the tags fetcher for the generate tags agent', async () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/TranslateContentMessageBalloon.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import TranslateContentMessageBalloon from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/components/TranslateContentMessageBalloon';
+import {putAgentInstanceResume} from '../../../../src/main/resources/META-INF/resources/js/TranslateContent/api';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/TranslateContent/api'
+);
+
+const mockPutAgentInstanceResume =
+	putAgentInstanceResume as jest.MockedFunction<
+		typeof putAgentInstanceResume
+	>;
+
+function renderComponent(props = {}) {
+	const setIsGenerating = jest.fn();
+
+	const view = render(
+		<TranslateContentMessageBalloon
+			agentInstanceId={12345}
+			availableLanguageIds={['es_ES', 'pt_BR', 'fr_FR']}
+			setIsGenerating={setIsGenerating}
+			sourceLanguageIdRef={{current: 'en_US'}}
+			{...props}
+		/>
+	);
+
+	return {setIsGenerating, ...view};
+}
+
+describe('TranslateContentMessageBalloon', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockPutAgentInstanceResume.mockResolvedValue(undefined);
+	});
+
+	describe('when results are available', () => {
+		let originalUnescapeHTML: typeof Liferay.Util.unescapeHTML;
+
+		beforeEach(() => {
+			originalUnescapeHTML = Liferay.Util.unescapeHTML;
+			Liferay.Util.unescapeHTML = (value: string) => value;
+		});
+
+		afterEach(() => {
+			Liferay.Util.unescapeHTML = originalUnescapeHTML;
+		});
+
+		it('shows a confirmation when the content has been translated', () => {
+			renderComponent({
+				results: [
+					{targetLanguageId: 'es_ES'},
+					{targetLanguageId: 'pt_BR'},
+				],
+			});
+
+			expect(
+				screen.getByText('the-content-has-been-translated')
+			).toBeInTheDocument();
+		});
+
+		it('fires the auto translate event for each result with fields', () => {
+			renderComponent({
+				results: [
+					{
+						fields: {title: 'Hola'},
+						targetLanguageId: 'es_ES',
+					},
+				],
+			});
+
+			expect(Liferay.fire).toHaveBeenCalledWith(
+				'localizationSelect:autoTranslate',
+				{
+					fields: {title: 'Hola'},
+					languageId: 'es_ES',
+				}
+			);
+		});
+
+		it('does not fire the auto translate event when a result has no fields', () => {
+			renderComponent({
+				results: [{targetLanguageId: 'es_ES'}],
+			});
+
+			expect(Liferay.fire).not.toHaveBeenCalledWith(
+				'localizationSelect:autoTranslate',
+				expect.anything()
+			);
+		});
+	});
+
+	describe('when selecting languages', () => {
+		it('hides the translate button until a language is selected', () => {
+			renderComponent();
+
+			expect(
+				screen.queryByRole('button', {name: 'translate'})
+			).not.toBeInTheDocument();
+		});
+
+		it('preselects requested languages that are available', () => {
+			renderComponent({requestedLanguageIds: ['es_ES', 'de_DE']});
+
+			expect(
+				screen.getByRole('button', {name: 'translate'})
+			).toBeEnabled();
+		});
+
+		it('submits the resume request for languages without an existing translation', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalledWith(
+				expect.objectContaining({
+					agentInstanceId: 12345,
+					context: expect.objectContaining({
+						sourceLanguageId: 'en_US',
+						targetLanguageIds: JSON.stringify(['es_ES']),
+					}),
+				})
+			);
+		});
+	});
+
+	describe('when a selected language is already translated', () => {
+		let fixture: HTMLDivElement;
+
+		beforeEach(() => {
+			fixture = document.createElement('div');
+			fixture.innerHTML = `
+				<div data-field-type="text" data-localizable="true">
+					<input name="field_es_ES" type="hidden" value="Hola" />
+				</div>
+			`;
+			document.body.appendChild(fixture);
+		});
+
+		afterEach(() => {
+			fixture.remove();
+		});
+
+		it('asks for confirmation before overwriting', async () => {
+			renderComponent({requestedLanguageIds: ['es_ES']});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+
+			expect(
+				screen.getByText(
+					'some-of-the-selected-languages-already-have-a-translation.-what-do-you-want-to-do'
+				)
+			).toBeInTheDocument();
+			expect(mockPutAgentInstanceResume).not.toHaveBeenCalled();
+		});
+
+		it('overwrites every translation when confirming', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+			await userEvent.click(
+				screen.getByRole('button', {name: 'overwrite-all'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalledWith(
+				expect.objectContaining({
+					context: expect.objectContaining({
+						targetLanguageIds: JSON.stringify(['es_ES']),
+					}),
+				})
+			);
+		});
+
+		it('lets the user review and overwrite the selected translations', async () => {
+			const {setIsGenerating} = renderComponent({
+				requestedLanguageIds: ['es_ES'],
+			});
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+			await userEvent.click(screen.getByRole('button', {name: 'review'}));
+
+			expect(screen.getByRole('checkbox', {name: 'es_ES'})).toBeChecked();
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'overwrite'})
+			);
+
+			expect(setIsGenerating).toHaveBeenCalledWith(true);
+			expect(mockPutAgentInstanceResume).toHaveBeenCalled();
+		});
+	});
+
+	it('stops generating when the resume request fails', async () => {
+		mockPutAgentInstanceResume.mockRejectedValue(new Error('boom'));
+
+		const {setIsGenerating} = renderComponent({
+			requestedLanguageIds: ['es_ES'],
+		});
+
+		await act(async () => {
+			await userEvent.click(
+				screen.getByRole('button', {name: 'translate'})
+			);
+		});
+
+		expect(setIsGenerating).toHaveBeenCalledWith(true);
+		expect(setIsGenerating).toHaveBeenCalledWith(false);
+	});
+});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/shells/AIAssistantSidebar.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/shells/AIAssistantSidebar.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen, waitFor, within} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
+import AIAssistantSidebar from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/shells/AIAssistantSidebar';
+
+function createBodyNode() {
+	const bodyNode = document.createElement('div');
+
+	bodyNode.textContent = 'Sidebar content';
+
+	return bodyNode;
+}
+
+function renderSidebar(
+	props: Partial<React.ComponentProps<typeof AIAssistantSidebar>> = {}
+) {
+	return render(
+		<AIAssistantSidebar
+			active
+			bodyNode={createBodyNode()}
+			onOpenChange={() => {}}
+			open
+			{...props}
+		/>
+	);
+}
+
+describe('AIAssistantSidebar', () => {
+	let wrapper: HTMLDivElement;
+
+	beforeEach(() => {
+
+		// Clay's SidePanel derives its mobile behavior (focus trap that
+		// aria-hides the rest of the page) from the body width, which is
+		// always 0 in jsdom; report a desktop width instead.
+
+		Object.defineProperty(document.body, 'clientWidth', {
+			configurable: true,
+			value: 1440,
+		});
+
+		wrapper = document.createElement('div');
+		wrapper.id = 'wrapper';
+
+		document.body.appendChild(wrapper);
+	});
+
+	afterEach(() => {
+		wrapper.remove();
+	});
+
+	it('adopts the body node inside a labelled complementary region', () => {
+		renderSidebar();
+
+		expect(
+			within(
+				screen.getByRole('complementary', {name: 'ai-assistant'})
+			).getByText('Sidebar content')
+		).toBeInTheDocument();
+	});
+
+	it('has no accessibility violations while open', async () => {
+		renderSidebar();
+
+		await checkAccessibility({
+			bestPractices: true,
+			context: screen.getByRole('complementary', {
+				name: 'ai-assistant',
+			}),
+		});
+	});
+
+	it('leaves the page container alone in the overlay behavior', () => {
+		renderSidebar({behavior: 'overlay'});
+
+		expect(wrapper).not.toHaveClass('ai-assistant-sidebar-push');
+		expect(wrapper).not.toHaveClass('c-slideout-container');
+	});
+
+	it('pushes the page container while open', async () => {
+		const bodyNode = createBodyNode();
+
+		const {rerender} = render(
+			<AIAssistantSidebar
+				active
+				bodyNode={bodyNode}
+				onOpenChange={() => {}}
+				open
+			/>
+		);
+
+		expect(wrapper).toHaveClass('ai-assistant-sidebar-push');
+
+		rerender(
+			<AIAssistantSidebar
+				active
+				bodyNode={bodyNode}
+				onOpenChange={() => {}}
+				open={false}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(wrapper).not.toHaveClass('ai-assistant-sidebar-push')
+		);
+	});
+});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/getGeneratedFieldValues.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/utils/getGeneratedFieldValues.test.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getGeneratedFieldValues from '../../../../src/main/resources/META-INF/resources/js/AIAssistantChat/utils/getGeneratedFieldValues';
+
+describe('getGeneratedFieldValues', () => {
+	it('parses a JSON object of field values', () => {
+		expect(getGeneratedFieldValues('{"title": "Hello"}')).toEqual({
+			title: 'Hello',
+		});
+	});
+
+	it('returns an empty object for invalid JSON', () => {
+		expect(getGeneratedFieldValues('not json')).toEqual({});
+	});
+
+	it('returns an empty object for a JSON array', () => {
+		expect(getGeneratedFieldValues('["a", "b"]')).toEqual({});
+	});
+
+	it('returns an empty object for a JSON primitive', () => {
+		expect(getGeneratedFieldValues('"just a string"')).toEqual({});
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
@@ -16,20 +16,19 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.site.cms.site.initializer.util.AssetTagUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,31 +80,6 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 		return additionalProps;
 	}
 
-	public Map<String, Object> getAIAssistantChatProps() {
-		String title = MapUtil.getString(objectEntry.getValues(), "title");
-
-		return HashMapBuilder.<String, Object>put(
-			"context",
-			HashMapBuilder.<String, Object>put(
-				"cmsGroupId", objectEntry.getGroupId()
-			).put(
-				"focusScope", "full-matrix"
-			).put(
-				"projectId", objectEntry.getObjectEntryId()
-			).build()
-		).put(
-			"initialMessage",
-			LanguageUtil.format(
-				httpServletRequest,
-				"get-ai-insights-for-the-x-content-coverage-matrix", title)
-		).put(
-			"instructionDefinitionScope", "cms"
-		).put(
-			"triggerLabel",
-			LanguageUtil.get(httpServletRequest, "get-ai-insights")
-		).build();
-	}
-
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
@@ -123,20 +97,30 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 
 	@Override
 	protected String[] getKeywords() {
-		try {
-			Set<String> assetTagNames = AssetTagUtil.getRelatedAssetTagNames(
-				assetTagLocalService, _objectDefinitionLocalService,
-				objectEntry, _objectEntryLocalService, _objectRelationship);
+		Set<String> tagNames = new HashSet<>();
 
-			return assetTagNames.toArray(new String[0]);
+		try {
+			for (ObjectEntry relatedObjectEntry :
+					_objectEntryLocalService.getOneToManyObjectEntries(
+						objectEntry.getGroupId(),
+						_objectRelationship.getObjectRelationshipId(), null,
+						false, objectEntry.getObjectEntryId(), true, null,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+				tagNames.addAll(
+					getTagNames(
+						_objectDefinitionLocalService.fetchObjectDefinition(
+							relatedObjectEntry.getObjectDefinitionId()),
+						relatedObjectEntry));
+			}
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(portalException);
 			}
-
-			return new String[0];
 		}
+
+		return tagNames.toArray(new String[0]);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -15,8 +15,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.EditCategoryDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.EditVocabularyDisplayContext" %><%@

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -19,6 +19,8 @@ import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 
 import Toolbar from '../../common/components/Toolbar';
+import applyFieldValues from '../utils/applyFieldValues';
+import getFieldValues from '../utils/getFieldValues';
 import {toMomentDate} from './ScheduleField';
 import SchedulePublicationModal from './SchedulePublicationModal';
 import PreviewModal from './preview/PreviewModal';
@@ -38,6 +40,9 @@ export const EVENT_HANDLE_PREVIEW = 'contentEditor:handlePreview';
 
 export const EVENT_VALIDATE_FORM = 'contentEditor:validateForm';
 
+const APPLY_OBJECT_FIELD_VALUES_EVENT =
+	'cms:aiAssistant:applyObjectFieldValues';
+
 const STATUS_DRAFT_CODE = 2;
 
 const SUCCESS_MESSAGE_SESSION_KEY =
@@ -52,6 +57,7 @@ export default function ContentEditorToolbar({
 	hasWorkflow,
 	headerTitle,
 	isNew,
+	objectFields,
 	title,
 	type,
 }: {
@@ -63,6 +69,7 @@ export default function ContentEditorToolbar({
 	hasWorkflow: boolean;
 	headerTitle: string;
 	isNew: boolean;
+	objectFields?: Array<{label: string; name: string}>;
 	title: string;
 	type: string;
 }) {
@@ -98,6 +105,17 @@ export default function ContentEditorToolbar({
 
 		return form as HTMLFormElement;
 	}, []);
+
+	const getContext = useCallback(() => {
+		const form = getForm();
+
+		return {
+			objectFields: JSON.stringify(objectFields ?? []),
+			properties: JSON.stringify(
+				form ? getFieldValues(form, objectFields ?? []) : {}
+			),
+		};
+	}, [getForm, objectFields]);
 
 	const setSuccessMessage = useCallback(
 		(message: string) => {
@@ -207,6 +225,31 @@ export default function ContentEditorToolbar({
 		openToast({message, type: 'success'});
 	}, [getForm]);
 
+	useEffect(() => {
+		const handleApplyObjectFieldValues = ({
+			values,
+		}: {
+			values: Record<string, string>;
+		}) => {
+			const form = getForm();
+
+			if (form) {
+				applyFieldValues(form, values, localizationLanguageId);
+			}
+		};
+
+		Liferay.on(
+			APPLY_OBJECT_FIELD_VALUES_EVENT,
+			handleApplyObjectFieldValues
+		);
+
+		return () =>
+			Liferay.detach(
+				APPLY_OBJECT_FIELD_VALUES_EVENT,
+				handleApplyObjectFieldValues
+			);
+	}, [getForm, localizationLanguageId]);
+
 	return (
 		<Toolbar
 			backURL={backURL}
@@ -219,6 +262,8 @@ export default function ContentEditorToolbar({
 					<Toolbar.Item>
 						<AIAssistantChat
 							context={{groupId}}
+							enableFreeFormCategorization
+							getContext={getContext}
 							hideTriggerLabel
 							instructionDefinitionScope="cms"
 							triggerRound

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_all_related_assets.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_all_related_assets.jsp
@@ -11,15 +11,6 @@
 ViewAllRelatedAssetsSectionDisplayContext viewAllRelatedAssetsSectionDisplayContext = (ViewAllRelatedAssetsSectionDisplayContext)request.getAttribute(ViewAllRelatedAssetsSectionDisplayContext.class.getName());
 %>
 
-<c:if test='<%= FeatureFlagManagerUtil.isEnabled(themeDisplay.getCompanyId(), "LPD-62272") %>'>
-	<div class="align-items-center d-flex justify-content-end mb-3">
-		<react:component
-			module="{AIAssistantChat} from ai-hub-cell-js-components-web"
-			props="<%= viewAllRelatedAssetsSectionDisplayContext.getAIAssistantChatProps() %>"
-		/>
-	</div>
-</c:if>
-
 <div class="cms-all-related-assets cms-section custom-empty-state"></div>
 	<frontend-data-set:headless-display
 		additionalProps="<%= viewAllRelatedAssetsSectionDisplayContext.getAdditionalProps() %>"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94145
https://liferay.atlassian.net/browse/LPD-92741

## What Is Being Fixed

The AI Assistant chat was a single ~730-line monolith that mixed the dropdown/sidebar shell, the message list, the per-agent balloons, and all chat state. It could only render as a dropdown, there was no sidebar presentation for the content editor, and the translate balloon's stepped flow (select → overwrite → confirm) was broken.

## How It Is Being Fixed

Restructures the chat into a thin shell plus a body: `AIAssistantChat` mounts either the dropdown or the sidebar shell, `AIAssistantChatBody` owns the message list, and `useAIChat` owns the conversation state and events. Each assistant agent renders through its own message balloon (categorization, field value, translate, image, user). Adds the sidebar presentation — dropdown/sidebar shells, panel header, trigger — with its stylesheet. The content editor toolbar and the related-assets view mount the assistant through this shell. Restores the stepped translate flow.

Stacked on #675 (davyson's content-editor field-value utilities, which the toolbar consumes); also depends on the foundation build config (renderer + `package.json`/tsconfig).

## Known Follow-ups (to be filed as separate bugs)

- With more than one trigger on a page, more than one sidebar can open, or a dropdown can open alongside a sidebar — needs single-active-assistant coordination.
- The attachment trigger's presentation and the image-generation response rendering.

## PR Check

Content validated on the equivalent branch: `ai-hub-cell` builds and 160 unit tests pass; `site-cms` compiles with davyson's field-value utilities present. Full source-format and per-module build on this base run via CI.
