### PR TITLE
LPD-100044 Allow Service Nodes to have multiple transition outputs

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
@@ -55,12 +55,6 @@ public class ServiceNodeValidator extends BaseNodeValidator<ServiceNode> {
 			throw new KaleoDefinitionValidationException.
 				MustSetOutgoingTransition(serviceNode.getDefaultLabel());
 		}
-
-		if (serviceNode.getOutgoingTransitionsCount() > 1) {
-			throw new KaleoDefinitionValidationException.
-				MustNotSetMultipleOutgoingTransitions(
-					serviceNode.getDefaultLabel());
-		}
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.DefaultWorkflowNodeSetting;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.kernel.workflow.WorkflowNodeSetting;
+import com.liferay.portal.kernel.workflow.WorkflowTransition;
 import com.liferay.portal.security.script.management.test.util.ScriptManagementConfigurationTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -38,6 +40,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -438,22 +441,30 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 
 	@Test
 	public void testDeployWorkflowDefinitionWithServiceNode() throws Exception {
-		AssertUtils.assertFailure(
-			KaleoDefinitionValidationException.
-				MustNotSetMultipleOutgoingTransitions.class,
-			"The convert node cannot have multiple outgoing transitions",
-			() -> {
-				InputStream inputStream = getResourceInputStream(
-					"service-node-multiple-transitions-workflow-" +
-						"definition.json");
+		InputStream inputStream = getResourceInputStream(
+			"service-node-multiple-transitions-workflow-definition.json");
 
-				_workflowDefinitionManager.deployWorkflowDefinition(
-					FileUtil.getBytes(inputStream),
-					TestPropsValues.getCompanyId(),
-					RandomTestUtil.randomString(),
-					"Service Node Multiple Transitions Workflow Definition",
-					RandomTestUtil.randomString(), TestPropsValues.getUserId());
-			});
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				FileUtil.getBytes(inputStream), TestPropsValues.getCompanyId(),
+				RandomTestUtil.randomString(),
+				"Service Node Multiple Transitions Workflow Definition",
+				RandomTestUtil.randomString(), TestPropsValues.getUserId());
+
+		List<String> targetNodeNames = new ArrayList<>();
+
+		for (WorkflowTransition workflowTransition :
+				workflowDefinition.getWorkflowTransitions()) {
+
+			if (Objects.equals(
+					workflowTransition.getSourceNodeName(), "convert")) {
+
+				targetNodeNames.add(workflowTransition.getTargetNodeName());
+			}
+		}
+
+		Assert.assertEquals(
+			List.of("end", "other"), ListUtil.sort(targetNodeNames));
 
 		byte[] bytes = FileUtil.getBytes(
 			getResourceInputStream("service-node-workflow-definition.json"));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100044

## What Is Being Fixed

`ServiceNodeValidator` rejected any service node with more than one outgoing transition, throwing `MustNotSetMultipleOutgoingTransitions`. That restriction prevented a workflow from branching after a service node, so a definition could not route to different targets based on what the node produced.

## How It Is Being Fixed

The multiple-outgoing-transitions check is removed from `ServiceNodeValidator`, leaving in place the requirement that a service node has at least one outgoing transition. The sibling validators for HTTP request, LLM, and AI Hub agent nodes keep their own single-transition restriction, so the change is scoped to service nodes only.

`WorkflowDefinitionManagerTest.testDeployWorkflowDefinitionWithServiceNode` asserted the old failure, so it now deploys `service-node-multiple-transitions-workflow-definition.json` successfully and verifies that the `convert` node reaches both of its targets.

## PR Check

**pr-check: PASS** — tested on `41b3c5aea822f5c18909b2b7c731e8365f28886a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "41b3c5aea822f5c18909b2b7c731e8365f28886a"} -->
