### PR TITLE
LPD-100157 Remove unused AI Assistant chat input styles

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -227,21 +227,6 @@ html#{$cadmin-selector} .cadmin {
 			padding-top: 1rem;
 		}
 
-		.ai-assistant-chat__input-row {
-			align-items: flex-end;
-			display: flex;
-			flex-direction: row;
-		}
-
-		.ai-assistant-chat__input {
-			height: auto;
-			margin-right: 0.5rem;
-			max-height: calc(1.25em * 4);
-			overflow-x: hidden;
-			overflow-y: auto;
-			resize: none;
-		}
-
 		.ai-assistant-chat__generating-loading-text {
 			-webkit-background-clip: text;
 			-webkit-text-fill-color: transparent;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100157

## What Is Being Fixed

LPD-100157 reported the AI Assistant prompt field rendering broken — the placeholder clipped to a couple of characters with a native scroll widget beside it.

That symptom is a CSS version skew, not a defect in this module. `ClayInputGroupAI` renders `<textarea class="form-control-inset">`, and in cadmin the base `.form-control-inset` is `width: 50px` (intended for tag inputs that grow via flex). The rule that makes it usable, `.input-group-ai .form-control-inset { width: 100% }`, ships in the `$cadmin-input-group-ai` palette added by `f261aaf` under LPD-97009. The reporter had the new markup deployed against theme CSS built before that commit, so the textarea stayed 50px wide. Rebuilding `frontend-css-cadmin-web` and the themes resolves the rendering with no change to this module.

What this branch does address is leftover dead code from the same migration.

## How It Is Being Fixed

Commit `5b7b687` moved `AIAssistantChatBody` from hand-rolled markup to Clay's `ClayInputGroupAI`, which dropped the `ai-assistant-chat__input-row` and `ai-assistant-chat__input` class names from the rendered tree. Their rules stayed behind in `chat.scss`, where they now match nothing and misleadingly suggest the module still sizes its own input. Both rules are removed so the file reflects that all input sizing comes from Clay's `.input-group-ai` palette.

## Why Are There No Tests?

The change only deletes two SCSS rules whose class names no longer appear anywhere in the codebase, so there is no reachable behavior to cover. `git grep ai-assistant-chat__input` returns no matches outside the deleted block.

## PR Check

**pr-check: PASS** — tested on `43c396dc1927d7cdf9d9ed2493e45ee4c77da872`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "43c396dc1927d7cdf9d9ed2493e45ee4c77da872"} -->
