### PR TITLE
LPD-100231 Open the AI assistant as a dropdown for tags and categories

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantHost.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantHost.tsx
@@ -61,19 +61,21 @@ const AIAssistantHost: React.FC = () => {
 
 	const sidebarId = useId();
 	const anchorRef = useRef<HTMLElement | null>(null);
+	const triggerElementRef = useRef<HTMLElement | null>(null);
 
 	useEffect(() => releaseHost, []);
 
 	useEffect(() => {
 		if (command) {
 			setLastCommand(command);
-			setOpenedByEvent(false);
 			setExpanded(false);
 		}
+		setOpenedByEvent(false);
 	}, [command]);
 
 	const activeCommand = command ?? lastCommand;
 	const anchorId = activeCommand?.anchorId;
+	const triggerId = activeCommand?.triggerId;
 
 	const isOpen = command !== null || openedByEvent;
 
@@ -88,6 +90,12 @@ const AIAssistantHost: React.FC = () => {
 
 		setAnchorElement(element);
 	}, [anchorId]);
+
+	useEffect(() => {
+		triggerElementRef.current = triggerId
+			? document.getElementById(triggerId)
+			: null;
+	}, [triggerId]);
 
 	useEffect(() => {
 		if (showSidebar) {
@@ -168,6 +176,7 @@ const AIAssistantHost: React.FC = () => {
 							handleClose();
 						}
 					}}
+					triggerRef={triggerElementRef}
 				>
 					<div className="ai-assistant ai-assistant-chat__dropdown-container">
 						<AIAssistantPanelHeader

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantTriggerButton.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantTriggerButton.tsx
@@ -19,17 +19,21 @@ type AIAssistantTriggerButtonProps = Omit<
 	AIAssistantOpenCommand,
 	'anchorId' | 'triggerId'
 > & {
+	anchorId?: string;
 	className?: string;
 	hideLabel?: boolean;
 	label?: string;
+	onOpen?: () => void;
 	round?: boolean;
 	triggerId?: string;
 };
 
 const AIAssistantTriggerButton: React.FC<AIAssistantTriggerButtonProps> = ({
+	anchorId,
 	className,
 	hideLabel,
 	label,
+	onOpen,
 	round = true,
 	triggerId,
 	...command
@@ -54,9 +58,12 @@ const AIAssistantTriggerButton: React.FC<AIAssistantTriggerButtonProps> = ({
 		open({
 			presentation: 'sidebar',
 			...command,
-			anchorId: id,
+			anchorId:
+				anchorId && document.getElementById(anchorId) ? anchorId : id,
 			triggerId: id,
 		});
+
+		onOpen?.();
 	};
 
 	return (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -8,12 +8,6 @@ $ai-assistant-sidebar-width: 448px;
 }
 
 html#{$cadmin-selector} {
-	.ai-assistant__separator {
-		align-self: center;
-		border: 1px solid #a7a9bc;
-		height: 16px;
-	}
-
 	.ai-assistant-chat__dropdown {
 		display: flex;
 		padding: 0;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -127,6 +127,7 @@ html#{$cadmin-selector} .cadmin {
 	.ai-assistant-chat__panel-close-button,
 	.ai-assistant-chat__panel-expand-button {
 		color: $cadmin-gray-600;
+		font-size: 0.75rem;
 	}
 
 	.ai-assistant-chat__body-slot {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantPanelHeader.tsx
@@ -39,6 +39,7 @@ const AIAssistantPanelHeader: React.FC<AIAssistantPanelHeaderProps> = ({
 									borderless
 									displayType="unstyled"
 									onClick={onToggleExpanded}
+									size="sm"
 								>
 									<ClayIcon
 										className="ai-assistant-chat__panel-expand-button"
@@ -58,6 +59,7 @@ const AIAssistantPanelHeader: React.FC<AIAssistantPanelHeaderProps> = ({
 							borderless
 							displayType="unstyled"
 							onClick={onClose}
+							size="sm"
 						>
 							<ClayIcon
 								className="ai-assistant-chat__panel-close-button"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistant.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistant.test.tsx
@@ -105,6 +105,70 @@ describe('AIAssistant single-host invariants', () => {
 });
 
 describe('AIAssistantTriggerButton', () => {
+	it('anchors the assistant to the anchorId element when it is on the page', () => {
+		const anchor = document.createElement('div');
+
+		anchor.id = 'toolbar-anchor';
+
+		document.body.appendChild(anchor);
+
+		renderTL(
+			<AIAssistantTriggerButton
+				anchorId="toolbar-anchor"
+				instructionDefinitionScope="cms"
+				label="Generate"
+				triggerId="generate"
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', {name: 'Generate'}));
+
+		expect(getState().command?.anchorId).toBe('toolbar-anchor');
+		expect(getState().command?.triggerId).toBe('generate');
+
+		anchor.remove();
+	});
+
+	it('anchors the assistant to itself when the anchorId element is absent', () => {
+		renderTL(
+			<AIAssistantTriggerButton
+				anchorId="missing-anchor"
+				instructionDefinitionScope="cms"
+				label="Generate"
+				triggerId="generate"
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', {name: 'Generate'}));
+
+		expect(getState().command?.anchorId).toBe('generate');
+	});
+
+	it('invokes onOpen when opening but not when toggling closed', () => {
+		const onOpen = jest.fn();
+
+		renderTL(
+			<AIAssistantTriggerButton
+				instructionDefinitionScope="cms"
+				label="Generate"
+				onOpen={onOpen}
+				triggerId="generate"
+			/>
+		);
+
+		const trigger = screen.getByRole('button', {name: 'Generate'});
+
+		fireEvent.click(trigger);
+
+		expect(onOpen).toHaveBeenCalledTimes(1);
+		expect(getState().command?.triggerId).toBe('generate');
+
+		fireEvent.click(trigger);
+
+		expect(onOpen).toHaveBeenCalledTimes(1);
+		expect(getState().command).toBeNull();
+	});
+
 	it('marks only the trigger that is driving the host as expanded', () => {
 		renderTL(
 			<>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -230,6 +230,49 @@ describe('AIAssistantHost', () => {
 		).toHaveLength(2);
 	});
 
+	it('closes the dropdown when a trigger anchored elsewhere is clicked again', async () => {
+		const anchor = document.createElement('button');
+
+		anchor.id = 'toolbar-anchor';
+
+		document.body.appendChild(anchor);
+
+		await renderAndOpen({
+			anchorId: 'toolbar-anchor',
+			presentation: 'dropdown',
+			triggerId: 'tags-trigger',
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({
+				agent: ECategorizationAgent.GENERATE_TAGS,
+				content: 'Body',
+			});
+		});
+
+		// While the dropdown is open, Clay's Overlay hides everything outside
+		// the menu with aria-hidden, so the trigger is only reachable by id.
+
+		const trigger = document.getElementById('tags-trigger') as HTMLElement;
+
+		expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+		await act(async () => {
+			fireEvent.pointerDown(trigger);
+			fireEvent.mouseDown(trigger);
+			fireEvent.pointerUp(trigger);
+			fireEvent.mouseUp(trigger);
+			fireEvent.click(trigger);
+		});
+
+		expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		expect(
+			screen.queryByRole('button', {name: 'maximize'})
+		).not.toBeInTheDocument();
+
+		anchor.remove();
+	});
+
 	it('closes the sidebar on Escape', async () => {
 		await renderAndOpen({presentation: 'sidebar'});
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -630,6 +630,17 @@ describe('AIAssistantHost', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders the panel header actions as small buttons', async () => {
+		await renderAndOpen();
+
+		expect(screen.getByRole('button', {name: 'maximize'})).toHaveClass(
+			'btn-sm'
+		);
+		expect(screen.getByRole('button', {name: 'close'})).toHaveClass(
+			'btn-sm'
+		);
+	});
+
 	it('reopens with the last presentation for an open event', async () => {
 		await renderAndOpen();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/CreationMenu.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/CreationMenu.js
@@ -23,24 +23,24 @@ describe('CreationMenu', () => {
 
 	it('forwards the item className to the dropdown item', async () => {
 		renderCreationMenu([
-			{className: 'cms-generate-content-with-ai', label: 'Generate'},
+			{className: 'cms-generate-with-ai', label: 'Generate'},
 			{label: 'Create Folder'},
 		]);
 
 		await userEvent.click(screen.getByTestId('fdsCreationActionButton'));
 
 		expect(screen.getByText('Generate')).toHaveClass(
-			'cms-generate-content-with-ai'
+			'cms-generate-with-ai'
 		);
 	});
 
 	it('forwards the item className to the single creation button', () => {
 		renderCreationMenu([
-			{className: 'cms-generate-content-with-ai', label: 'Generate'},
+			{className: 'cms-generate-with-ai', label: 'Generate'},
 		]);
 
 		expect(screen.getByText('Generate')).toHaveClass(
-			'cms-generate-content-with-ai'
+			'cms-generate-with-ai'
 		);
 	});
 });

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
@@ -1,3 +1,4 @@
+@import 'components/ai_assistant';
 @import 'components/breadcrumb';
 @import 'components/ckeditor';
 @import 'components/control_menu';

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ai_assistant.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ai_assistant.scss
@@ -1,0 +1,9 @@
+.cms-generate-with-ai {
+	color: $purple;
+
+	&:focus,
+	&:hover {
+		background-color: $purple-l5;
+		color: $purple;
+	}
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
@@ -83,19 +83,15 @@ export default function EditorToolbar({
 			title={title}
 		>
 			{Liferay.FeatureFlags['LPD-62272'] && (
-				<>
-					<Toolbar.Item>
-						<AIAssistantTriggerButton
-							context={{groupId}}
-							hideLabel
-							instructionDefinitionScope="cms"
-							presentation="dropdown"
-							round
-						/>
-					</Toolbar.Item>
-
-					<div className="ai-assistant__separator" />
-				</>
+				<Toolbar.Item className="nav-divider-end">
+					<AIAssistantTriggerButton
+						context={{groupId}}
+						hideLabel
+						instructionDefinitionScope="cms"
+						presentation="dropdown"
+						round
+					/>
+				</Toolbar.Item>
 			)}
 
 			<Toolbar.Item>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
@@ -74,16 +74,6 @@
 	}
 }
 
-.cms-generate-content-with-ai {
-	color: $purple;
-
-	&:focus,
-	&:hover {
-		background-color: $purple-l5;
-		color: $purple;
-	}
-}
-
 .cms-related-assets {
 	padding-top: 1px;
 	position: relative;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
@@ -9,6 +9,8 @@ export const OBJECT_ENTRY_CLASS_NAME = 'com.liferay.object.model.ObjectEntry';
 export const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
+export const AI_ASSISTANT_TOOLBAR_TRIGGER_ID = 'ai-assistant-toolbar-trigger';
+
 export const ENTERPRISE_URL =
 	'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU';
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -258,21 +258,17 @@ export default function ContentEditorToolbar({
 			title={headerTitle}
 		>
 			{Liferay.FeatureFlags['LPD-62272'] && (
-				<>
-					<Toolbar.Item>
-						<AIAssistantTriggerButton
-							context={{groupId}}
-							enableFreeFormCategorization
-							getContext={getContext}
-							hideLabel
-							instructionDefinitionScope="cms"
-							presentation="dropdown"
-							round
-						/>
-					</Toolbar.Item>
-
-					<div className="ai-assistant__separator" />
-				</>
+				<Toolbar.Item className="nav-divider-end">
+					<AIAssistantTriggerButton
+						context={{groupId}}
+						enableFreeFormCategorization
+						getContext={getContext}
+						hideLabel
+						instructionDefinitionScope="cms"
+						presentation="dropdown"
+						round
+					/>
+				</Toolbar.Item>
 			)}
 
 			<Toolbar.Item className="nav-divider-end">

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -19,6 +19,7 @@ import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 
 import Toolbar from '../../common/components/Toolbar';
+import {AI_ASSISTANT_TOOLBAR_TRIGGER_ID} from '../../common/utils/constants';
 import applyFieldValues from '../utils/applyFieldValues';
 import getFieldValues from '../utils/getFieldValues';
 import {toMomentDate} from './ScheduleField';
@@ -267,6 +268,7 @@ export default function ContentEditorToolbar({
 						instructionDefinitionScope="cms"
 						presentation="dropdown"
 						round
+						triggerId={AI_ASSISTANT_TOOLBAR_TRIGGER_ID}
 					/>
 				</Toolbar.Item>
 			)}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
 import Label from '@clayui/label';
 import ClayPanel from '@clayui/panel';
+import {AIAssistantTriggerButton} from '@liferay/ai-hub-cell-js-components-web';
 import {ItemSelector} from '@liferay/frontend-js-item-selector-web';
 import React, {useCallback, useId, useMemo, useState} from 'react';
 
@@ -16,6 +16,7 @@ import {
 	IGroupedTaxonomies,
 	ITaxonomyCategoryFacade,
 } from '../../../common/types/AssetType';
+import {AI_ASSISTANT_TOOLBAR_TRIGGER_ID} from '../../../common/utils/constants';
 import {CategorizationInputSize} from './AssetCategorization';
 import {
 	AUTO_CATEGORIZE_AGENT,
@@ -338,18 +339,16 @@ const AssetCategories = ({
 					{!vocabularyId &&
 					Liferay.FeatureFlags?.['LPD-62272'] &&
 					hasUpdatePermission ? (
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get(
+						<AIAssistantTriggerButton
+							anchorId={AI_ASSISTANT_TOOLBAR_TRIGGER_ID}
+							className="ml-2"
+							hideLabel
+							instructionDefinitionScope="cms"
+							label={Liferay.Language.get(
 								'add-categories-with-ai'
 							)}
-							className="cms-generate-with-ai ml-2"
-							displayType="unstyled"
-							onClick={handleGenerateCategories}
-							rounded={true}
-							symbol="stars"
-							title={Liferay.Language.get(
-								'add-categories-with-ai'
-							)}
+							onOpen={handleGenerateCategories}
+							presentation="dropdown"
 						/>
 					) : null}
 				</div>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -342,9 +342,10 @@ const AssetCategories = ({
 							aria-label={Liferay.Language.get(
 								'add-categories-with-ai'
 							)}
-							className="ml-2"
+							className="cms-generate-with-ai ml-2"
 							displayType="unstyled"
 							onClick={handleGenerateCategories}
+							rounded={true}
 							symbol="stars"
 							title={Liferay.Language.get(
 								'add-categories-with-ai'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
 import Label from '@clayui/label';
 import ClayPanel from '@clayui/panel';
+import {AIAssistantTriggerButton} from '@liferay/ai-hub-cell-js-components-web';
 import {ItemSelector} from '@liferay/frontend-js-item-selector-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
@@ -14,6 +14,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import ApiHelper from '../../../common/services/ApiHelper';
 import TagService from '../../../common/services/TagService';
 import {IAssetObjectEntry} from '../../../common/types/AssetType';
+import {AI_ASSISTANT_TOOLBAR_TRIGGER_ID} from '../../../common/utils/constants';
 import {EntryCategorizationDTO} from '../services/ObjectEntryService';
 import {CategorizationInputSize} from './AssetCategorization';
 import {
@@ -233,18 +234,16 @@ const AssetTags = ({
 					hasUpdatePermission &&
 					(getContent ||
 						(objectEntry as IAssetObjectEntry).contentRawText) ? (
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get(
+						<AIAssistantTriggerButton
+							anchorId={AI_ASSISTANT_TOOLBAR_TRIGGER_ID}
+							className="ml-2"
+							hideLabel
+							instructionDefinitionScope="cms"
+							label={Liferay.Language.get(
 								'generate-tags-with-ai'
 							)}
-							className="cms-generate-with-ai ml-2"
-							displayType="unstyled"
-							onClick={handleGenerateTags}
-							rounded={true}
-							symbol="stars"
-							title={Liferay.Language.get(
-								'generate-tags-with-ai'
-							)}
+							onOpen={handleGenerateTags}
+							presentation="dropdown"
 						/>
 					) : null}
 				</div>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -62,7 +62,7 @@ const AssetTags = ({
 	const apiURL = useMemo(() => {
 		const baseURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/headless-admin-taxonomy/v1.0/sites`;
 
-		if (scopeId >= 0) {
+		if (scopeId > 0) {
 			return `${baseURL}/${scopeId}/keywords`;
 		}
 
@@ -237,9 +237,10 @@ const AssetTags = ({
 							aria-label={Liferay.Language.get(
 								'generate-tags-with-ai'
 							)}
-							className="ml-2"
+							className="cms-generate-with-ai ml-2"
 							displayType="unstyled"
 							onClick={handleGenerateTags}
+							rounded={true}
 							symbol="stars"
 							title={Liferay.Language.get(
 								'generate-tags-with-ai'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -263,7 +263,7 @@ export default function AssetsFDSPropsTransformer({
 				ACTIONS
 			).map((item) =>
 				GENERATE_WITH_AI_ACTIONS.includes(item.data?.action ?? '')
-					? {...item, className: 'cms-generate-content-with-ai'}
+					? {...item, className: 'cms-generate-with-ai'}
 					: item
 			),
 		},

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -261,6 +261,16 @@ describe('AssetCategories', () => {
 		);
 	});
 
+	it('styles the sparkle with the shared AI class', () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+
+		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: 123});
+
+		expect(
+			screen.getByRole('button', {name: 'add-categories-with-ai'})
+		).toHaveClass('cms-generate-with-ai');
+	});
+
 	it('hides categories from system vocabularies', () => {
 		renderComponent({
 			systemVocabularyIds: [10],

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -40,9 +40,36 @@ function MockItemSelector({
 	);
 }
 
+function MockAIAssistantTriggerButton({
+	anchorId,
+	label,
+	onOpen,
+	presentation,
+}: {
+	anchorId?: string;
+	label?: string;
+	onOpen?: () => void;
+	presentation?: string;
+}) {
+	return (
+		<button
+			aria-label={label}
+			data-anchor-id={anchorId}
+			data-presentation={presentation}
+			onClick={onOpen}
+		>
+			{label}
+		</button>
+	);
+}
+
 function MockItemSelectorItem({children}: {children: React.ReactNode}) {
 	return <div>{children}</div>;
 }
+
+jest.mock('@liferay/ai-hub-cell-js-components-web', () => ({
+	AIAssistantTriggerButton: MockAIAssistantTriggerButton,
+}));
 
 jest.mock('@liferay/frontend-js-item-selector-web', () => {
 	return {
@@ -261,16 +288,6 @@ describe('AssetCategories', () => {
 		);
 	});
 
-	it('styles the sparkle with the shared AI class', () => {
-		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
-
-		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: 123});
-
-		expect(
-			screen.getByRole('button', {name: 'add-categories-with-ai'})
-		).toHaveClass('cms-generate-with-ai');
-	});
-
 	it('hides categories from system vocabularies', () => {
 		renderComponent({
 			systemVocabularyIds: [10],
@@ -295,6 +312,22 @@ describe('AssetCategories', () => {
 
 		expect(screen.getByText('vocabulary-b')).toBeInTheDocument();
 		expect(screen.getByText('category-3')).toBeInTheDocument();
+	});
+
+	it('opens the AI assistant as a dropdown anchored to the toolbar trigger when adding categories', () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+
+		renderComponent();
+
+		const trigger = screen.getByRole('button', {
+			name: 'add-categories-with-ai',
+		});
+
+		expect(trigger).toHaveAttribute(
+			'data-anchor-id',
+			'ai-assistant-toolbar-trigger'
+		);
+		expect(trigger).toHaveAttribute('data-presentation', 'dropdown');
 	});
 
 	it('prefers the edited content from getContent over the persisted content', async () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
@@ -239,6 +239,16 @@ describe('AssetTags', () => {
 		);
 	});
 
+	it('styles the sparkle with the shared AI class', () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
+
+		renderComponent({cmsGroupId: 456, scopeId: 123});
+
+		expect(
+			screen.getByRole('button', {name: 'generate-tags-with-ai'})
+		).toHaveClass('cms-generate-with-ai');
+	});
+
 	it('prefers the edited content from getContent over the persisted content', async () => {
 		const fire = jest.fn();
 		const getContent = jest.fn().mockResolvedValue('edited content');

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
@@ -41,9 +41,36 @@ function MockItemSelector({
 	);
 }
 
+function MockAIAssistantTriggerButton({
+	anchorId,
+	label,
+	onOpen,
+	presentation,
+}: {
+	anchorId?: string;
+	label?: string;
+	onOpen?: () => void;
+	presentation?: string;
+}) {
+	return (
+		<button
+			aria-label={label}
+			data-anchor-id={anchorId}
+			data-presentation={presentation}
+			onClick={onOpen}
+		>
+			{label}
+		</button>
+	);
+}
+
 function MockItemSelectorItem({children}: {children: React.ReactNode}) {
 	return <div>{children}</div>;
 }
+
+jest.mock('@liferay/ai-hub-cell-js-components-web', () => ({
+	AIAssistantTriggerButton: MockAIAssistantTriggerButton,
+}));
 
 jest.mock(
 	'../../../../../src/main/resources/META-INF/resources/js/common/services/ApiHelper'
@@ -239,14 +266,20 @@ describe('AssetTags', () => {
 		);
 	});
 
-	it('styles the sparkle with the shared AI class', () => {
+	it('opens the AI assistant as a dropdown anchored to the toolbar trigger when generating tags', () => {
 		(global as any).Liferay.FeatureFlags = {'LPD-62272': true};
 
-		renderComponent({cmsGroupId: 456, scopeId: 123});
+		renderComponent({contentRawText: 'persisted content'});
 
-		expect(
-			screen.getByRole('button', {name: 'generate-tags-with-ai'})
-		).toHaveClass('cms-generate-with-ai');
+		const trigger = screen.getByRole('button', {
+			name: 'generate-tags-with-ai',
+		});
+
+		expect(trigger).toHaveAttribute(
+			'data-anchor-id',
+			'ai-assistant-toolbar-trigger'
+		);
+		expect(trigger).toHaveAttribute('data-presentation', 'dropdown');
 	});
 
 	it('prefers the edited content from getContent over the persisted content', async () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
@@ -250,8 +250,8 @@ describe('AssetsFDSPropsTransformer', () => {
 		const [contentItem, imageItem, folderItem] =
 			result.creationMenu.primaryItems;
 
-		expect(contentItem.className).toBe('cms-generate-content-with-ai');
-		expect(imageItem.className).toBe('cms-generate-content-with-ai');
+		expect(contentItem.className).toBe('cms-generate-with-ai');
+		expect(imageItem.className).toBe('cms-generate-with-ai');
 		expect(folderItem.className).toBeUndefined();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100231

**Note:** the first five commits belong to LPD-98877, in review at liferay-ai-hub/liferay-portal#698; they are included because both changes touch the same files. Please do not merge this PR before that one.

## What Is Being Fixed

Clicking Generate Tags With AI (or Add Categories With AI) in the CMS categorization panels opened the AI Assistant as a sidebar. For these contextual actions the assistant should open as a dropdown anchored to the content editor toolbar's AI trigger. In addition, clicking the trigger while the assistant was open did not close it — it appended another generation request instead of closing the panel.

## How It Is Being Fixed

The generate buttons in AssetTags and AssetCategories are replaced with the shared AIAssistantTriggerButton, which issues the assistant open command. The trigger button gains two props: onOpen, so the categorize event fires once the assistant opens, and anchorId, so the dropdown anchors to the content editor toolbar's trigger, falling back to the button itself when the toolbar is not on the page (such as the Edit Tags modal in the main view).

In the assistant host, the active trigger is passed to the Clay dropdown as triggerRef, so clicking it again toggles the panel closed instead of being treated as an outside interaction that closes and instantly reopens it, and the opened-by-event flag is cleared whenever the command changes so a plain close() actually closes the panel.

The chat scroll behavior during generation is handled separately by LPD-99471 (liferay-ai-hub/liferay-portal#686); this PR intentionally carries no scroll logic.

## PR Check

**pr-check: PASS** — tested on `edd1656f2f8a6e7fb7c4115a4741528c3c6bd043`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "edd1656f2f8a6e7fb7c4115a4741528c3c6bd043"} -->
