### PR TITLE
LPD-98877 Align the AI affordances across the CMS and CMP UI

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -8,12 +8,6 @@ $ai-assistant-sidebar-width: 448px;
 }
 
 html#{$cadmin-selector} {
-	.ai-assistant__separator {
-		align-self: center;
-		border: 1px solid #a7a9bc;
-		height: 16px;
-	}
-
 	.ai-assistant-chat__dropdown {
 		display: flex;
 		padding: 0;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -127,6 +127,7 @@ html#{$cadmin-selector} .cadmin {
 	.ai-assistant-chat__panel-close-button,
 	.ai-assistant-chat__panel-expand-button {
 		color: $cadmin-gray-600;
+		font-size: 0.75rem;
 	}
 
 	.ai-assistant-chat__body-slot {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
@@ -39,6 +39,7 @@ const AIAssistantPanelHeader: React.FC<AIAssistantPanelHeaderProps> = ({
 									borderless
 									displayType="unstyled"
 									onClick={onToggleExpanded}
+									size="sm"
 								>
 									<ClayIcon
 										className="ai-assistant-chat__panel-expand-button"
@@ -58,6 +59,7 @@ const AIAssistantPanelHeader: React.FC<AIAssistantPanelHeaderProps> = ({
 							borderless
 							displayType="unstyled"
 							onClick={onClose}
+							size="sm"
 						>
 							<ClayIcon
 								className="ai-assistant-chat__panel-close-button"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -630,6 +630,17 @@ describe('AIAssistantHost', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders the panel header actions as small buttons', async () => {
+		await renderAndOpen();
+
+		expect(screen.getByRole('button', {name: 'maximize'})).toHaveClass(
+			'btn-sm'
+		);
+		expect(screen.getByRole('button', {name: 'close'})).toHaveClass(
+			'btn-sm'
+		);
+	});
+
 	it('reopens with the last presentation for an open event', async () => {
 		await renderAndOpen();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/CreationMenu.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/CreationMenu.js
@@ -23,24 +23,24 @@ describe('CreationMenu', () => {
 
 	it('forwards the item className to the dropdown item', async () => {
 		renderCreationMenu([
-			{className: 'cms-generate-content-with-ai', label: 'Generate'},
+			{className: 'cms-generate-with-ai', label: 'Generate'},
 			{label: 'Create Folder'},
 		]);
 
 		await userEvent.click(screen.getByTestId('fdsCreationActionButton'));
 
 		expect(screen.getByText('Generate')).toHaveClass(
-			'cms-generate-content-with-ai'
+			'cms-generate-with-ai'
 		);
 	});
 
 	it('forwards the item className to the single creation button', () => {
 		renderCreationMenu([
-			{className: 'cms-generate-content-with-ai', label: 'Generate'},
+			{className: 'cms-generate-with-ai', label: 'Generate'},
 		]);
 
 		expect(screen.getByText('Generate')).toHaveClass(
-			'cms-generate-content-with-ai'
+			'cms-generate-with-ai'
 		);
 	});
 });

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
@@ -1,3 +1,4 @@
+@import 'components/ai_assistant';
 @import 'components/breadcrumb';
 @import 'components/ckeditor';
 @import 'components/control_menu';

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ai_assistant.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ai_assistant.scss
@@ -1,0 +1,9 @@
+.cms-generate-with-ai {
+	color: $purple;
+
+	&:focus,
+	&:hover {
+		background-color: $purple-l5;
+		color: $purple;
+	}
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
@@ -83,19 +83,15 @@ export default function EditorToolbar({
 			title={title}
 		>
 			{Liferay.FeatureFlags['LPD-62272'] && (
-				<>
-					<Toolbar.Item>
-						<AIAssistantTriggerButton
-							context={{groupId}}
-							hideLabel
-							instructionDefinitionScope="cms"
-							presentation="dropdown"
-							round
-						/>
-					</Toolbar.Item>
-
-					<div className="ai-assistant__separator" />
-				</>
+				<Toolbar.Item className="nav-divider-end">
+					<AIAssistantTriggerButton
+						context={{groupId}}
+						hideLabel
+						instructionDefinitionScope="cms"
+						presentation="dropdown"
+						round
+					/>
+				</Toolbar.Item>
 			)}
 
 			<Toolbar.Item>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
@@ -74,16 +74,6 @@
 	}
 }
 
-.cms-generate-content-with-ai {
-	color: $purple;
-
-	&:focus,
-	&:hover {
-		background-color: $purple-l5;
-		color: $purple;
-	}
-}
-
 .cms-related-assets {
 	padding-top: 1px;
 	position: relative;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -258,21 +258,17 @@ export default function ContentEditorToolbar({
 			title={headerTitle}
 		>
 			{Liferay.FeatureFlags['LPD-62272'] && (
-				<>
-					<Toolbar.Item>
-						<AIAssistantTriggerButton
-							context={{groupId}}
-							enableFreeFormCategorization
-							getContext={getContext}
-							hideLabel
-							instructionDefinitionScope="cms"
-							presentation="dropdown"
-							round
-						/>
-					</Toolbar.Item>
-
-					<div className="ai-assistant__separator" />
-				</>
+				<Toolbar.Item className="nav-divider-end">
+					<AIAssistantTriggerButton
+						context={{groupId}}
+						enableFreeFormCategorization
+						getContext={getContext}
+						hideLabel
+						instructionDefinitionScope="cms"
+						presentation="dropdown"
+						round
+					/>
+				</Toolbar.Item>
 			)}
 
 			<Toolbar.Item className="nav-divider-end">

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -342,9 +342,10 @@ const AssetCategories = ({
 							aria-label={Liferay.Language.get(
 								'add-categories-with-ai'
 							)}
-							className="ml-2"
+							className="cms-generate-with-ai ml-2"
 							displayType="unstyled"
 							onClick={handleGenerateCategories}
+							rounded={true}
 							symbol="stars"
 							title={Liferay.Language.get(
 								'add-categories-with-ai'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -62,7 +62,7 @@ const AssetTags = ({
 	const apiURL = useMemo(() => {
 		const baseURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/headless-admin-taxonomy/v1.0/sites`;
 
-		if (scopeId >= 0) {
+		if (scopeId > 0) {
 			return `${baseURL}/${scopeId}/keywords`;
 		}
 
@@ -235,9 +235,10 @@ const AssetTags = ({
 							aria-label={Liferay.Language.get(
 								'generate-tags-with-ai'
 							)}
-							className="ml-2"
+							className="cms-generate-with-ai ml-2"
 							displayType="unstyled"
 							onClick={handleGenerateTags}
+							rounded={true}
 							symbol="stars"
 							title={Liferay.Language.get(
 								'generate-tags-with-ai'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -260,7 +260,7 @@ export default function AssetsFDSPropsTransformer({
 				ACTIONS
 			).map((item) =>
 				GENERATE_WITH_AI_ACTIONS.includes(item.data?.action ?? '')
-					? {...item, className: 'cms-generate-content-with-ai'}
+					? {...item, className: 'cms-generate-with-ai'}
 					: item
 			),
 		},

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -261,6 +261,16 @@ describe('AssetCategories', () => {
 		);
 	});
 
+	it('styles the sparkle with the shared AI class', () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+
+		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: 123});
+
+		expect(
+			screen.getByRole('button', {name: 'add-categories-with-ai'})
+		).toHaveClass('cms-generate-with-ai');
+	});
+
 	it('hides categories from system vocabularies', () => {
 		renderComponent({
 			systemVocabularyIds: [10],

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
@@ -251,6 +251,16 @@ describe('AssetTags', () => {
 		);
 	});
 
+	it('styles the sparkle with the shared AI class', () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+
+		renderComponent({cmsGroupId: 456, scopeId: 123});
+
+		expect(
+			screen.getByRole('button', {name: 'generate-tags-with-ai'})
+		).toHaveClass('cms-generate-with-ai');
+	});
+
 	it('prefers the edited content from getContent over the persisted content', async () => {
 		const fire = jest.fn();
 		const getContent = jest.fn().mockResolvedValue('edited content');

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
@@ -250,8 +250,8 @@ describe('AssetsFDSPropsTransformer', () => {
 		const [contentItem, imageItem, folderItem] =
 			result.creationMenu.primaryItems;
 
-		expect(contentItem.className).toBe('cms-generate-content-with-ai');
-		expect(imageItem.className).toBe('cms-generate-content-with-ai');
+		expect(contentItem.className).toBe('cms-generate-with-ai');
+		expect(imageItem.className).toBe('cms-generate-with-ai');
 		expect(folderItem.className).toBeUndefined();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98877

## What Is Being Fixed

The AI affordances outside the categories and tags suggestion flow did not match the rest of the AI UI. The chat panel header actions used the regular button size instead of the small one, the AI trigger divider in the CMS and CMP editor toolbars did not line up with the trigger, an AI assistant separator style was left behind with no markup using it, and the sparkle buttons in the categories and tags panels carried no AI styling at all, so they rendered as plain unstyled icon buttons next to the purple affordances used everywhere else in CMS.

## How It Is Being Fixed

The categories and tags buttons now share the class the AI creation menu items already use. That class is renamed to cms-generate-with-ai because it no longer applies only to content generation, and it rounds the hover on monospaced icon buttons so the affordance reads as a circle. The style moves out of the site initializer stylesheet into a components partial in the CMS theme, since the categorization panels are also rendered by the CMP site initializer, which never links that stylesheet. The remaining commits align the chat panel header actions with the small button variant, match the trigger divider in both editor toolbars, and drop the unused separator style.

## PR Check

**pr-check: PASS** — tested on `0daa1c82f1c28aef8bae0e691675799add828a86`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0daa1c82f1c28aef8bae0e691675799add828a86"} -->
