### PR TITLE
LPD-100054 Grant the AI Hub Cell Object Admin and project link scopes

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -111,7 +111,9 @@ public class AIHubCellConfigurationModelListener
 				Arrays.asList(
 					"Liferay.Headless.Batch.Engine.everything",
 					"Liferay.Headless.CMP.everything.read",
-					"Liferay.Portal.Search.REST.everything.read"),
+					"Liferay.Object.Admin.REST.everything.read",
+					"Liferay.Portal.Search.REST.everything.read",
+					"cmpprojectlink.everything"),
 				false, new ServiceContext());
 		}
 		catch (PortalException portalException) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100054

## What Is Being Fixed

The Generate Gap Content agent's workflow makes two HTTP calls with the AI Hub Cell's user token: it reads the CMS Basic Web Content object definition from `/o/object-admin/v1.0/object-definitions/by-external-reference-code/L_CMS_BASIC_WEB_CONTENT` to resolve the generated asset's `className`, and it POSTs to `/o/cmp/project-links/scopes/{scopeKey}` to link that asset to the CMP project. The token is minted from the AI-HUB-CELL OAuth2 application, whose scope list covered neither endpoint, so both calls returned 403 and the agent could not link generated content to a project.

## How It Is Being Fixed

Add `Liferay.Object.Admin.REST.everything.read` and `cmpprojectlink.everything` to the AI-HUB-CELL OAuth2 application's scope list in `AIHubCellConfigurationModelListener`. The first authorizes the object-definition read — `Liferay.Object.Admin.REST` is the `osgi.jaxrs.name` of the object-admin application, and the call is a GET, so read access is sufficient. The second authorizes the project-link write; `/o/cmp/project-links` is the Objects REST surface for the `CMPProjectLink` object rather than a JAX-RS application, so its scope alias is the lowercased object short name, matching the `aihubagentdefinition.everything` style already used for the AI Hub objects. This follows LPD-98258, which granted the same application CMP read access for the Content Gap Analysis agent's coverage call.

## Why Are There No Tests?

The change appends two scope aliases to the OAuth2 application's scope list. `AIHubCellConfigurationModelListenerTest` covers only `onBeforeSave`'s service-URL validation, and a repo-wide search finds no test asserting the contents of this list or of the sibling provisioning application's list, so this follows the established convention of not testing individual scope entries.

## PR Check

**pr-check: PASS** — tested on `708472aa150304f4ef2d9aed3051e600588655dc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "708472aa150304f4ef2d9aed3051e600588655dc"} -->
