### PR TITLE
LPD-98873 Use the large label size for suggested chips

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/SuggestionLabel.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/SuggestionLabel.tsx
@@ -33,7 +33,7 @@ export default function SuggestionLabel({
 			}}
 			displayType="secondary"
 			inverse
-			style={{textTransform: 'none'}}
+			size="lg"
 		>
 			<span className="align-items-center d-inline-flex">
 				{suggestion.isNew && (


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98873

## What Is Being Fixed

The suggested category and tag chips in the AI Assistant chat rendered at Clay's default label size. The design library does not allow that size to carry a sticker, so the star icon marking a suggestion as new had no valid placement on the chip.

## How It Is Being Fixed

The chip now passes `size="lg"` to `ClayLabel`. That is the size Figma calls regular, and the smallest one whose variables define a sticker slot, so the star icon sits correctly. Since `label-lg` already sets `text-transform` to none in both the atlas and cadmin variable maps, the inline style that forced it is redundant and was removed.

## Why Are There No Tests?

The module's existing Jest suite (28 suites, 169 tests) covers the surrounding component behavior and passes; the change alters styling only.

## PR Check

**pr-check: PASS** — tested on `c77c9505fb5f8e07341f5fa2bc89f3bbf64f5262`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c77c9505fb5f8e07341f5fa2bc89f3bbf64f5262"} -->
