### PR TITLE
LPD-98715 Keep the calendar view across quick actions and reloads

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
@@ -11,6 +11,7 @@ import React, {useState} from 'react';
 
 import {patchTaskById} from '../../utils/api';
 import {displayAssignSuccessToast} from '../../utils/toastUtil';
+import {ITaskObjectEntry} from '../../utils/types';
 import CustomAssignee from '../CustomAssignee';
 
 import './../AssigneeTrigger.scss';
@@ -20,6 +21,7 @@ type Props = {
 	cmpTaskObjectEntryId: string;
 	cmpTaskObjectEntryTitle: string;
 	loadData: Function;
+	onTaskUpdated?: (task: ITaskObjectEntry) => void;
 	value: AssigneeValue | {} | null;
 };
 
@@ -28,6 +30,7 @@ export default function EditAssigneeModalContent({
 	cmpTaskObjectEntryId,
 	cmpTaskObjectEntryTitle,
 	loadData,
+	onTaskUpdated,
 	value: initialValue,
 }: Props) {
 	const [value, setValue] = useState<AssigneeValue | null | {}>(initialValue);
@@ -35,7 +38,7 @@ export default function EditAssigneeModalContent({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const {error} = await patchTaskById({
+		const {data, error} = await patchTaskById({
 			body: {assignTo: value},
 			taskId: cmpTaskObjectEntryId,
 		});
@@ -43,7 +46,12 @@ export default function EditAssigneeModalContent({
 		if (!error) {
 			closeModal();
 
-			loadData();
+			if (onTaskUpdated && data) {
+				onTaskUpdated(data);
+			}
+			else {
+				loadData();
+			}
 
 			displayAssignSuccessToast(
 				cmpTaskObjectEntryTitle,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/UpdateDueDateModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/UpdateDueDateModalContent.tsx
@@ -11,6 +11,7 @@ import React, {useId, useState} from 'react';
 
 import {patchTaskById} from '../../utils/api';
 import {displayDueDateSuccessToast} from '../../utils/toastUtil';
+import {ITaskObjectEntry} from '../../utils/types';
 import DateField, {dateConfig} from '../DateField';
 
 type Props = {
@@ -19,6 +20,7 @@ type Props = {
 	cmpTaskObjectEntryTitle: string;
 	dueDate?: string;
 	loadData: Function;
+	onTaskUpdated?: (task: ITaskObjectEntry) => void;
 };
 
 export default function UpdateDueDateModalContent({
@@ -27,6 +29,7 @@ export default function UpdateDueDateModalContent({
 	cmpTaskObjectEntryTitle,
 	dueDate: initialDueDate,
 	loadData,
+	onTaskUpdated,
 }: Props) {
 	const initialValue = initialDueDate
 		? moment(initialDueDate.slice(0, 10)).format(dateConfig.momentFormat)
@@ -37,7 +40,7 @@ export default function UpdateDueDateModalContent({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const {error} = await patchTaskById({
+		const {data, error} = await patchTaskById({
 			body: {
 				dueDate: dueDate
 					? moment(dueDate, dateConfig.momentFormat).format(
@@ -51,7 +54,12 @@ export default function UpdateDueDateModalContent({
 		if (!error) {
 			closeModal();
 
-			loadData();
+			if (onTaskUpdated && data) {
+				onTaskUpdated(data);
+			}
+			else {
+				loadData();
+			}
 
 			displayDueDateSuccessToast(cmpTaskObjectEntryTitle);
 		}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -41,6 +41,8 @@ import type {FirstDayOfWeekLocale} from 'frontend-js-web';
 
 const ADD_TASK_BUTTON_CLASS_NAME = 'lfr__calendar-view-add-task-button';
 
+const calendarNavigationStates = new Map<string, {date: Date; view: string}>();
+
 interface CalendarViewProps {
 	cmpProjectObjectDefinitionId: number;
 	cmpProjectObjectEntryId?: string;
@@ -62,7 +64,9 @@ export default function CalendarView({
 	items,
 	itemsActions,
 }: CalendarViewProps) {
-	const {loadData, onItemsChange} = useContext(FrontendDataSetContext);
+	const {id, loadData, onItemsChange} = useContext(FrontendDataSetContext);
+
+	const calendarNavigationState = calendarNavigationStates.get(id ?? '');
 
 	const calendarRef = useRef<FullCalendar>(null);
 	const calendarViewRef = useRef<HTMLDivElement>(null);
@@ -73,7 +77,9 @@ export default function CalendarView({
 		{label: Liferay.Language.get('month'), view: 'dayGridMonth'},
 	];
 
-	const [currentView, setCurrentView] = useState('dayGridMonth');
+	const [currentView, setCurrentView] = useState(
+		calendarNavigationState?.view ?? 'dayGridMonth'
+	);
 	const [datePickerExpanded, setDatePickerExpanded] = useState(false);
 	const [datePickerValue, setDatePickerValue] = useState('');
 	const [fdsContainerElement, setFDSContainerElement] =
@@ -438,6 +444,11 @@ export default function CalendarView({
 
 			<FullCalendar
 				datesSet={({view}) => {
+					calendarNavigationStates.set(id ?? '', {
+						date: view.currentStart,
+						view: view.type,
+					});
+
 					setCurrentView(view.type);
 					setTitle(view.title);
 				}}
@@ -524,7 +535,8 @@ export default function CalendarView({
 				events={events}
 				fixedWeekCount={false}
 				headerToolbar={false}
-				initialView="dayGridMonth"
+				initialDate={calendarNavigationState?.date}
+				initialView={currentView}
 				moreLinkClassNames={[
 					'btn',
 					'btn-outline-secondary',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -28,7 +28,7 @@ import {
 	displayDueDateSuccessToast,
 	displayErrorToast,
 } from '../../../../utils/toastUtil';
-import {ITask, ITaskObjectEntry} from '../../../../utils/types';
+import {ITask, ITaskItemsActionsTask} from '../../../../utils/types';
 import CreateTaskModal from '../../../modal/CreateTaskModal';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
 import CalendarMoreLinkPopover from './components/CalendarMoreLinkPopover';
@@ -52,7 +52,7 @@ interface CalendarViewProps {
 interface MoreLinkPopover {
 	alignElement: HTMLElement;
 	date: Date;
-	tasks: ITaskObjectEntry[];
+	taskIds: string[];
 }
 
 export default function CalendarView({
@@ -230,6 +230,28 @@ export default function CalendarView({
 		}
 
 		displayDueDateSuccessToast(task.title);
+	};
+
+	const handleTaskChanged = ({actions, embedded}: ITaskItemsActionsTask) => {
+		const changedItem = items.find(
+			(item) => item.embedded?.id === embedded.id
+		);
+
+		if (!changedItem) {
+			loadData();
+
+			return;
+		}
+
+		onItemsChange({
+			itemKey: 'embedded.id',
+			items: [
+				{
+					...changedItem,
+					embedded: {...embedded, ...(actions && {actions})},
+				},
+			],
+		});
 	};
 
 	const currentYear = new Date().getFullYear();
@@ -469,6 +491,7 @@ export default function CalendarView({
 						expanded={currentView !== 'dayGridMonth'}
 						itemsActions={itemsActions}
 						loadData={loadData}
+						onTaskChanged={handleTaskChanged}
 						task={arg.event.extendedProps.task}
 					/>
 				)}
@@ -511,8 +534,8 @@ export default function CalendarView({
 					setMoreLinkPopover({
 						alignElement: arg.jsEvent.currentTarget as HTMLElement,
 						date: arg.date,
-						tasks: arg.allSegs.map(
-							(seg) => seg.event.extendedProps.task
+						taskIds: arg.allSegs.map((seg) =>
+							String(seg.event.extendedProps.task.id)
 						),
 					});
 
@@ -560,7 +583,13 @@ export default function CalendarView({
 					itemsActions={itemsActions}
 					loadData={loadData}
 					onClose={() => setMoreLinkPopover(null)}
-					tasks={moreLinkPopover.tasks}
+					onTaskChanged={handleTaskChanged}
+					tasks={items
+						.map((item) => item.embedded)
+						.filter(Boolean)
+						.filter((task) =>
+							moreLinkPopover.taskIds.includes(String(task.id))
+						)}
 				/>
 			)}
 
@@ -568,6 +597,7 @@ export default function CalendarView({
 				<UnscheduledTasksPanel
 					containerRef={fdsContainerRef}
 					onOpenChange={setUnscheduledTasksPanelOpen}
+					onTaskChanged={handleTaskChanged}
 					open={unscheduledTasksPanelOpen}
 					tasks={unscheduledTasks}
 				/>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
@@ -15,7 +15,10 @@ import React, {useMemo} from 'react';
 import getTaskItemsActions from '../../../../../utils/getTaskItemsActions';
 import isActionsMenuEvent from '../../../../../utils/isActionsMenuEvent';
 import isOverdue from '../../../../../utils/isOverdue';
-import {ITaskObjectEntry} from '../../../../../utils/types';
+import {
+	ITaskItemsActionsTask,
+	ITaskObjectEntry,
+} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
 import sortTasksByPriority from '../utils/sortTasksByPriority';
 
@@ -34,6 +37,7 @@ interface CalendarMoreLinkPopoverProps {
 	itemsActions: IItemsActions[];
 	loadData: Function;
 	onClose: () => void;
+	onTaskChanged?: (task: ITaskItemsActionsTask) => void;
 	tasks: ITaskObjectEntry[];
 }
 
@@ -42,6 +46,7 @@ export default function CalendarMoreLinkPopover({
 	itemsActions,
 	loadData,
 	onClose,
+	onTaskChanged,
 	tasks,
 }: CalendarMoreLinkPopoverProps) {
 	const sortedTasks = useMemo(() => sortTasksByPriority(tasks), [tasks]);
@@ -74,7 +79,8 @@ export default function CalendarMoreLinkPopover({
 						{
 							actions: task.actions,
 							embedded: task,
-						}
+						},
+						onTaskChanged
 					);
 
 					return (

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
@@ -15,7 +15,10 @@ import React from 'react';
 import getTaskItemsActions from '../../../../../utils/getTaskItemsActions';
 import isActionsMenuEvent from '../../../../../utils/isActionsMenuEvent';
 import isOverdue from '../../../../../utils/isOverdue';
-import {ITaskObjectEntry} from '../../../../../utils/types';
+import {
+	ITaskItemsActionsTask,
+	ITaskObjectEntry,
+} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
 
 import './CalendarTaskCard.scss';
@@ -24,6 +27,7 @@ interface CalendarTaskCardProps {
 	expanded?: boolean;
 	itemsActions?: IItemsActions[];
 	loadData: Function;
+	onTaskChanged?: (task: ITaskItemsActionsTask) => void;
 	task: ITaskObjectEntry;
 }
 
@@ -31,6 +35,7 @@ export default function CalendarTaskCard({
 	expanded = false,
 	itemsActions = [],
 	loadData,
+	onTaskChanged,
 	task,
 }: CalendarTaskCardProps) {
 	const {assignTo, dueDate, state, title} = task;
@@ -38,10 +43,15 @@ export default function CalendarTaskCard({
 	const blocked = state?.key === 'blocked';
 	const overdue = isOverdue({dueDate, state});
 
-	const taskItemsActions = getTaskItemsActions(itemsActions, loadData, {
-		actions: task.actions,
-		embedded: task,
-	});
+	const taskItemsActions = getTaskItemsActions(
+		itemsActions,
+		loadData,
+		{
+			actions: task.actions,
+			embedded: task,
+		},
+		onTaskChanged
+	);
 
 	const hasViewPermission = Boolean(task.actions?.get);
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/UnscheduledTasksPanel.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/UnscheduledTasksPanel.tsx
@@ -22,7 +22,10 @@ import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {TASK_DRAGGING_CLASS_NAME} from '../../../../../utils/constants';
 import getTaskItemsActions from '../../../../../utils/getTaskItemsActions';
-import {ITaskObjectEntry} from '../../../../../utils/types';
+import {
+	ITaskItemsActionsTask,
+	ITaskObjectEntry,
+} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
 import sortTasksByPriority from '../utils/sortTasksByPriority';
 
@@ -38,6 +41,7 @@ const DRAGGABLE_ITEM_CLASS_NAME = 'lfr__cmp-unscheduled-tasks-panel-item';
 interface UnscheduledTasksPanelProps {
 	containerRef: React.RefObject<HTMLElement>;
 	onOpenChange: (open: boolean) => void;
+	onTaskChanged?: (task: ITaskItemsActionsTask) => void;
 	open: boolean;
 	tasks: ITaskObjectEntry[];
 }
@@ -45,6 +49,7 @@ interface UnscheduledTasksPanelProps {
 export default function UnscheduledTasksPanel({
 	containerRef,
 	onOpenChange,
+	onTaskChanged,
 	open,
 	tasks,
 }: UnscheduledTasksPanelProps) {
@@ -181,7 +186,8 @@ export default function UnscheduledTasksPanel({
 								const taskItemsActions = getTaskItemsActions(
 									itemsActions ?? [],
 									loadData,
-									{actions: task.actions, embedded: task}
+									{actions: task.actions, embedded: task},
+									onTaskChanged
 								);
 
 								const viewURL = task.actions?.get

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/hooks/useOptimisticBoard.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/hooks/useOptimisticBoard.ts
@@ -13,7 +13,7 @@ import {
 	mapStateKeyToLabel,
 } from '../../../../../utils/constants';
 import {displayStateSuccessToast} from '../../../../../utils/toastUtil';
-import {IColumn, ITask} from '../../../../../utils/types';
+import {IColumn, ITask, ITaskObjectEntry} from '../../../../../utils/types';
 
 function mapByStateCode(items: ITask[]): {[key: string]: IColumn} {
 	const boardData: {[name: string]: IColumn} = {};
@@ -52,7 +52,7 @@ export function useOptimisticBoard(
 	onTaskMoveApi: (
 		task: ITask,
 		newStatus: {key: string; name: string}
-	) => Promise<RequestResult<ITask>>
+	) => Promise<RequestResult<ITaskObjectEntry>>
 ) {
 
 	// Source of truth

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
@@ -5,7 +5,7 @@
 
 import {ApiHelper} from '@liferay/site-cms-site-initializer';
 
-import {ITask} from './types';
+import {ITaskObjectEntry} from './types';
 
 type WorkflowTaskAssignee = {
 	assignableUsers: Array<{id: number; name: string}>;
@@ -62,6 +62,10 @@ export async function getStateObjectField() {
 	);
 }
 
+export async function getTaskById({taskId}: {taskId: string}) {
+	return await ApiHelper.get<ITaskObjectEntry>(`/o/cmp/tasks/${taskId}`);
+}
+
 export async function getUserAccount(id: string) {
 	return ApiHelper.get(`/o/headless-admin-user/v1.0/user-accounts/${id}`)
 		.then((response) => {
@@ -101,7 +105,10 @@ export async function patchTaskById({
 	body: {[key: string]: any};
 	taskId: string;
 }) {
-	return await ApiHelper.patch<ITask>(body, `/o/cmp/tasks/${taskId}`);
+	return await ApiHelper.patch<ITaskObjectEntry>(
+		body,
+		`/o/cmp/tasks/${taskId}`
+	);
 }
 
 export async function postSubscribeTaskByExternalReferenceCode({

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getTaskItemsActions.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getTaskItemsActions.tsx
@@ -4,7 +4,6 @@
  */
 
 import {IItemsActions, getItemActionURL} from '@liferay/frontend-data-set-web';
-import {Immutable} from '@liferay/frontend-js-state-web';
 import {
 	displayErrorToast,
 	displayRequestSuccessToast,
@@ -17,6 +16,7 @@ import EditAssigneeModalContent from '../components/modal/EditAssigneeModalConte
 import UpdateDueDateModalContent from '../components/modal/UpdateDueDateModalContent';
 import {
 	deleteTaskById,
+	getTaskById,
 	getUserAccount,
 	patchTaskById,
 	postSubscribeTaskByExternalReferenceCode,
@@ -27,16 +27,45 @@ import {
 	displayAssignSuccessToast,
 	displayDeleteSuccessToast,
 } from './toastUtil';
-import {ITaskObjectEntry} from './types';
+import {ITaskItemsActionsTask, ITaskObjectEntry} from './types';
 
 export default function getTaskItemsActions(
 	itemsActions: IItemsActions[],
 	loadData: Function,
-	task: {
-		actions?: ITaskObjectEntry['actions'];
-		embedded: Immutable<ITaskObjectEntry> | ITaskObjectEntry;
-	}
+	task: ITaskItemsActionsTask,
+	onTaskChanged?: (task: ITaskItemsActionsTask) => void
 ) {
+	const applyTaskUpdates = (updatedTask: Partial<ITaskObjectEntry>) => {
+		if (onTaskChanged) {
+			onTaskChanged({
+				actions: updatedTask.actions ?? task.actions,
+				embedded: {...task.embedded, ...updatedTask},
+			});
+		}
+		else {
+			loadData();
+		}
+	};
+
+	const refreshTask = async () => {
+		if (!onTaskChanged) {
+			loadData();
+
+			return;
+		}
+
+		const {data} = await getTaskById({
+			taskId: String(task.embedded.id),
+		});
+
+		if (data) {
+			applyTaskUpdates(data);
+		}
+		else {
+			loadData();
+		}
+	};
+
 	const topItems = [];
 
 	if (task.actions?.update) {
@@ -83,7 +112,8 @@ export default function getTaskItemsActions(
 				});
 
 				if (!error) {
-					loadData();
+					await refreshTask();
+
 					displayRequestSuccessToast();
 				}
 				else {
@@ -106,7 +136,8 @@ export default function getTaskItemsActions(
 					});
 
 				if (!error) {
-					loadData();
+					await refreshTask();
+
 					displayRequestSuccessToast();
 				}
 				else {
@@ -128,7 +159,7 @@ export default function getTaskItemsActions(
 					name: string;
 				};
 
-				const {error} = await patchTaskById({
+				const {data, error} = await patchTaskById({
 					body: {
 						assignTo: {
 							externalReferenceCode: user.externalReferenceCode,
@@ -140,7 +171,13 @@ export default function getTaskItemsActions(
 				});
 
 				if (!error) {
-					loadData();
+					if (data) {
+						applyTaskUpdates(data);
+					}
+					else {
+						loadData();
+					}
+
 					displayAssignSuccessToast(task.embedded.title, user.name);
 				}
 				else {
@@ -166,6 +203,9 @@ export default function getTaskItemsActions(
 							cmpTaskObjectEntryId={String(task.embedded.id)}
 							cmpTaskObjectEntryTitle={task.embedded.title}
 							loadData={loadData}
+							onTaskUpdated={
+								onTaskChanged ? applyTaskUpdates : undefined
+							}
 							value={task.embedded.assignTo}
 						/>
 					),
@@ -192,6 +232,9 @@ export default function getTaskItemsActions(
 							cmpTaskObjectEntryTitle={task.embedded.title}
 							dueDate={task.embedded.dueDate}
 							loadData={loadData}
+							onTaskUpdated={
+								onTaskChanged ? applyTaskUpdates : undefined
+							}
 						/>
 					),
 					size: 'md',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {Immutable} from '@liferay/frontend-js-state-web';
 import {AssigneeValue} from '@liferay/object-dynamic-data-mapping-form-field-type';
 
 import {DISPLAY_TYPES} from './constants';
@@ -123,6 +124,11 @@ export interface ITask {
 	embedded: ITaskObjectEntry;
 	entryClassName: string;
 	score: number;
+}
+
+export interface ITaskItemsActionsTask {
+	actions?: ITaskObjectEntry['actions'];
+	embedded: Immutable<ITaskObjectEntry> | ITaskObjectEntry;
 }
 
 export type TaskAction = {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
@@ -4,10 +4,17 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render} from '@testing-library/react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
 import React from 'react';
 
 import CalendarTaskCard from '../../js/components/props_transformer/views/calendar_view/components/CalendarTaskCard';
+import {
+	getTaskById,
+	getUserAccount,
+	patchTaskById,
+	postSubscribeTaskByExternalReferenceCode,
+	postUnsubscribeTaskByExternalReferenceCode,
+} from '../../js/utils/api';
 import {ITaskObjectEntry} from '../../js/utils/types';
 import {mockNavigate} from './__mocks__/frontend-js-web';
 
@@ -24,6 +31,7 @@ jest.mock('@liferay/site-cms-site-initializer', () => ({
 
 jest.mock('../../js/utils/api', () => ({
 	deleteTaskById: jest.fn(),
+	getTaskById: jest.fn(),
 	getUserAccount: jest.fn(),
 	patchTaskById: jest.fn(),
 	postSubscribeTaskByExternalReferenceCode: jest.fn(),
@@ -67,7 +75,10 @@ function createTask(overrides: Partial<ITaskObjectEntry> = {}) {
 	} as ITaskObjectEntry;
 }
 
-function renderCard(task: ITaskObjectEntry, props: {expanded?: boolean} = {}) {
+function renderCard(
+	task: ITaskObjectEntry,
+	props: Partial<React.ComponentProps<typeof CalendarTaskCard>> = {}
+) {
 	return render(
 		<CalendarTaskCard loadData={jest.fn()} task={task} {...props} />
 	);
@@ -205,5 +216,215 @@ describe('CalendarTaskCard', () => {
 		expect(getByText('edit')).toBeInTheDocument();
 		expect(getByText('view')).toBeInTheDocument();
 		expect(getByText('watch-task')).toBeInTheDocument();
+	});
+
+	describe('quick actions with in-place task updates', () => {
+		const task = createTask({
+			actions: taskActions,
+			externalReferenceCode: 'TASK-1',
+			id: 1,
+			scopeKey: 'scope-1',
+		} as Partial<ITaskObjectEntry>);
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('keeps the task untouched when watching fails', async () => {
+			(
+				postSubscribeTaskByExternalReferenceCode as jest.Mock
+			).mockResolvedValue({error: 'error'});
+
+			const loadData = jest.fn();
+			const onTaskChanged = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(task, {
+				loadData,
+				onTaskChanged,
+			});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('watch-task'));
+
+			await waitFor(() => {
+				expect(
+					postSubscribeTaskByExternalReferenceCode
+				).toHaveBeenCalled();
+			});
+
+			expect(loadData).not.toHaveBeenCalled();
+			expect(onTaskChanged).not.toHaveBeenCalled();
+		});
+
+		it('merges the assign to me response into the task instead of reloading', async () => {
+			(getUserAccount as jest.Mock).mockResolvedValue({
+				externalReferenceCode: 'USER-1',
+				name: 'John Doe',
+			});
+
+			const updatedTask = {
+				assignTo: {name: 'John Doe'},
+				dateModified: '2026-02-05T00:00:00Z',
+			};
+
+			(patchTaskById as jest.Mock).mockResolvedValue({
+				data: updatedTask,
+				error: null,
+			});
+
+			const loadData = jest.fn();
+			const onTaskChanged = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(task, {
+				loadData,
+				onTaskChanged,
+			});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('assign-to-me'));
+
+			await waitFor(() => {
+				expect(onTaskChanged).toHaveBeenCalledWith({
+					actions: taskActions,
+					embedded: {...task, ...updatedTask},
+				});
+			});
+
+			expect(loadData).not.toHaveBeenCalled();
+		});
+
+		it('refreshes the task after stop watching instead of reloading', async () => {
+			(
+				postUnsubscribeTaskByExternalReferenceCode as jest.Mock
+			).mockResolvedValue({error: null});
+
+			const watchedTask = createTask({
+				...task,
+				actions: {
+					assignToMe: taskActions.assignToMe,
+					delete: taskActions.delete,
+					get: taskActions.get,
+					unsubscribe: {href: '/unsubscribe', method: 'POST'},
+					update: taskActions.update,
+				},
+			} as Partial<ITaskObjectEntry>);
+
+			const refreshedTask = {...watchedTask, actions: taskActions};
+
+			(getTaskById as jest.Mock).mockResolvedValue({
+				data: refreshedTask,
+				error: null,
+			});
+
+			const loadData = jest.fn();
+			const onTaskChanged = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(watchedTask, {
+				loadData,
+				onTaskChanged,
+			});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('stop-watching-task'));
+
+			await waitFor(() => {
+				expect(onTaskChanged).toHaveBeenCalledWith({
+					actions: taskActions,
+					embedded: refreshedTask,
+				});
+			});
+
+			expect(getTaskById).toHaveBeenCalledWith({taskId: '1'});
+			expect(loadData).not.toHaveBeenCalled();
+		});
+
+		it('refreshes the task after watching instead of reloading', async () => {
+			(
+				postSubscribeTaskByExternalReferenceCode as jest.Mock
+			).mockResolvedValue({error: null});
+
+			const refreshedTaskActions = {
+				assignToMe: taskActions.assignToMe,
+				delete: taskActions.delete,
+				get: taskActions.get,
+				unsubscribe: {href: '/unsubscribe', method: 'POST'},
+				update: taskActions.update,
+			};
+
+			const refreshedTask = {...task, actions: refreshedTaskActions};
+
+			(getTaskById as jest.Mock).mockResolvedValue({
+				data: refreshedTask,
+				error: null,
+			});
+
+			const loadData = jest.fn();
+			const onTaskChanged = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(task, {
+				loadData,
+				onTaskChanged,
+			});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('watch-task'));
+
+			await waitFor(() => {
+				expect(onTaskChanged).toHaveBeenCalledWith({
+					actions: refreshedTaskActions,
+					embedded: refreshedTask,
+				});
+			});
+
+			expect(getTaskById).toHaveBeenCalledWith({taskId: '1'});
+			expect(loadData).not.toHaveBeenCalled();
+		});
+
+		it('reloads after watching when in-place updates are unavailable', async () => {
+			(
+				postSubscribeTaskByExternalReferenceCode as jest.Mock
+			).mockResolvedValue({error: null});
+
+			const loadData = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(task, {loadData});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('watch-task'));
+
+			await waitFor(() => {
+				expect(loadData).toHaveBeenCalled();
+			});
+
+			expect(getTaskById).not.toHaveBeenCalled();
+		});
+
+		it('reloads after watching when the task refetch returns no data', async () => {
+			(
+				postSubscribeTaskByExternalReferenceCode as jest.Mock
+			).mockResolvedValue({error: null});
+
+			(getTaskById as jest.Mock).mockResolvedValue({
+				data: null,
+				error: 'error',
+			});
+
+			const loadData = jest.fn();
+			const onTaskChanged = jest.fn();
+
+			const {getByLabelText, getByText} = renderCard(task, {
+				loadData,
+				onTaskChanged,
+			});
+
+			fireEvent.click(getByLabelText('actions'));
+			fireEvent.click(getByText('watch-task'));
+
+			await waitFor(() => {
+				expect(loadData).toHaveBeenCalled();
+			});
+
+			expect(onTaskChanged).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
@@ -4,17 +4,19 @@
  */
 
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {FrontendDataSetContext} from '@liferay/frontend-data-set-web';
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import CalendarView from '../../js/components/props_transformer/views/calendar_view/CalendarView';
+import {ITask} from '../../js/utils/types';
 
 jest.mock('@fullcalendar/daygrid', () => ({}));
 
 jest.mock('@fullcalendar/interaction', () => ({}));
 
-// FullCalendar cannot run under jsdom, so render only the day cell
-// content to test what CalendarView feeds it.
+// FullCalendar cannot run under jsdom, so render only the day cell and
+// event content to test what CalendarView feeds it.
 
 jest.mock('@fullcalendar/react', () => {
 	const React = require('react');
@@ -27,31 +29,128 @@ jest.mock('@fullcalendar/react', () => {
 					date: new Date(2026, 6, 15),
 					dayNumberText: '15',
 				})}
+
+				{props.events?.map((event: any) => (
+					<div key={event.id}>
+						{props.eventContent?.({
+							event: {extendedProps: event.extendedProps},
+						})}
+					</div>
+				))}
 			</div>
 		)),
 	};
 });
 
-const renderCalendarView = (hasAddTaskPermission: boolean) =>
+jest.mock(
+	'../../js/components/props_transformer/views/calendar_view/components/CalendarTaskCard',
+	() => ({
+		__esModule: true,
+		default: ({onTaskChanged, task}: any) => (
+			<button
+				onClick={() =>
+					onTaskChanged({
+						actions: {get: {href: '/view', method: 'GET'}},
+						embedded: {
+							...task,
+							id: task.reportedId ?? task.id,
+							title: 'Renamed',
+						},
+					})
+				}
+				type="button"
+			>
+				{task.title}
+			</button>
+		),
+	})
+);
+
+const renderCalendarView = (
+	hasAddTaskPermission: boolean,
+	{
+		items = [],
+		loadData = jest.fn(),
+		onItemsChange = jest.fn(),
+	}: {items?: ITask[]; loadData?: Function; onItemsChange?: Function} = {}
+) =>
 	render(
-		<CalendarView
-			cmpProjectObjectDefinitionId={456}
-			cmpProjectObjectEntryId="123"
-			hasAddTaskPermission={hasAddTaskPermission}
-			items={[]}
-			itemsActions={[]}
-		/>
+		<FrontendDataSetContext.Provider
+			value={{loadData, onItemsChange} as any}
+		>
+			<CalendarView
+				cmpProjectObjectDefinitionId={456}
+				cmpProjectObjectEntryId="123"
+				hasAddTaskPermission={hasAddTaskPermission}
+				items={items}
+				itemsActions={[]}
+			/>
+		</FrontendDataSetContext.Provider>
 	);
+
+function createItem(overrides: Partial<ITask['embedded']> = {}) {
+	return {
+		embedded: {
+			dueDate: '2026-07-10T00:00:00Z',
+			id: 1,
+			title: 'Design the landing page',
+			...overrides,
+		},
+		entryClassName: 'com.liferay.object.model.ObjectEntry',
+	} as unknown as ITask;
+}
 
 describe('CalendarView', () => {
 	beforeEach(() => {
 		(globalThis as any).Liferay.fire = jest.fn();
 	});
 
+	it('falls back to reloading when the changed task is not among the items', () => {
+		const loadData = jest.fn();
+		const onItemsChange = jest.fn();
+
+		renderCalendarView(false, {
+			items: [createItem({reportedId: 999} as any)],
+			loadData,
+			onItemsChange,
+		});
+
+		fireEvent.click(screen.getByText('Design the landing page'));
+
+		expect(loadData).toHaveBeenCalled();
+		expect(onItemsChange).not.toHaveBeenCalled();
+	});
+
 	it('hides the add task button without add task permission', () => {
 		renderCalendarView(false);
 
 		expect(screen.queryByLabelText('add-task')).not.toBeInTheDocument();
+	});
+
+	it('replaces a changed task in the data set instead of reloading', () => {
+		const item = createItem();
+
+		const loadData = jest.fn();
+		const onItemsChange = jest.fn();
+
+		renderCalendarView(false, {items: [item], loadData, onItemsChange});
+
+		fireEvent.click(screen.getByText('Design the landing page'));
+
+		expect(onItemsChange).toHaveBeenCalledWith({
+			itemKey: 'embedded.id',
+			items: [
+				{
+					...item,
+					embedded: {
+						...item.embedded,
+						actions: {get: {href: '/view', method: 'GET'}},
+						title: 'Renamed',
+					},
+				},
+			],
+		});
+		expect(loadData).not.toHaveBeenCalled();
 	});
 
 	it('shows the add task button with add task permission', () => {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
@@ -16,7 +16,9 @@ jest.mock('@fullcalendar/daygrid', () => ({}));
 jest.mock('@fullcalendar/interaction', () => ({}));
 
 // FullCalendar cannot run under jsdom, so render only the day cell and
-// event content to test what CalendarView feeds it.
+// event content to test what CalendarView feeds it, expose the initial
+// navigation props, and let tests report a view change through a button
+// the way the real calendar reports it through datesSet.
 
 jest.mock('@fullcalendar/react', () => {
 	const React = require('react');
@@ -24,7 +26,26 @@ jest.mock('@fullcalendar/react', () => {
 	return {
 		__esModule: true,
 		default: React.forwardRef((props: any, _ref: unknown) => (
-			<div>
+			<div
+				data-initial-date={props.initialDate?.toISOString() ?? ''}
+				data-initial-view={props.initialView}
+				data-testid="fullCalendar"
+			>
+				<button
+					onClick={() =>
+						props.datesSet?.({
+							view: {
+								currentStart: new Date(2026, 6, 13),
+								title: 'Jul 13 – 19, 2026',
+								type: 'dayGridWeek',
+							},
+						})
+					}
+					type="button"
+				>
+					Switch to week
+				</button>
+
 				{props.dayCellContent?.({
 					date: new Date(2026, 6, 15),
 					dayNumberText: '15',
@@ -69,14 +90,20 @@ jest.mock(
 const renderCalendarView = (
 	hasAddTaskPermission: boolean,
 	{
+		id,
 		items = [],
 		loadData = jest.fn(),
 		onItemsChange = jest.fn(),
-	}: {items?: ITask[]; loadData?: Function; onItemsChange?: Function} = {}
+	}: {
+		id?: string;
+		items?: ITask[];
+		loadData?: Function;
+		onItemsChange?: Function;
+	} = {}
 ) =>
 	render(
 		<FrontendDataSetContext.Provider
-			value={{loadData, onItemsChange} as any}
+			value={{id, loadData, onItemsChange} as any}
 		>
 			<CalendarView
 				cmpProjectObjectDefinitionId={456}
@@ -153,9 +180,42 @@ describe('CalendarView', () => {
 		expect(loadData).not.toHaveBeenCalled();
 	});
 
+	it('restores the calendar view and date when it remounts', () => {
+		const {unmount} = renderCalendarView(false, {id: 'remount-fds'});
+
+		fireEvent.click(screen.getByText('Switch to week'));
+
+		unmount();
+
+		renderCalendarView(false, {id: 'remount-fds'});
+
+		const fullCalendar = screen.getByTestId('fullCalendar');
+
+		expect(fullCalendar).toHaveAttribute(
+			'data-initial-date',
+			new Date(2026, 6, 13).toISOString()
+		);
+		expect(fullCalendar).toHaveAttribute(
+			'data-initial-view',
+			'dayGridWeek'
+		);
+	});
+
 	it('shows the add task button with add task permission', () => {
 		renderCalendarView(true);
 
 		expect(screen.getByLabelText('add-task')).toBeInTheDocument();
+	});
+
+	it('starts on the month view when the data set has no stored state', () => {
+		renderCalendarView(false, {id: 'fresh-fds'});
+
+		const fullCalendar = screen.getByTestId('fullCalendar');
+
+		expect(fullCalendar).toHaveAttribute('data-initial-date', '');
+		expect(fullCalendar).toHaveAttribute(
+			'data-initial-view',
+			'dayGridMonth'
+		);
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/EditAssigneeModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/EditAssigneeModalContent.spec.tsx
@@ -51,4 +51,32 @@ describe('EditAssigneeModalContent', () => {
 		expect(mockCloseModal).toHaveBeenCalled();
 		expect(mockLoadData).toHaveBeenCalled();
 	});
+
+	it('hands the updated task to onTaskUpdated instead of reloading', async () => {
+		const updatedTask = {assignTo: {name: 'New Assignee'}, id: 123};
+
+		mockPatchTaskById.mockResolvedValue({data: updatedTask, error: null});
+
+		const onTaskUpdated = jest.fn();
+
+		const {getByText} = render(
+			<EditAssigneeModalContent
+				closeModal={mockCloseModal}
+				cmpTaskObjectEntryId="123"
+				cmpTaskObjectEntryTitle="Task Title"
+				loadData={mockLoadData}
+				onTaskUpdated={onTaskUpdated}
+				value={{name: 'New Assignee'}}
+			/>
+		);
+
+		fireEvent.click(getByText('save'));
+
+		await waitFor(() => {
+			expect(onTaskUpdated).toHaveBeenCalledWith(updatedTask);
+		});
+
+		expect(mockCloseModal).toHaveBeenCalled();
+		expect(mockLoadData).not.toHaveBeenCalled();
+	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UpdateDueDateModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UpdateDueDateModalContent.spec.tsx
@@ -95,6 +95,29 @@ describe('UpdateDueDateModalContent', () => {
 		expect(mockLoadData).toHaveBeenCalled();
 	});
 
+	it('hands the updated task to onTaskUpdated instead of reloading', async () => {
+		const updatedTask = {dueDate: '2026-08-20', id: 123};
+
+		mockPatchTaskById.mockResolvedValue({data: updatedTask, error: null});
+
+		const onTaskUpdated = jest.fn();
+
+		const {getByTestId, getByText} = renderModal({onTaskUpdated});
+
+		fireEvent.change(getByTestId('mock-date-field'), {
+			target: {value: '08/20/2026'},
+		});
+
+		fireEvent.submit(getByText('update').closest('form')!);
+
+		await waitFor(() => {
+			expect(onTaskUpdated).toHaveBeenCalledWith(updatedTask);
+		});
+
+		expect(mockCloseModal).toHaveBeenCalled();
+		expect(mockLoadData).not.toHaveBeenCalled();
+	});
+
 	it('pre-fills the picker with the task due date', () => {
 		const {getByTestId} = renderModal();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98715
https://liferay.atlassian.net/browse/LPD-98677

## What Is Being Fixed

On the Project Tasks Calendar, any data set reload unmounts the calendar view and remounts it with default state, throwing the user back to the month view on today's date. Two flows trigger this: task kebab quick actions (Watch, Stop Watching, Assign to Me, Assign to…, Update Due Date) reload the whole data set after saving (LPD-98715), and applying a status filter or a search term refetches the data, remounting the calendar (LPD-98677).

## How It Is Being Fixed

The quick actions no longer reload the data set. `getTaskItemsActions` receives an optional `onTaskChanged` callback and patches the changed task in place through the FDS `onItemsChange` API, following the pattern the drag-and-drop rescheduling already uses. The PATCH-based actions merge the server response into the task entry, and watch/unwatch — whose endpoints return no body — refetch the task by id so the entry and its actions map come from the server rather than being derived on the client. `CalendarView` owns the merge back into the full FDS item and falls back to a reload when the task is not among the loaded items. Delete keeps reloading because the FDS cannot remove an item in place. The "+N more" popover now stores task IDs and resolves them against the current items, so it reflects in-place updates instead of a snapshot taken when it opened.

For the reloads that are unavoidable (filters, search, delete), the calendar's navigation state (view and date) is kept outside the component, keyed by data set, and restored through FullCalendar's `initialView`/`initialDate` when the calendar remounts, so the user stays on the week or day they were working in.

## PR Check

**pr-check: PASS** — tested on `e39200bcadece8c411eb40ee1402be77747d6680`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e39200bcadece8c411eb40ee1402be77747d6680"} -->
