### PR TITLE
LPD-98868 Standardize the AI Assistant confirm and retry labels

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
@@ -57,7 +57,7 @@ const FieldValueMessageBalloon: React.FC<FieldValueMessageBalloonProps> = ({
 						symbol="reload"
 					/>
 
-					{Liferay.Language.get('regenerate')}
+					{Liferay.Language.get('try-again')}
 				</ClayButton>
 
 				<ClayButton

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
@@ -130,9 +130,7 @@ export default function CategorizationSuggestions({
 						symbol="reload"
 					/>
 
-					{kind === 'categories'
-						? Liferay.Language.get('try-again')
-						: Liferay.Language.get('regenerate')}
+					{Liferay.Language.get('try-again')}
 				</ClayButton>
 
 				<ClayButton
@@ -142,7 +140,7 @@ export default function CategorizationSuggestions({
 					size="sm"
 				>
 					{kind === 'categories'
-						? Liferay.Language.get('save-categories')
+						? Liferay.Language.get('add-categories')
 						: Liferay.Language.get('add-tags')}
 				</ClayButton>
 			</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -170,7 +170,7 @@ describe('CategorizationMessageBalloon', () => {
 			);
 		});
 
-		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+		fireEvent.click(screen.getByRole('button', {name: 'add-categories'}));
 
 		expect(
 			screen.queryByText(/Great! I have added/)
@@ -218,7 +218,7 @@ describe('CategorizationMessageBalloon', () => {
 			);
 		});
 
-		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+		fireEvent.click(screen.getByRole('button', {name: 'add-categories'}));
 
 		expect(
 			screen.getByText(/Great! I have added 1 categories/)
@@ -271,7 +271,7 @@ describe('CategorizationMessageBalloon', () => {
 
 		expect(screen.getByText('International')).toBeInTheDocument();
 
-		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+		fireEvent.click(screen.getByRole('button', {name: 'add-categories'}));
 
 		expect(mockFire).toHaveBeenCalledWith(
 			'cms:aiAssistant:commit',
@@ -372,7 +372,7 @@ describe('CategorizationMessageBalloon', () => {
 
 		expect(screen.getByText('Fishing')).toBeInTheDocument();
 		expect(
-			screen.getByRole('button', {name: 'save-categories'})
+			screen.getByRole('button', {name: 'add-categories'})
 		).toBeInTheDocument();
 		expect(mockCreateEventSource).not.toHaveBeenCalled();
 	});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
@@ -20,57 +20,72 @@ const baseProps = {
 };
 
 describe('CategorizationSuggestions', () => {
-	it('renders nothing when idle', () => {
-		const {container} = render(
-			<CategorizationSuggestions
-				{...baseProps}
-				kind="categories"
-				status="idle"
-			/>
-		);
-
-		expect(container).toBeEmptyDOMElement();
-	});
-
-	it('shows the categories loading text', () => {
+	it('disables the actions once committed', () => {
 		render(
 			<CategorizationSuggestions
 				{...baseProps}
+				committed
 				kind="categories"
-				status="loading"
+				status="ready"
+				suggestions={[{id: 1, name: 'International'}]}
 			/>
 		);
 
 		expect(
-			screen.getByText('searching-for-categories')
-		).toBeInTheDocument();
+			screen.getByRole('button', {name: 'add-categories'})
+		).toBeDisabled();
+		expect(screen.getByRole('button', {name: 'try-again'})).toBeDisabled();
 	});
 
-	it('shows the tags loading text', () => {
+	it('fires dismiss when a label close button is clicked', () => {
+		const onDismiss = jest.fn();
+		const suggestion = {isNew: false, name: 'Japan'};
+
 		render(
 			<CategorizationSuggestions
 				{...baseProps}
 				kind="tags"
-				status="loading"
+				onDismiss={onDismiss}
+				status="ready"
+				suggestions={[suggestion]}
 			/>
 		);
 
-		expect(screen.getByText('generating-tags')).toBeInTheDocument();
+		fireEvent.click(screen.getByRole('button', {name: 'remove'}));
+
+		expect(onDismiss).toHaveBeenCalledWith(suggestion);
 	});
 
-	it('shows the no-match text when empty', () => {
+	it('fires try again', () => {
+		const onRegenerate = jest.fn();
+
 		render(
 			<CategorizationSuggestions
 				{...baseProps}
-				kind="categories"
-				status="empty"
+				kind="tags"
+				onRegenerate={onRegenerate}
+				status="ready"
+				suggestions={[{isNew: false, name: 'Japan'}]}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
+
+		expect(onRegenerate).toHaveBeenCalled();
+	});
+
+	it('flags new tags with the new class', () => {
+		const {container} = render(
+			<CategorizationSuggestions
+				{...baseProps}
+				kind="tags"
+				status="ready"
+				suggestions={[{isNew: true, name: 'Culture'}]}
 			/>
 		);
 
 		expect(
-			screen.getByText(
-				'i-have-not-found-any-matching-categories-what-would-you-like-to-do'
-			)
+			container.querySelector('.categorization-suggestion-label--new')
 		).toBeInTheDocument();
 	});
 
@@ -99,72 +114,57 @@ describe('CategorizationSuggestions', () => {
 		expect(onCommit).toHaveBeenCalledWith(suggestions);
 	});
 
-	it('fires regenerate', () => {
-		const onRegenerate = jest.fn();
-
-		render(
-			<CategorizationSuggestions
-				{...baseProps}
-				kind="tags"
-				onRegenerate={onRegenerate}
-				status="ready"
-				suggestions={[{isNew: false, name: 'Japan'}]}
-			/>
-		);
-
-		fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
-
-		expect(onRegenerate).toHaveBeenCalled();
-	});
-
-	it('fires dismiss when a label close button is clicked', () => {
-		const onDismiss = jest.fn();
-		const suggestion = {isNew: false, name: 'Japan'};
-
-		render(
-			<CategorizationSuggestions
-				{...baseProps}
-				kind="tags"
-				onDismiss={onDismiss}
-				status="ready"
-				suggestions={[suggestion]}
-			/>
-		);
-
-		fireEvent.click(screen.getByRole('button', {name: 'remove'}));
-
-		expect(onDismiss).toHaveBeenCalledWith(suggestion);
-	});
-
-	it('flags new tags with the new class', () => {
+	it('renders nothing when idle', () => {
 		const {container} = render(
 			<CategorizationSuggestions
 				{...baseProps}
-				kind="tags"
-				status="ready"
-				suggestions={[{isNew: true, name: 'Culture'}]}
+				kind="categories"
+				status="idle"
 			/>
 		);
 
-		expect(
-			container.querySelector('.categorization-suggestion-label--new')
-		).toBeInTheDocument();
+		expect(container).toBeEmptyDOMElement();
 	});
 
-	it('disables the actions once committed', () => {
+	it('shows the categories loading text', () => {
 		render(
 			<CategorizationSuggestions
 				{...baseProps}
-				committed
 				kind="categories"
-				status="ready"
-				suggestions={[{id: 1, name: 'International'}]}
+				status="loading"
 			/>
 		);
 
 		expect(
-			screen.getByRole('button', {name: 'add-categories'})
-		).toBeDisabled();
-		expect(screen.getByRole('button', {name: 'try-again'})).toBeDisabled();
+			screen.getByText('searching-for-categories')
+		).toBeInTheDocument();
+	});
+
+	it('shows the no-match text when empty', () => {
+		render(
+			<CategorizationSuggestions
+				{...baseProps}
+				kind="categories"
+				status="empty"
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'i-have-not-found-any-matching-categories-what-would-you-like-to-do'
+			)
+		).toBeInTheDocument();
+	});
+
+	it('shows the tags loading text', () => {
+		render(
+			<CategorizationSuggestions
+				{...baseProps}
+				kind="tags"
+				status="loading"
+			/>
+		);
+
+		expect(screen.getByText('generating-tags')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/components/CategorizationSuggestions.test.tsx
@@ -94,7 +94,7 @@ describe('CategorizationSuggestions', () => {
 		expect(screen.getByText('International')).toBeInTheDocument();
 		expect(screen.getByText('Roadtrip')).toBeInTheDocument();
 
-		fireEvent.click(screen.getByRole('button', {name: 'save-categories'}));
+		fireEvent.click(screen.getByRole('button', {name: 'add-categories'}));
 
 		expect(onCommit).toHaveBeenCalledWith(suggestions);
 	});
@@ -112,7 +112,7 @@ describe('CategorizationSuggestions', () => {
 			/>
 		);
 
-		fireEvent.click(screen.getByRole('button', {name: 'regenerate'}));
+		fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
 
 		expect(onRegenerate).toHaveBeenCalled();
 	});
@@ -163,7 +163,7 @@ describe('CategorizationSuggestions', () => {
 		);
 
 		expect(
-			screen.getByRole('button', {name: 'save-categories'})
+			screen.getByRole('button', {name: 'add-categories'})
 		).toBeDisabled();
 		expect(screen.getByRole('button', {name: 'try-again'})).toBeDisabled();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98868

## What Is Being Fixed

The AI Assistant's direct-action balloons labeled their confirm and retry buttons inconsistently. The categorization balloon derived both labels from the suggestion kind, so categories showed "Try Again" and "Save Categories" while tags showed "Regenerate" and "Add Tags". "Save" was also misleading, since nothing is persisted until the user commits the suggestions. The field value balloon shared the same "Regenerate" wording.

## How It Is Being Fixed

Both balloons now use "Try Again" for the retry button and the "Add ..." form for the confirm button. In the categorization balloon the retry label no longer branches on the suggestion kind, since both branches resolved to the same wording, and the confirm label uses the existing `add-categories` key in place of `save-categories`. The field value balloon's retry button moves from `regenerate` to `try-again`. Every key involved already exists in `Language.properties`, so no new key or `buildLang` run is needed.

## Why Are There No Tests?

This is a copy-only change to two button labels. The existing specs already assert on both buttons and were updated to the new keys, so no new test would add coverage.

## PR Check

**pr-check: PASS** — tested on `93719f5af30055be7aba0a22f6c2062cda132fbf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "93719f5af30055be7aba0a22f6c2062cda132fbf"} -->
