### PR TITLE
LPD-97611 AI Hub workflow node types appear in client DXP Kaleo Designer when the AI Hub feature flag is enabled

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils.js
@@ -6,6 +6,7 @@
 import {v4 as uuidv4} from 'uuid';
 
 import {defaultLanguageId} from '../../../constants';
+import {isAIHubDeployment} from '../../../util/isAIHubDeployment';
 import {insertNodeAt} from '../../util/insertNodeAt';
 import AIDecisionNode from './AIDecisionNode';
 import AIHubAgentNode from './AIHubAgentNode';
@@ -77,10 +78,13 @@ let nodeTypes = {
 
 if (Liferay.FeatureFlags['LPD-62272']) {
 	nodeTypes = insertNodeAt(nodeTypes, 'ai-hub-agent', AIHubAgentNode, 1);
-	nodeTypes = insertNodeAt(nodeTypes, 'ai-decision', AIDecisionNode, 2);
-	nodeTypes = insertNodeAt(nodeTypes, 'llm', LLMNode, 7);
-	nodeTypes = insertNodeAt(nodeTypes, 'http-request', HTTPRequestNode, 8);
-	nodeTypes = insertNodeAt(nodeTypes, 'service', ServiceNode, 9);
+
+	if (isAIHubDeployment()) {
+		nodeTypes = insertNodeAt(nodeTypes, 'ai-decision', AIDecisionNode, 2);
+		nodeTypes = insertNodeAt(nodeTypes, 'llm', LLMNode, 7);
+		nodeTypes = insertNodeAt(nodeTypes, 'http-request', HTTPRequestNode, 8);
+		nodeTypes = insertNodeAt(nodeTypes, 'service', ServiceNode, 9);
+	}
 }
 
 export {defaultNodes, nodeDescription, nodeTypes};

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
@@ -7,6 +7,7 @@ import React, {useContext, useEffect, useState} from 'react';
 import {isEdge, isNode} from 'react-flow-renderer';
 
 import {DefinitionBuilderContext} from '../../../DefinitionBuilderContext';
+import {isAIHubDeployment} from '../../../util/isAIHubDeployment';
 import {DiagramBuilderContext} from '../../DiagramBuilderContext';
 import {DefinitionInfo} from './DefinitionInfo/DefinitionInfo';
 import SidebarBody from './SidebarBody';
@@ -138,16 +139,6 @@ export const contents = {
 };
 
 if (Liferay.FeatureFlags['LPD-62272']) {
-	contents['ai-decision'] = {
-		sections: [
-			'nodeInformation',
-			'promptSummary',
-			'ragSummary',
-			'toolsSummary',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('ai-decision'),
-	};
 	contents['ai-hub-agent'] = {
 		sections: [
 			'nodeInformation',
@@ -157,33 +148,46 @@ if (Liferay.FeatureFlags['LPD-62272']) {
 		showDeleteButton: true,
 		title: Liferay.Language.get('ai-hub-agent'),
 	};
-	contents['http-request'] = {
-		sections: [
-			'nodeInformation',
-			'httpEndpoint',
-			'payload',
-			'variables',
-			'connectionTimeout',
-			'authentication',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('http-request'),
-	};
-	contents['llm'] = {
-		sections: [
-			'nodeInformation',
-			'promptSummary',
-			'ragSummary',
-			'toolsSummary',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('llm-node'),
-	};
-	contents['service'] = {
-		sections: ['nodeInformation', 'serviceConfiguration'],
-		showDeleteButton: true,
-		title: Liferay.Language.get('service-node'),
-	};
+
+	if (isAIHubDeployment()) {
+		contents['ai-decision'] = {
+			sections: [
+				'nodeInformation',
+				'promptSummary',
+				'ragSummary',
+				'toolsSummary',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('ai-decision'),
+		};
+		contents['http-request'] = {
+			sections: [
+				'nodeInformation',
+				'httpEndpoint',
+				'payload',
+				'variables',
+				'connectionTimeout',
+				'authentication',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('http-request'),
+		};
+		contents['llm'] = {
+			sections: [
+				'nodeInformation',
+				'promptSummary',
+				'ragSummary',
+				'toolsSummary',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('llm-node'),
+		};
+		contents['service'] = {
+			sections: ['nodeInformation', 'serviceConfiguration'],
+			showDeleteButton: true,
+			title: Liferay.Language.get('service-node'),
+		};
+	}
 }
 
 const errorsDefaultValues = {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {isAIHubDeployment} from '../util/isAIHubDeployment';
+
 const BUFFER_ATTR = [null, '="', null, '" '];
 const BUFFER_CLOSE_NODE = ['</', null, '>'];
 const BUFFER_OPEN_NODE = ['<', null, null, '>'];
@@ -18,22 +20,20 @@ const COL_TYPES_ASSIGNMENT = [
 	'user',
 	'userId',
 ];
+const aiHubEnabled = Liferay.FeatureFlags['LPD-62272'] === true;
+const aiHubDeployment = aiHubEnabled && isAIHubDeployment();
+
 const COL_TYPES_FIELD = [
+	...(aiHubEnabled ? ['ai-hub-agent'] : []),
+	...(aiHubDeployment ? ['ai-decision'] : []),
 	'condition',
 	'fork',
 	'join',
+	...(aiHubDeployment ? ['llm', 'http-request', 'service'] : []),
 	'join-xor',
 	'state',
 	'task',
 ];
-
-if (Liferay.FeatureFlags['LPD-62272'] === true) {
-	COL_TYPES_FIELD.splice(0, 0, 'ai-hub-agent');
-	COL_TYPES_FIELD.splice(1, 0, 'ai-decision');
-	COL_TYPES_FIELD.splice(5, 0, 'llm');
-	COL_TYPES_FIELD.splice(6, 0, 'http-request');
-	COL_TYPES_FIELD.splice(7, 0, 'service');
-}
 
 const DEFAULT_LANGUAGE = 'groovy';
 const STR_BLANK = '';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/isAIHubDeployment.ts
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/isAIHubDeployment.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const AI_HUB_HOSTNAMES = [
+	'ai-dev.liferay.net',
+	'ai-uat.liferay.net',
+	'ai.hub.liferay.com',
+	'localhost',
+];
+
+function isAIHubDeployment(): boolean {
+	return AI_HUB_HOSTNAMES.includes(window.location.hostname);
+}
+
+export {isAIHubDeployment};

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnAIHubDeployment.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnAIHubDeployment.spec.js
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const AI_HUB_NODE_TYPES = [
+	'ai-decision',
+	'ai-hub-agent',
+	'http-request',
+	'llm',
+	'service',
+];
+
+const originalLocation = window.location;
+
+describe('AI Hub node gating on an AI Hub deployment', () => {
+	let colTypesField;
+	let contents;
+	let nodeTypes;
+
+	beforeAll(() => {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: new URL('https://ai.hub.liferay.com/'),
+		});
+
+		Liferay.FeatureFlags['LPD-62272'] = true;
+
+		colTypesField =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants').COL_TYPES_FIELD;
+		contents =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar').contents;
+		nodeTypes =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils').nodeTypes;
+	});
+
+	afterAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		});
+	});
+
+	it('offers every AI Hub node', () => {
+		AI_HUB_NODE_TYPES.forEach((nodeType) => {
+			expect(colTypesField).toContain(nodeType);
+			expect(contents).toHaveProperty(nodeType);
+			expect(nodeTypes).toHaveProperty(nodeType);
+		});
+	});
+});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnClientDeployment.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnClientDeployment.spec.js
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const AI_HUB_ONLY_NODE_TYPES = [
+	'ai-decision',
+	'http-request',
+	'llm',
+	'service',
+];
+
+const originalLocation = window.location;
+
+describe('AI Hub node gating on a client deployment', () => {
+	let colTypesField;
+	let contents;
+	let nodeTypes;
+
+	beforeAll(() => {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: new URL('https://dxp.acme.com/'),
+		});
+
+		Liferay.FeatureFlags['LPD-62272'] = true;
+
+		colTypesField =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants').COL_TYPES_FIELD;
+		contents =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar').contents;
+		nodeTypes =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils').nodeTypes;
+	});
+
+	afterAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		});
+	});
+
+	it('offers the AI Hub Agent node', () => {
+		expect(colTypesField).toContain('ai-hub-agent');
+		expect(contents).toHaveProperty('ai-hub-agent');
+		expect(nodeTypes).toHaveProperty('ai-hub-agent');
+	});
+
+	it('withholds the nodes whose executors the AI Hub deploys', () => {
+		AI_HUB_ONLY_NODE_TYPES.forEach((nodeType) => {
+			expect(colTypesField).not.toContain(nodeType);
+			expect(contents).not.toHaveProperty(nodeType);
+			expect(nodeTypes).not.toHaveProperty(nodeType);
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97611

## What Is Being Fixed

The AI Decision, HTTP Request, LLM, and Service node executors are deployed by the AI Hub, so those nodes cannot run on a client DXP. The Kaleo Designer ships to every DXP and added them to the palette, to the node configuration panels, and to the source builder column types based only on the `LPD-62272` feature flag, which exposed them wherever the flag was enabled.

## How It Is Being Fixed

A new `isAIHubDeployment` helper matches the current hostname against the known AI Hub hostnames, and the three places that register the node types now gate the four AI Hub only nodes behind it in addition to the feature flag. The AI Hub Agent node stays behind the feature flag alone, because the portal deploys its node executor itself.

The source builder column types are now built from a single array rather than from a chain of splice calls, whose indexes each assumed that the previous insertion had already happened.

Coverage comes from two Jest specs, one per deployment shape, that assert the gating across all three surfaces: on a client hostname the AI Hub Agent node is still offered while the other four are withheld, and on an AI Hub hostname all five are offered. They are split into separate files because re-importing the Sidebar dependency graph within one file trips singleton guards in CKEditor and `@jsonurl/jsonurl`.

## PR Check

**pr-check: PASS** — tested on `55b927a71ad3d2417b6320c91f1f9466702afbc9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "55b927a71ad3d2417b6320c91f1f9466702afbc9"} -->
