### PR TITLE
LPD-97611 AI Hub workflow node types appear in client DXP Kaleo Designer when the AI Hub feature flag is enabled

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/LiferayGlobalObjectPreAUIDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/LiferayGlobalObjectPreAUIDynamicInclude.java
@@ -535,6 +535,10 @@ public class LiferayGlobalObjectPreAUIDynamicInclude
 				WebKeys.THEME_DISPLAY);
 
 		_renderValue(
+			"ENTERPRISE_PRODUCT_AI_HUB_ENABLED", sb,
+			PropsValues.ENTERPRISE_PRODUCT_AI_HUB_ENABLED);
+
+		_renderValue(
 			"JAVASCRIPT_SINGLE_PAGE_APPLICATION_TIMEOUT", sb,
 			_prefsProps.getInteger(
 				themeDisplay.getCompanyId(),

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -139,6 +139,7 @@ declare module Liferay {
 	}
 
 	namespace PropsValues {
+		export const ENTERPRISE_PRODUCT_AI_HUB_ENABLED: boolean;
 		export const UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE: number;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/test/resources/com/liferay/frontend/js/web/internal/servlet/taglib/dependencies/liferay_test.js.tpl
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/resources/com/liferay/frontend/js/web/internal/servlet/taglib/dependencies/liferay_test.js.tpl
@@ -140,6 +140,7 @@ INSTANCE_SETTINGS: 'com_liferay_configuration_admin_web_portlet_InstanceSettings
 ITEM_SELECTOR: 'com_liferay_item_selector_web_portlet_ItemSelectorPortlet',
 },
 PropsValues: {
+ENTERPRISE_PRODUCT_AI_HUB_ENABLED: false,
 JAVASCRIPT_SINGLE_PAGE_APPLICATION_TIMEOUT: 0,
 UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE: 0,
 },

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils.js
@@ -6,6 +6,7 @@
 import {v4 as uuidv4} from 'uuid';
 
 import {defaultLanguageId} from '../../../constants';
+import {isAIHubInstance} from '../../../util/isAIHubInstance';
 import {insertNodeAt} from '../../util/insertNodeAt';
 import AIDecisionNode from './AIDecisionNode';
 import AIHubAgentNode from './AIHubAgentNode';
@@ -77,10 +78,13 @@ let nodeTypes = {
 
 if (Liferay.FeatureFlags['LPD-62272']) {
 	nodeTypes = insertNodeAt(nodeTypes, 'ai-hub-agent', AIHubAgentNode, 1);
-	nodeTypes = insertNodeAt(nodeTypes, 'ai-decision', AIDecisionNode, 2);
-	nodeTypes = insertNodeAt(nodeTypes, 'llm', LLMNode, 7);
-	nodeTypes = insertNodeAt(nodeTypes, 'http-request', HTTPRequestNode, 8);
-	nodeTypes = insertNodeAt(nodeTypes, 'service', ServiceNode, 9);
+
+	if (isAIHubInstance()) {
+		nodeTypes = insertNodeAt(nodeTypes, 'ai-decision', AIDecisionNode, 2);
+		nodeTypes = insertNodeAt(nodeTypes, 'llm', LLMNode, 7);
+		nodeTypes = insertNodeAt(nodeTypes, 'http-request', HTTPRequestNode, 8);
+		nodeTypes = insertNodeAt(nodeTypes, 'service', ServiceNode, 9);
+	}
 }
 
 export {defaultNodes, nodeDescription, nodeTypes};

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar.js
@@ -7,6 +7,7 @@ import React, {useContext, useEffect, useState} from 'react';
 import {isEdge, isNode} from 'react-flow-renderer';
 
 import {DefinitionBuilderContext} from '../../../DefinitionBuilderContext';
+import {isAIHubInstance} from '../../../util/isAIHubInstance';
 import {DiagramBuilderContext} from '../../DiagramBuilderContext';
 import {DefinitionInfo} from './DefinitionInfo/DefinitionInfo';
 import SidebarBody from './SidebarBody';
@@ -138,16 +139,6 @@ export const contents = {
 };
 
 if (Liferay.FeatureFlags['LPD-62272']) {
-	contents['ai-decision'] = {
-		sections: [
-			'nodeInformation',
-			'promptSummary',
-			'ragSummary',
-			'toolsSummary',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('ai-decision'),
-	};
 	contents['ai-hub-agent'] = {
 		sections: [
 			'nodeInformation',
@@ -157,33 +148,46 @@ if (Liferay.FeatureFlags['LPD-62272']) {
 		showDeleteButton: true,
 		title: Liferay.Language.get('ai-hub-agent'),
 	};
-	contents['http-request'] = {
-		sections: [
-			'nodeInformation',
-			'httpEndpoint',
-			'payload',
-			'variables',
-			'connectionTimeout',
-			'authentication',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('http-request'),
-	};
-	contents['llm'] = {
-		sections: [
-			'nodeInformation',
-			'promptSummary',
-			'ragSummary',
-			'toolsSummary',
-		],
-		showDeleteButton: true,
-		title: Liferay.Language.get('llm-node'),
-	};
-	contents['service'] = {
-		sections: ['nodeInformation', 'serviceConfiguration'],
-		showDeleteButton: true,
-		title: Liferay.Language.get('service-node'),
-	};
+
+	if (isAIHubInstance()) {
+		contents['ai-decision'] = {
+			sections: [
+				'nodeInformation',
+				'promptSummary',
+				'ragSummary',
+				'toolsSummary',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('ai-decision'),
+		};
+		contents['http-request'] = {
+			sections: [
+				'nodeInformation',
+				'httpEndpoint',
+				'payload',
+				'variables',
+				'connectionTimeout',
+				'authentication',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('http-request'),
+		};
+		contents['llm'] = {
+			sections: [
+				'nodeInformation',
+				'promptSummary',
+				'ragSummary',
+				'toolsSummary',
+			],
+			showDeleteButton: true,
+			title: Liferay.Language.get('llm-node'),
+		};
+		contents['service'] = {
+			sections: ['nodeInformation', 'serviceConfiguration'],
+			showDeleteButton: true,
+			title: Liferay.Language.get('service-node'),
+		};
+	}
 }
 
 const errorsDefaultValues = {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {isAIHubInstance} from '../util/isAIHubInstance';
+
 const BUFFER_ATTR = [null, '="', null, '" '];
 const BUFFER_CLOSE_NODE = ['</', null, '>'];
 const BUFFER_OPEN_NODE = ['<', null, null, '>'];
@@ -18,7 +20,13 @@ const COL_TYPES_ASSIGNMENT = [
 	'user',
 	'userId',
 ];
+const isFeatureFlagActive = Liferay.FeatureFlags['LPD-62272'] === true;
+
 const COL_TYPES_FIELD = [
+	...(isFeatureFlagActive ? ['ai-hub-agent'] : []),
+	...(isFeatureFlagActive && isAIHubInstance()
+		? ['ai-decision', 'http-request', 'llm', 'service']
+		: []),
 	'condition',
 	'fork',
 	'join',
@@ -26,14 +34,6 @@ const COL_TYPES_FIELD = [
 	'state',
 	'task',
 ];
-
-if (Liferay.FeatureFlags['LPD-62272'] === true) {
-	COL_TYPES_FIELD.splice(0, 0, 'ai-hub-agent');
-	COL_TYPES_FIELD.splice(1, 0, 'ai-decision');
-	COL_TYPES_FIELD.splice(5, 0, 'llm');
-	COL_TYPES_FIELD.splice(6, 0, 'http-request');
-	COL_TYPES_FIELD.splice(7, 0, 'service');
-}
 
 const DEFAULT_LANGUAGE = 'groovy';
 const STR_BLANK = '';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/isAIHubInstance.ts
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/isAIHubInstance.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+function isAIHubInstance(): boolean {
+	return Boolean(
+		Liferay.PropsValues &&
+			Liferay.PropsValues.ENTERPRISE_PRODUCT_AI_HUB_ENABLED
+	);
+}
+
+export {isAIHubInstance};

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnAIHubInstance.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnAIHubInstance.spec.js
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const AI_HUB_NODE_TYPES = [
+	'ai-decision',
+	'ai-hub-agent',
+	'http-request',
+	'llm',
+	'service',
+];
+
+describe('AI Hub node gating on an AI Hub instance', () => {
+	let colTypesField;
+	let contents;
+	let nodeTypes;
+
+	beforeAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = true;
+		Liferay.PropsValues = {
+			...Liferay.PropsValues,
+			ENTERPRISE_PRODUCT_AI_HUB_ENABLED: true,
+		};
+
+		colTypesField =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants').COL_TYPES_FIELD;
+		contents =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar').contents;
+		nodeTypes =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils').nodeTypes;
+	});
+
+	afterAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+
+		delete Liferay.PropsValues.ENTERPRISE_PRODUCT_AI_HUB_ENABLED;
+	});
+
+	it('offers every AI Hub node type', () => {
+		AI_HUB_NODE_TYPES.forEach((nodeType) => {
+			expect(colTypesField).toContain(nodeType);
+			expect(contents).toHaveProperty(nodeType);
+			expect(nodeTypes).toHaveProperty(nodeType);
+		});
+	});
+});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnClientInstance.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/aiHubNodeGatingOnClientInstance.spec.js
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const AI_HUB_ONLY_NODE_TYPES = [
+	'ai-decision',
+	'http-request',
+	'llm',
+	'service',
+];
+
+describe('AI Hub node gating on a client DXP instance', () => {
+	let colTypesField;
+	let contents;
+	let nodeTypes;
+
+	beforeAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = true;
+		Liferay.PropsValues = {
+			...Liferay.PropsValues,
+			ENTERPRISE_PRODUCT_AI_HUB_ENABLED: false,
+		};
+
+		colTypesField =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/constants').COL_TYPES_FIELD;
+		contents =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/Sidebar').contents;
+		nodeTypes =
+			require('../../../../src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/utils').nodeTypes;
+	});
+
+	afterAll(() => {
+		Liferay.FeatureFlags['LPD-62272'] = false;
+
+		delete Liferay.PropsValues.ENTERPRISE_PRODUCT_AI_HUB_ENABLED;
+	});
+
+	it('offers the AI Hub Agent node, whose executor the portal deploys', () => {
+		expect(colTypesField).toContain('ai-hub-agent');
+		expect(contents).toHaveProperty('ai-hub-agent');
+		expect(nodeTypes).toHaveProperty('ai-hub-agent');
+	});
+
+	it('withholds the nodes whose executors only the AI Hub deploys', () => {
+		AI_HUB_ONLY_NODE_TYPES.forEach((nodeType) => {
+			expect(colTypesField).not.toContain(nodeType);
+			expect(contents).not.toHaveProperty(nodeType);
+			expect(nodeTypes).not.toHaveProperty(nodeType);
+		});
+	});
+});

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1660,6 +1660,17 @@
 ##
 
     #
+    # Set this property to true to indicate that this instance is a Liferay AI
+    # Hub deployment. The AI Hub is a separate product from Liferay DXP and is
+    # licensed separately. Only an AI Hub deployment sets this property to true.
+    # Your right to use the AI Hub is subject to the applicable end user license
+    # agreement covering the AI Hub.
+    #
+    # Env: LIFERAY_ENTERPRISE_PERIOD_PRODUCT_PERIOD_AI_PERIOD_HUB_PERIOD_ENABLED
+    #
+    enterprise.product.ai.hub.enabled=false
+
+    #
     # Set this property to true to enable use of Liferay Enterprise Search (LES)
     # applications and features. Your right to use LES is subject to the
     # applicable end user license agreement covering LES.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1018,6 +1018,9 @@ public interface PropsKeys {
 	public static final String EHCACHE_SINGLE_VM_CONFIG_LOCATION =
 		"ehcache.single.vm.config.location";
 
+	public static final String ENTERPRISE_PRODUCT_AI_HUB_ENABLED =
+		"enterprise.product.ai.hub.enabled";
+
 	public static final String ENTERPRISE_PRODUCT_NOTIFICATION_ENABLED =
 		"enterprise.product.notification.enabled";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -806,6 +806,10 @@ public class PropsValues {
 	public static final String EDITOR_WYSIWYG_DEFAULT = PropsUtil.get(
 		PropsKeys.EDITOR_WYSIWYG_DEFAULT);
 
+	public static final boolean ENTERPRISE_PRODUCT_AI_HUB_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.ENTERPRISE_PRODUCT_AI_HUB_ENABLED));
+
 	public static final boolean ENTERPRISE_PRODUCT_NOTIFICATION_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.ENTERPRISE_PRODUCT_NOTIFICATION_ENABLED));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97611

## What Is Being Fixed

The AI Decision, HTTP Request, LLM, and Service node executors are deployed by the AI Hub, so those nodes cannot run on a client DXP. The Kaleo Designer ships to every DXP and added them to the palette, to the node configuration panels, and to the source builder column types based only on the `LPD-62272` feature flag, which exposed them wherever the flag was enabled.

## How It Is Being Fixed

A new portal property, `enterprise.product.ai.hub.enabled`, identifies an AI Hub instance. It sits with the other enterprise product properties, defaults to false, and only an AI Hub deployment sets it to true. The value is published to the browser through `Liferay.PropsValues`, so the Kaleo Designer can read it without a service call.

The `isAIHubInstance` helper reads that value, and the three places that register the node types now gate the four AI Hub only nodes behind it in addition to the feature flag. The AI Hub Agent node stays behind the feature flag alone, because the portal deploys its node executor itself.

An earlier revision of this fix matched the browser hostname against a list of known AI Hub hostnames. A portal property replaces that approach because the hostname list is deployment specific, breaks for any instance served from a different domain, and puts a licensing decision in the browser rather than in the portal configuration.

The source builder column types are now built from a single array rather than from a chain of splice calls, whose indexes each assumed that the previous insertion had already happened.

Coverage comes from two Jest specs, one per instance shape, that assert the gating across all three surfaces: on a client instance the AI Hub Agent node is still offered while the other four are withheld, and on an AI Hub instance all five are offered. They are split into separate files because re-importing the Sidebar dependency graph within one file trips singleton guards in CKEditor and `@jsonurl/jsonurl`.

## PR Check

**pr-check: PASS** — tested on `fa4496bb1310eb7c96ea50051f1967ea67ab3490`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fa4496bb1310eb7c96ea50051f1967ea67ab3490"} -->
