### PR TITLE
LPD-101039 Accept the system property in the workflow definition API

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/KaleoDefinitionVersionCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/KaleoDefinitionVersionCTTest.java
@@ -62,7 +62,7 @@ public class KaleoDefinitionVersionCTTest {
 		_kaleoDefinition = _kaleoDefinitionLocalService.addKaleoDefinition(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), null, null,
-			WorkflowDefinitionConstants.SCOPE_ALL, 1, _serviceContext);
+			WorkflowDefinitionConstants.SCOPE_ALL, false, 1, _serviceContext);
 
 		_kaleoDefinitionLocalService.activateKaleoDefinition(
 			_kaleoDefinition.getKaleoDefinitionId(), _serviceContext);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Workflow API
 Bundle-SymbolicName: com.liferay.headless.admin.workflow.api
-Bundle-Version: 25.4.1
+Bundle-Version: 25.5.0
 Export-Package:\
 	com.liferay.headless.admin.workflow.dto.v1_0,\
 	com.liferay.headless.admin.workflow.resource.v1_0

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowDefinition.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowDefinition.java
@@ -595,6 +595,47 @@ public class WorkflowDefinition implements Serializable {
 	private Supplier<String> _scopeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getSystem() {
+		if (_systemSupplier != null) {
+			system = _systemSupplier.get();
+
+			_systemSupplier = null;
+		}
+
+		return system;
+	}
+
+	public void setSystem(Boolean system) {
+		this.system = system;
+
+		_systemSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSystem(
+		UnsafeSupplier<Boolean, Exception> systemUnsafeSupplier) {
+
+		_systemSupplier = () -> {
+			try {
+				return systemUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean system;
+
+	@JsonIgnore
+	private Supplier<Boolean> _systemSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getTitle() {
 		if (_titleSupplier != null) {
 			title = _titleSupplier.get();
@@ -989,6 +1030,18 @@ public class WorkflowDefinition implements Serializable {
 			sb.append("\"");
 		}
 
+		Boolean system = getSystem();
+
+		if (system != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"system\": ");
+
+			sb.append(system);
+		}
+
 		String title = getTitle();
 
 		if (title != null) {
@@ -1156,4 +1209,4 @@ public class WorkflowDefinition implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1245554120
+// LIFERAY-REST-BUILDER-HASH:-1964195778

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/resources/com/liferay/headless/admin/workflow/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/resources/com/liferay/headless/admin/workflow/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 11.17.0
+version 11.18.0

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/dto/v1_0/WorkflowDefinition.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/dto/v1_0/WorkflowDefinition.java
@@ -301,6 +301,27 @@ public class WorkflowDefinition implements Cloneable, Serializable {
 
 	protected String scope;
 
+	public Boolean getSystem() {
+		return system;
+	}
+
+	public void setSystem(Boolean system) {
+		this.system = system;
+	}
+
+	public void setSystem(
+		UnsafeSupplier<Boolean, Exception> systemUnsafeSupplier) {
+
+		try {
+			system = systemUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean system;
+
 	public String getTitle() {
 		return title;
 	}
@@ -418,4 +439,4 @@ public class WorkflowDefinition implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-683857376
+// LIFERAY-REST-BUILDER-HASH:677865872

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowDefinitionSerDes.java
@@ -231,6 +231,16 @@ public class WorkflowDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (workflowDefinition.getSystem() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"system\": ");
+
+			sb.append(workflowDefinition.getSystem());
+		}
+
 		if (workflowDefinition.getTitle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -420,6 +430,13 @@ public class WorkflowDefinitionSerDes {
 			map.put("scope", String.valueOf(workflowDefinition.getScope()));
 		}
 
+		if (workflowDefinition.getSystem() == null) {
+			map.put("system", null);
+		}
+		else {
+			map.put("system", String.valueOf(workflowDefinition.getSystem()));
+		}
+
 		if (workflowDefinition.getTitle() == null) {
 			map.put("title", null);
 		}
@@ -511,6 +528,9 @@ public class WorkflowDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "scope")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "system")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "title")) {
@@ -619,6 +639,11 @@ public class WorkflowDefinitionSerDes {
 			else if (Objects.equals(jsonParserFieldName, "scope")) {
 				if (jsonParserFieldValue != null) {
 					workflowDefinition.setScope((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "system")) {
+				if (jsonParserFieldValue != null) {
+					workflowDefinition.setSystem((Boolean)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "title")) {
@@ -734,4 +759,4 @@ public class WorkflowDefinitionSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1741752813
+// LIFERAY-REST-BUILDER-HASH:-243674494

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -242,6 +242,8 @@ components:
                     type: array
                 scope:
                     type: string
+                system:
+                    type: boolean
                 title:
                     type: string
                 title_i18n:

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -172,7 +172,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {workflowDefinition(workflowDefinitionId: ___){actions, active, content, creator, dateCreated, dateModified, description, externalReferenceCode, groupExternalReferenceCode, id, name, nodes, scope, title, title_i18n, transitions, version}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {workflowDefinition(workflowDefinitionId: ___){actions, active, content, creator, dateCreated, dateModified, description, externalReferenceCode, groupExternalReferenceCode, id, name, nodes, scope, system, title, title_i18n, transitions, version}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public WorkflowDefinition workflowDefinition(
@@ -190,7 +190,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {workflowDefinitionByName(contentFormat: ___, name: ___, version: ___){actions, active, content, creator, dateCreated, dateModified, description, externalReferenceCode, groupExternalReferenceCode, id, name, nodes, scope, title, title_i18n, transitions, version}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {workflowDefinitionByName(contentFormat: ___, name: ___, version: ___){actions, active, content, creator, dateCreated, dateModified, description, externalReferenceCode, groupExternalReferenceCode, id, name, nodes, scope, system, title, title_i18n, transitions, version}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public WorkflowDefinition workflowDefinitionByName(
@@ -1332,4 +1332,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:709059334
+// LIFERAY-REST-BUILDER-HASH:1931698662

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
@@ -320,7 +320,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "system": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -388,7 +388,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/deploy' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/deploy' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "system": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -410,7 +410,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/save' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/save' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "system": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -563,7 +563,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/{workflowDefinitionId}' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-workflow/v1.0/workflow-definitions/{workflowDefinitionId}' -d $'{"active": ___, "content": ___, "externalReferenceCode": ___, "groupExternalReferenceCode": ___, "name": ___, "scope": ___, "system": ___, "title": ___, "title_i18n": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1391,4 +1391,4 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 		LogFactoryUtil.getLog(BaseWorkflowDefinitionResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-968012697
+// LIFERAY-REST-BUILDER-HASH:777378861

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
@@ -228,6 +228,7 @@ public class WorkflowDefinitionResourceImpl
 				GetterUtil.getString(
 					workflowDefinition.getScope(),
 					WorkflowDefinitionConstants.SCOPE_ALL),
+				GetterUtil.getBoolean(workflowDefinition.getSystem()),
 				_getTitle(workflowDefinition), contextUser.getUserId()));
 	}
 
@@ -247,6 +248,7 @@ public class WorkflowDefinitionResourceImpl
 				GetterUtil.getString(
 					workflowDefinition.getScope(),
 					WorkflowDefinitionConstants.SCOPE_ALL),
+				GetterUtil.getBoolean(workflowDefinition.getSystem()),
 				_getTitle(workflowDefinition), contextUser.getUserId()));
 	}
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
@@ -392,6 +392,7 @@ public class WorkflowDefinitionResourceImpl
 							workflowNode),
 						Node.class));
 				setScope(workflowDefinition::getScope);
+				setSystem(workflowDefinition::isSystem);
 				setTitle(
 					() -> workflowDefinition.getTitle(
 						_language.getLanguageId(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -1814,6 +1814,14 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("system", additionalAssertFieldName)) {
+				if (workflowDefinition.getSystem() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("title", additionalAssertFieldName)) {
 				if (workflowDefinition.getTitle() == null) {
 					valid = false;
@@ -2111,6 +2119,17 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 				if (!Objects.deepEquals(
 						workflowDefinition1.getScope(),
 						workflowDefinition2.getScope())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("system", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						workflowDefinition1.getSystem(),
+						workflowDefinition2.getSystem())) {
 
 					return false;
 				}
@@ -2629,6 +2648,11 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("system")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("title")) {
 			Object object = workflowDefinition.getTitle();
 
@@ -2791,6 +2815,7 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				scope = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				system = RandomTestUtil.randomBoolean();
 				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				version = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
@@ -3068,4 +3093,4 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:438749719
+// LIFERAY-REST-BUILDER-HASH:1453249279

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/WorkflowDefinitionLinkResourceTest.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/WorkflowDefinitionLinkResourceTest.java
@@ -56,7 +56,8 @@ public class WorkflowDefinitionLinkResourceTest
 			StringPool.BLANK,
 			WorkflowDefinitionTestUtil.getContent(
 				RandomTestUtil.randomString(), "workflow-definition.xml", name),
-			StringPool.BLANK, 1, ServiceContextTestUtil.getServiceContext());
+			StringPool.BLANK, false, 1,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Ignore

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/WorkflowDefinitionResourceTest.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/WorkflowDefinitionResourceTest.java
@@ -253,6 +253,8 @@ public class WorkflowDefinitionResourceTest
 
 		assertEquals(randomWorkflowDefinition, postWorkflowDefinition);
 		assertValid(postWorkflowDefinition);
+
+		_testPostWorkflowDefinitionSaveWithSystem();
 	}
 
 	@Override
@@ -288,7 +290,7 @@ public class WorkflowDefinitionResourceTest
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"active", "name", "nodes", "scope", "title", "title_i18n",
+			"active", "name", "nodes", "scope", "system", "title", "title_i18n",
 			"transitions", "version"
 		};
 	}
@@ -535,6 +537,32 @@ public class WorkflowDefinitionResourceTest
 			workflowDefinitionJSONObject.toString(),
 			"headless-admin-workflow/v1.0/workflow-definitions",
 			Http.Method.POST);
+	}
+
+	private void _testPostWorkflowDefinitionSaveWithSystem() throws Exception {
+		WorkflowDefinition randomWorkflowDefinition =
+			randomWorkflowDefinition();
+
+		randomWorkflowDefinition.setNodes(new Node[0]);
+		randomWorkflowDefinition.setSystem(true);
+		randomWorkflowDefinition.setTransitions(new Transition[0]);
+
+		WorkflowDefinition workflowDefinition =
+			testPostWorkflowDefinitionSave_addWorkflowDefinition(
+				randomWorkflowDefinition);
+
+		Assert.assertTrue(workflowDefinition.getSystem());
+
+		randomWorkflowDefinition.setSystem(false);
+
+		workflowDefinition =
+			workflowDefinitionResource.postWorkflowDefinitionSave(
+				randomWorkflowDefinition);
+
+		_workflowDefinitions.put(
+			workflowDefinition.getName(), workflowDefinition);
+
+		Assert.assertFalse(workflowDefinition.getSystem());
 	}
 
 	private static com.liferay.portal.kernel.workflow.WorkflowDefinition

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionInitialRequestPortalInstanceLifecycleListener.java
@@ -74,7 +74,7 @@ public class
 				0,
 				WorkflowDefinitionConstants.
 					NAME_MESSAGE_BOARDS_USER_STATS_MODERATION,
-				MBMessage.class.getName(),
+				MBMessage.class.getName(), false,
 				_localization.getXml(
 					_getTitleMap(companyId),
 					_language.getLanguageId(company.getLocale()), "title"),

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/upgrade/v1_0_0/MBModerationWorkflowDefinitionUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/upgrade/v1_0_0/MBModerationWorkflowDefinitionUpgradeProcess.java
@@ -62,7 +62,7 @@ public class MBModerationWorkflowDefinitionUpgradeProcess
 			_workflowDefinitionManager.deployWorkflowDefinition(
 				content.getBytes(), companyId, null, 0,
 				latestWorkflowDefinition.getName(),
-				latestWorkflowDefinition.getScope(),
+				latestWorkflowDefinition.getScope(), false,
 				latestWorkflowDefinition.getTitle(),
 				latestWorkflowDefinition.getUserId());
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1920,7 +1920,7 @@ public class ObjectDefinitionLocalServiceImpl
 					_kaleoDefinitionLocalService.addKaleoDefinition(
 						workflowDefinitionName, workflowDefinitionName,
 						workflowDefinitionName, null, null,
-						WorkflowDefinitionConstants.SCOPE_ALL, 1,
+						WorkflowDefinitionConstants.SCOPE_ALL, false, 1,
 						serviceContext);
 			}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -964,7 +964,7 @@ public class ObjectDefinitionLocalServiceTest {
 			_workflowDefinitionManager.saveWorkflowDefinition(
 				content.getBytes(), TestPropsValues.getCompanyId(),
 				kaleoDefinition.getExternalReferenceCode(), 0,
-				kaleoDefinition.getName(), kaleoDefinition.getScope(),
+				kaleoDefinition.getName(), kaleoDefinition.getScope(), false,
 				kaleoDefinition.getTitle(), TestPropsValues.getUserId());
 
 		workflowDefinitionLink =

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
@@ -23,7 +23,8 @@ public interface WorkflowDefinitionManager {
 
 	public default WorkflowDefinition deployWorkflowDefinition(
 			byte[] bytes, long companyId, String externalReferenceCode,
-			long groupId, String name, String scope, String title, long userId)
+			long groupId, String name, String scope, boolean system,
+			String title, long userId)
 		throws WorkflowException {
 
 		throw new UnsupportedOperationException();
@@ -140,7 +141,8 @@ public interface WorkflowDefinitionManager {
 
 	public default WorkflowDefinition saveWorkflowDefinition(
 			byte[] bytes, long companyId, String externalReferenceCode,
-			long groupId, String name, String scope, String title, long userId)
+			long groupId, String name, String scope, boolean system,
+			String title, long userId)
 		throws WorkflowException {
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/manager/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/resources/com/liferay/portal/workflow/manager/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.api
-Bundle-Version: 21.1.0
+Bundle-Version: 22.0.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo,\
 	com.liferay.portal.workflow.kaleo.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalService.java
@@ -92,8 +92,8 @@ public interface KaleoDefinitionLocalService
 
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
-			ServiceContext serviceContext)
+			String description, String content, String scope, boolean system,
+			int version, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -412,7 +412,8 @@ public interface KaleoDefinitionLocalService
 
 	public KaleoDefinition updatedKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content, ServiceContext serviceContext)
+			String description, String content, boolean system,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -445,4 +446,4 @@ public interface KaleoDefinitionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:351544488
+// LIFERAY-SERVICE-BUILDER-HASH:161701466

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceUtil.java
@@ -83,13 +83,14 @@ public class KaleoDefinitionLocalServiceUtil {
 
 	public static KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
+			String description, String content, String scope, boolean system,
+			int version,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addKaleoDefinition(
 			externalReferenceCode, name, title, description, content, scope,
-			version, serviceContext);
+			system, version, serviceContext);
 	}
 
 	/**
@@ -523,13 +524,13 @@ public class KaleoDefinitionLocalServiceUtil {
 
 	public static KaleoDefinition updatedKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content,
+			String description, String content, boolean system,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updatedKaleoDefinition(
 			externalReferenceCode, kaleoDefinitionId, title, description,
-			content, serviceContext);
+			content, system, serviceContext);
 	}
 
 	/**
@@ -558,4 +559,4 @@ public class KaleoDefinitionLocalServiceUtil {
 			KaleoDefinitionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1298329247
+// LIFERAY-SERVICE-BUILDER-HASH:-333319507

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceWrapper.java
@@ -82,13 +82,14 @@ public class KaleoDefinitionLocalServiceWrapper
 	@Override
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
+			String description, String content, String scope, boolean system,
+			int version,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kaleoDefinitionLocalService.addKaleoDefinition(
 			externalReferenceCode, name, title, description, content, scope,
-			version, serviceContext);
+			system, version, serviceContext);
 	}
 
 	/**
@@ -601,13 +602,13 @@ public class KaleoDefinitionLocalServiceWrapper
 	@Override
 	public KaleoDefinition updatedKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content,
+			String description, String content, boolean system,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kaleoDefinitionLocalService.updatedKaleoDefinition(
 			externalReferenceCode, kaleoDefinitionId, title, description,
-			content, serviceContext);
+			content, system, serviceContext);
 	}
 
 	/**
@@ -668,4 +669,4 @@ public class KaleoDefinitionLocalServiceWrapper
 	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1053299482
+// LIFERAY-SERVICE-BUILDER-HASH:-1599064282

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionService.java
@@ -48,8 +48,8 @@ public interface KaleoDefinitionService extends BaseService {
 	 */
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
-			ServiceContext serviceContext)
+			String description, String content, String scope, boolean system,
+			int version, ServiceContext serviceContext)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -89,8 +89,9 @@ public interface KaleoDefinitionService extends BaseService {
 
 	public KaleoDefinition updateKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content, ServiceContext serviceContext)
+			String description, String content, boolean system,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2068579258
+// LIFERAY-SERVICE-BUILDER-HASH:63165950

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceUtil.java
@@ -33,13 +33,14 @@ public class KaleoDefinitionServiceUtil {
 	 */
 	public static KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
+			String description, String content, String scope, boolean system,
+			int version,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addKaleoDefinition(
 			externalReferenceCode, name, title, description, content, scope,
-			version, serviceContext);
+			system, version, serviceContext);
 	}
 
 	public static KaleoDefinition getKaleoDefinition(long kaleoDefinitionId)
@@ -95,13 +96,13 @@ public class KaleoDefinitionServiceUtil {
 
 	public static KaleoDefinition updateKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content,
+			String description, String content, boolean system,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateKaleoDefinition(
 			externalReferenceCode, kaleoDefinitionId, title, description,
-			content, serviceContext);
+			content, system, serviceContext);
 	}
 
 	public static KaleoDefinitionService getService() {
@@ -113,4 +114,4 @@ public class KaleoDefinitionServiceUtil {
 			KaleoDefinitionServiceUtil.class, KaleoDefinitionService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1564946146
+// LIFERAY-SERVICE-BUILDER-HASH:1585344898

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceWrapper.java
@@ -31,13 +31,14 @@ public class KaleoDefinitionServiceWrapper
 	@Override
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
+			String description, String content, String scope, boolean system,
+			int version,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kaleoDefinitionService.addKaleoDefinition(
 			externalReferenceCode, name, title, description, content, scope,
-			version, serviceContext);
+			system, version, serviceContext);
 	}
 
 	@Override
@@ -102,13 +103,13 @@ public class KaleoDefinitionServiceWrapper
 	@Override
 	public KaleoDefinition updateKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content,
+			String description, String content, boolean system,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kaleoDefinitionService.updateKaleoDefinition(
 			externalReferenceCode, kaleoDefinitionId, title, description,
-			content, serviceContext);
+			content, system, serviceContext);
 	}
 
 	@Override
@@ -126,4 +127,4 @@ public class KaleoDefinitionServiceWrapper
 	private KaleoDefinitionService _kaleoDefinitionService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-294050812
+// LIFERAY-SERVICE-BUILDER-HASH:1493128664

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.1
+version 17.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Definition API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.definition.api
-Bundle-Version: 15.5.1
+Bundle-Version: 16.0.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo.definition,\
 	com.liferay.portal.workflow.kaleo.definition.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/src/main/java/com/liferay/portal/workflow/kaleo/definition/deployment/WorkflowDeployer.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/src/main/java/com/liferay/portal/workflow/kaleo/definition/deployment/WorkflowDeployer.java
@@ -17,12 +17,14 @@ public interface WorkflowDeployer {
 
 	public WorkflowDefinition deploy(
 			String externalReferenceCode, String title, String name,
-			String scope, Definition definition, ServiceContext serviceContext)
+			String scope, boolean system, Definition definition,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public WorkflowDefinition save(
 			String externalReferenceCode, String title, String name,
-			String scope, Definition definition, ServiceContext serviceContext)
+			String scope, boolean system, Definition definition,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/src/main/resources/com/liferay/portal/workflow/kaleo/definition/deployment/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-api/src/main/resources/com/liferay/portal/workflow/kaleo/definition/deployment/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/deployment/DefaultWorkflowDeployer.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/deployment/DefaultWorkflowDeployer.java
@@ -50,13 +50,14 @@ public class DefaultWorkflowDeployer implements WorkflowDeployer {
 	@Override
 	public WorkflowDefinition deploy(
 			String externalReferenceCode, String title, String name,
-			String scope, Definition definition, ServiceContext serviceContext)
+			String scope, boolean system, Definition definition,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_checkPermissions(serviceContext);
 
 		KaleoDefinition kaleoDefinition = _addOrUpdateKaleoDefinition(
-			externalReferenceCode, title, name, scope, definition,
+			externalReferenceCode, title, name, scope, system, definition,
 			serviceContext);
 
 		KaleoDefinitionVersion kaleoDefinitionVersion =
@@ -151,11 +152,12 @@ public class DefaultWorkflowDeployer implements WorkflowDeployer {
 	@Override
 	public WorkflowDefinition save(
 			String externalReferenceCode, String title, String name,
-			String scope, Definition definition, ServiceContext serviceContext)
+			String scope, boolean system, Definition definition,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		KaleoDefinition kaleoDefinition = _addOrUpdateKaleoDefinition(
-			externalReferenceCode, title, name, scope, definition,
+			externalReferenceCode, title, name, scope, system, definition,
 			serviceContext);
 
 		return _kaleoWorkflowModelConverter.toWorkflowDefinition(
@@ -164,7 +166,8 @@ public class DefaultWorkflowDeployer implements WorkflowDeployer {
 
 	private KaleoDefinition _addOrUpdateKaleoDefinition(
 			String externalReferenceCode, String title, String name,
-			String scope, Definition definition, ServiceContext serviceContext)
+			String scope, boolean system, Definition definition,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		KaleoDefinition kaleoDefinition =
@@ -174,13 +177,13 @@ public class DefaultWorkflowDeployer implements WorkflowDeployer {
 		if (kaleoDefinition == null) {
 			kaleoDefinition = _kaleoDefinitionService.addKaleoDefinition(
 				externalReferenceCode, name, title, definition.getDescription(),
-				definition.getContent(), scope, 1, serviceContext);
+				definition.getContent(), scope, system, 1, serviceContext);
 		}
 		else {
 			kaleoDefinition = _kaleoDefinitionService.updateKaleoDefinition(
 				externalReferenceCode, kaleoDefinition.getKaleoDefinitionId(),
 				title, definition.getDescription(), definition.getContent(),
-				serviceContext);
+				system, serviceContext);
 		}
 
 		return kaleoDefinition;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Runtime API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.runtime.api
-Bundle-Version: 19.0.2
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo.runtime,\
 	com.liferay.portal.workflow.kaleo.runtime.action,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/WorkflowEngine.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/WorkflowEngine.java
@@ -38,7 +38,7 @@ public interface WorkflowEngine {
 
 	public WorkflowDefinition deployWorkflowDefinition(
 			String externalReferenceCode, String title, String name,
-			String scope, InputStream inputStream,
+			String scope, boolean system, InputStream inputStream,
 			ServiceContext serviceContext)
 		throws WorkflowException;
 
@@ -96,7 +96,8 @@ public interface WorkflowEngine {
 
 	public WorkflowDefinition saveWorkflowDefinition(
 			String externalReferenceCode, String title, String name,
-			String scope, byte[] bytes, ServiceContext serviceContext)
+			String scope, boolean system, byte[] bytes,
+			ServiceContext serviceContext)
 		throws WorkflowException;
 
 	public default List<WorkflowInstance> search(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/resources/com/liferay/portal/workflow/kaleo/runtime/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/resources/com/liferay/portal/workflow/kaleo/runtime/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 7.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
@@ -147,7 +147,7 @@ public class DefaultWorkflowEngineImpl
 	@Override
 	public WorkflowDefinition deployWorkflowDefinition(
 			String externalReferenceCode, String title, String name,
-			String scope, InputStream inputStream,
+			String scope, boolean system, InputStream inputStream,
 			ServiceContext serviceContext)
 		throws WorkflowException {
 
@@ -165,8 +165,8 @@ public class DefaultWorkflowEngineImpl
 					definitionName, serviceContext);
 
 			WorkflowDefinition workflowDefinition = _workflowDeployer.deploy(
-				externalReferenceCode, title, definitionName, scope, definition,
-				serviceContext);
+				externalReferenceCode, title, definitionName, scope, system,
+				definition, serviceContext);
 
 			_updateWorkflowDefinitionLinks(
 				serviceContext.getCompanyId(), kaleoDefinition,
@@ -451,7 +451,8 @@ public class DefaultWorkflowEngineImpl
 	@Override
 	public WorkflowDefinition saveWorkflowDefinition(
 			String externalReferenceCode, String title, String name,
-			String scope, byte[] bytes, ServiceContext serviceContext)
+			String scope, boolean system, byte[] bytes,
+			ServiceContext serviceContext)
 		throws WorkflowException {
 
 		try {
@@ -465,8 +466,8 @@ public class DefaultWorkflowEngineImpl
 					definitionName, serviceContext);
 
 			WorkflowDefinition workflowDefinition = _workflowDeployer.save(
-				externalReferenceCode, title, definitionName, scope, definition,
-				serviceContext);
+				externalReferenceCode, title, definitionName, scope, system,
+				definition, serviceContext);
 
 			_updateWorkflowDefinitionLinks(
 				serviceContext.getCompanyId(), kaleoDefinition,

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
@@ -204,6 +204,7 @@ public class KaleoWorkflowModelConverterImpl
 			defaultWorkflowDefinition.setActive(false);
 			defaultWorkflowDefinition.setScope(
 				WorkflowDefinitionConstants.SCOPE_ALL);
+			defaultWorkflowDefinition.setSystem(false);
 		}
 
 		String content = kaleoDefinitionVersion.getContent();

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -54,7 +54,8 @@ public class WorkflowDefinitionManagerImpl
 	@Override
 	public WorkflowDefinition deployWorkflowDefinition(
 			byte[] bytes, long companyId, String externalReferenceCode,
-			long groupId, String name, String scope, String title, long userId)
+			long groupId, String name, String scope, boolean system,
+			String title, long userId)
 		throws WorkflowException {
 
 		ServiceContext serviceContext = new ServiceContext();
@@ -64,7 +65,7 @@ public class WorkflowDefinitionManagerImpl
 		serviceContext.setUserId(userId);
 
 		return _workflowEngine.deployWorkflowDefinition(
-			externalReferenceCode, title, name, scope,
+			externalReferenceCode, title, name, scope, system,
 			new UnsyncByteArrayInputStream(bytes), serviceContext);
 	}
 
@@ -76,7 +77,7 @@ public class WorkflowDefinitionManagerImpl
 
 		return deployWorkflowDefinition(
 			bytes, companyId, externalReferenceCode, 0, name,
-			WorkflowDefinitionConstants.SCOPE_ALL, title, userId);
+			WorkflowDefinitionConstants.SCOPE_ALL, false, title, userId);
 	}
 
 	@Override
@@ -304,7 +305,8 @@ public class WorkflowDefinitionManagerImpl
 	@Override
 	public WorkflowDefinition saveWorkflowDefinition(
 			byte[] bytes, long companyId, String externalReferenceCode,
-			long groupId, String name, String scope, String title, long userId)
+			long groupId, String name, String scope, boolean system,
+			String title, long userId)
 		throws WorkflowException {
 
 		ServiceContext serviceContext = new ServiceContext();
@@ -314,7 +316,8 @@ public class WorkflowDefinitionManagerImpl
 		serviceContext.setUserId(userId);
 
 		return _workflowEngine.saveWorkflowDefinition(
-			externalReferenceCode, title, name, scope, bytes, serviceContext);
+			externalReferenceCode, title, name, scope, system, bytes,
+			serviceContext);
 	}
 
 	@Override
@@ -325,7 +328,7 @@ public class WorkflowDefinitionManagerImpl
 
 		return saveWorkflowDefinition(
 			bytes, companyId, externalReferenceCode, 0, name,
-			WorkflowDefinitionConstants.SCOPE_ALL, title, userId);
+			WorkflowDefinitionConstants.SCOPE_ALL, false, title, userId);
 	}
 
 	@Override

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/http/KaleoDefinitionServiceHttp.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/http/KaleoDefinitionServiceHttp.java
@@ -45,7 +45,7 @@ public class KaleoDefinitionServiceHttp {
 			addKaleoDefinition(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
 				String name, String title, String description, String content,
-				String scope, int version,
+				String scope, boolean system, int version,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -56,7 +56,7 @@ public class KaleoDefinitionServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, name, title, description,
-				content, scope, version, serviceContext);
+				content, scope, system, version, serviceContext);
 
 			Object returnObj = null;
 
@@ -321,7 +321,7 @@ public class KaleoDefinitionServiceHttp {
 			updateKaleoDefinition(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
 				long kaleoDefinitionId, String title, String description,
-				String content,
+				String content, boolean system,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -332,7 +332,7 @@ public class KaleoDefinitionServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, kaleoDefinitionId, title,
-				description, content, serviceContext);
+				description, content, system, serviceContext);
 
 			Object returnObj = null;
 
@@ -369,7 +369,7 @@ public class KaleoDefinitionServiceHttp {
 	private static final Class<?>[] _addKaleoDefinitionParameterTypes0 =
 		new Class[] {
 			String.class, String.class, String.class, String.class,
-			String.class, String.class, int.class,
+			String.class, String.class, boolean.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _getKaleoDefinitionParameterTypes1 =
@@ -395,8 +395,9 @@ public class KaleoDefinitionServiceHttp {
 	private static final Class<?>[] _updateKaleoDefinitionParameterTypes6 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
+			boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-141709008
+// LIFERAY-SERVICE-BUILDER-HASH:1796864672

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
@@ -126,8 +126,8 @@ public class KaleoDefinitionLocalServiceImpl
 	@Override
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
-			ServiceContext serviceContext)
+			String description, String content, String scope, boolean system,
+			int version, ServiceContext serviceContext)
 		throws PortalException {
 
 		// Kaleo definition
@@ -166,6 +166,7 @@ public class KaleoDefinitionLocalServiceImpl
 		kaleoDefinition.setScope(scope);
 		kaleoDefinition.setVersion(version);
 		kaleoDefinition.setActive(false);
+		kaleoDefinition.setSystem(system);
 		kaleoDefinition.setStatus(WorkflowConstants.STATUS_DRAFT);
 
 		kaleoDefinition = kaleoDefinitionPersistence.update(kaleoDefinition);
@@ -376,7 +377,8 @@ public class KaleoDefinitionLocalServiceImpl
 	@Override
 	public KaleoDefinition updatedKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content, ServiceContext serviceContext)
+			String description, String content, boolean system,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Kaleo definition
@@ -410,6 +412,7 @@ public class KaleoDefinitionLocalServiceImpl
 		kaleoDefinition.setVersion(nextVersion);
 
 		kaleoDefinition.setActive(false);
+		kaleoDefinition.setSystem(system);
 
 		kaleoDefinition = kaleoDefinitionPersistence.update(kaleoDefinition);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
@@ -43,15 +43,15 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 	@Override
 	public KaleoDefinition addKaleoDefinition(
 			String externalReferenceCode, String name, String title,
-			String description, String content, String scope, int version,
-			ServiceContext serviceContext)
+			String description, String content, String scope, boolean system,
+			int version, ServiceContext serviceContext)
 		throws PortalException {
 
 		_checkPermissions(serviceContext);
 
 		return _kaleoDefinitionLocalService.addKaleoDefinition(
 			externalReferenceCode, name, title, description, content, scope,
-			version, serviceContext);
+			system, version, serviceContext);
 	}
 
 	@Override
@@ -134,14 +134,15 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 	@Override
 	public KaleoDefinition updateKaleoDefinition(
 			String externalReferenceCode, long kaleoDefinitionId, String title,
-			String description, String content, ServiceContext serviceContext)
+			String description, String content, boolean system,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_checkPermissions(serviceContext);
 
 		return _kaleoDefinitionLocalService.updatedKaleoDefinition(
 			externalReferenceCode, kaleoDefinitionId, title, description,
-			content, serviceContext);
+			content, system, serviceContext);
 	}
 
 	private void _checkPermissions(ServiceContext serviceContext)

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/change/tracking/test/BaseKaleoTableReferenceDefinitionTestCase.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/change/tracking/test/BaseKaleoTableReferenceDefinitionTestCase.java
@@ -83,7 +83,7 @@ public abstract class BaseKaleoTableReferenceDefinitionTestCase
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			_read("legal-marketing-workflow-definition.xml"), StringPool.BLANK,
-			1, serviceContext);
+			false, 1, serviceContext);
 	}
 
 	protected KaleoInstance addKaleoInstance() throws Exception {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
@@ -481,6 +481,39 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 	}
 
 	@Test
+	public void testDeployWorkflowDefinitionWithSystem() throws Exception {
+		byte[] bytes = FileUtil.getBytes(
+			getResourceInputStream("single-approver-workflow-definition.xml"));
+
+		String name = StringUtil.randomId();
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				bytes, TestPropsValues.getCompanyId(), null, 0, name,
+				WorkflowDefinitionConstants.SCOPE_ALL, true,
+				StringUtil.randomId(), TestPropsValues.getUserId());
+
+		Assert.assertTrue(workflowDefinition.isSystem());
+
+		workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				bytes, TestPropsValues.getCompanyId(), null, 0, name,
+				WorkflowDefinitionConstants.SCOPE_ALL, false,
+				StringUtil.randomId(), TestPropsValues.getUserId());
+
+		Assert.assertFalse(workflowDefinition.isSystem());
+
+		// Overload without a system parameter
+
+		workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				bytes, TestPropsValues.getCompanyId(), null, name,
+				StringUtil.randomId(), TestPropsValues.getUserId());
+
+		Assert.assertFalse(workflowDefinition.isSystem());
+	}
+
+	@Test
 	public void testDeployWorkflowDraftDefinition() throws Exception {
 		WorkflowDefinition workflowDefinition = _saveWorkflowDefinition();
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowInstanceManagerImplPerformanceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowInstanceManagerImplPerformanceTest.java
@@ -126,7 +126,7 @@ public class WorkflowInstanceManagerImplPerformanceTest {
 				TestPropsValues.getCompanyId(), null,
 				accountEntry.getAccountEntryGroupId(),
 				RandomTestUtil.randomString(),
-				WorkflowDefinitionConstants.SCOPE_AI,
+				WorkflowDefinitionConstants.SCOPE_AI, false,
 				RandomTestUtil.randomString(), TestPropsValues.getUserId());
 
 		int workflowInstancesThreadCount = GetterUtil.getInteger(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/test/KaleoDefinitionVersionUpgradeProcessTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/test/KaleoDefinitionVersionUpgradeProcessTest.java
@@ -93,7 +93,7 @@ public class KaleoDefinitionVersionUpgradeProcessTest {
 		_kaleoDefinitionLocalService.addKaleoDefinition(
 			RandomTestUtil.randomString(), name, StringUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK,
-			WorkflowDefinitionConstants.SCOPE_ALL, version,
+			WorkflowDefinitionConstants.SCOPE_ALL, false, version,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_4_0/test/KaleoDefinitionUpgradeProcessTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_4_0/test/KaleoDefinitionUpgradeProcessTest.java
@@ -77,8 +77,8 @@ public class KaleoDefinitionUpgradeProcessTest {
 			_kaleoDefinitionLocalService.addKaleoDefinition(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				StringUtil.randomString(), StringUtil.randomString(),
-				StringPool.BLANK, WorkflowDefinitionConstants.SCOPE_ALL, 0,
-				ServiceContextTestUtil.getServiceContext());
+				StringPool.BLANK, WorkflowDefinitionConstants.SCOPE_ALL, false,
+				0, ServiceContextTestUtil.getServiceContext());
 
 		kaleoDefinition.setActive(active);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/BaseKaleoLocalServiceTestCase.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/BaseKaleoLocalServiceTestCase.java
@@ -98,9 +98,16 @@ public abstract class BaseKaleoLocalServiceTestCase {
 	protected KaleoDefinition addKaleoDefinition(String scope)
 		throws IOException, PortalException {
 
+		return addKaleoDefinition(scope, false);
+	}
+
+	protected KaleoDefinition addKaleoDefinition(String scope, boolean system)
+		throws IOException, PortalException {
+
 		return addKaleoDefinition(
 			StringUtil.randomString(), StringUtil.randomString(),
-			StringUtil.randomString(), StringUtil.randomString(), scope);
+			StringUtil.randomString(), StringUtil.randomString(), scope,
+			system);
 	}
 
 	protected KaleoDefinition addKaleoDefinition(
@@ -108,13 +115,22 @@ public abstract class BaseKaleoLocalServiceTestCase {
 			String title, String scope)
 		throws IOException, PortalException {
 
+		return addKaleoDefinition(
+			externalReferenceCode, name, description, title, scope, false);
+	}
+
+	protected KaleoDefinition addKaleoDefinition(
+			String externalReferenceCode, String name, String description,
+			String title, String scope, boolean system)
+		throws IOException, PortalException {
+
 		KaleoDefinition kaleoDefinition =
 			_kaleoDefinitionLocalService.addKaleoDefinition(
 				externalReferenceCode, name,
 				LocalizationUtil.getXml(new LocalizedValuesMap(title), "title"),
 				description, _read("legal-marketing-workflow-definition.xml"),
-				GetterUtil.get(scope, WorkflowDefinitionConstants.SCOPE_ALL), 1,
-				serviceContext);
+				GetterUtil.get(scope, WorkflowDefinitionConstants.SCOPE_ALL),
+				system, 1, serviceContext);
 
 		_kaleoDefinitionLocalService.activateKaleoDefinition(
 			kaleoDefinition.getKaleoDefinitionId(), serviceContext);
@@ -274,10 +290,17 @@ public abstract class BaseKaleoLocalServiceTestCase {
 			KaleoDefinition kaleoDefinition)
 		throws IOException, PortalException {
 
+		return updateKaleoDefinition(kaleoDefinition, false);
+	}
+
+	protected KaleoDefinition updateKaleoDefinition(
+			KaleoDefinition kaleoDefinition, boolean system)
+		throws IOException, PortalException {
+
 		kaleoDefinition = _kaleoDefinitionLocalService.updatedKaleoDefinition(
 			kaleoDefinition.getExternalReferenceCode(),
 			kaleoDefinition.getKaleoDefinitionId(), StringUtil.randomString(),
-			StringUtil.randomString(), kaleoDefinition.getContent(),
+			StringUtil.randomString(), kaleoDefinition.getContent(), system,
 			serviceContext);
 
 		_kaleoDefinitionLocalService.activateKaleoDefinition(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionLocalServiceTest.java
@@ -38,6 +38,7 @@ public class KaleoDefinitionLocalServiceTest
 	public void testAddKaleoDefinition() throws Exception {
 		_testAddKaleoDefinition();
 		_testAddKaleoDefinitionWithScope();
+		_testAddKaleoDefinitionWithSystem();
 	}
 
 	@Test
@@ -72,6 +73,7 @@ public class KaleoDefinitionLocalServiceTest
 	public void testUpdateKaleoDefinition() throws Exception {
 		_testUpdateKaleoDefinition();
 		_testUpdateKaleoDefinitionWithScope();
+		_testUpdateKaleoDefinitionWithSystem();
 	}
 
 	private AccountEntry _addAccountEntry() throws Exception {
@@ -122,6 +124,16 @@ public class KaleoDefinitionLocalServiceTest
 			() -> addKaleoDefinition(WorkflowDefinitionConstants.SCOPE_AI));
 	}
 
+	private void _testAddKaleoDefinitionWithSystem() throws Exception {
+		KaleoDefinition kaleoDefinition = addKaleoDefinition(null, false);
+
+		Assert.assertFalse(kaleoDefinition.isSystem());
+
+		kaleoDefinition = addKaleoDefinition(null, true);
+
+		Assert.assertTrue(kaleoDefinition.isSystem());
+	}
+
 	private void _testUpdateKaleoDefinition() throws Exception {
 		KaleoDefinition kaleoDefinition = addKaleoDefinition(null);
 
@@ -164,6 +176,20 @@ public class KaleoDefinitionLocalServiceTest
 			"Invalid group ID " + TestPropsValues.getGroupId() +
 				" for scope AI",
 			() -> updateKaleoDefinition(kaleoDefinition));
+	}
+
+	private void _testUpdateKaleoDefinitionWithSystem() throws Exception {
+		KaleoDefinition kaleoDefinition = addKaleoDefinition(null, true);
+
+		Assert.assertTrue(kaleoDefinition.isSystem());
+
+		kaleoDefinition = updateKaleoDefinition(kaleoDefinition, true);
+
+		Assert.assertTrue(kaleoDefinition.isSystem());
+
+		kaleoDefinition = updateKaleoDefinition(kaleoDefinition, false);
+
+		Assert.assertFalse(kaleoDefinition.isSystem());
 	}
 
 	@Inject

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
@@ -184,7 +184,7 @@ public class KaleoDefinitionServiceImplTest {
 		return _kaleoDefinitionService.addKaleoDefinition(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_read(), "company", 1, _serviceContext);
+			_read(), "company", false, 1, _serviceContext);
 	}
 
 	private KaleoDefinition _addKaleoDefinition(ServiceContext serviceContext)
@@ -193,7 +193,7 @@ public class KaleoDefinitionServiceImplTest {
 		return _kaleoDefinitionService.addKaleoDefinition(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_read(), "ai", 1, serviceContext);
+			_read(), "ai", false, 1, serviceContext);
 	}
 
 	private User _addUser() throws Exception {
@@ -363,7 +363,7 @@ public class KaleoDefinitionServiceImplTest {
 				kaleoDefinition.getExternalReferenceCode(),
 				kaleoDefinition.getKaleoDefinitionId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				kaleoDefinition.getContent(), _serviceContext));
+				kaleoDefinition.getContent(), false, _serviceContext));
 
 		// Administrator with "company.administrator.can.publish" enabled
 
@@ -378,7 +378,7 @@ public class KaleoDefinitionServiceImplTest {
 				kaleoDefinition.getExternalReferenceCode(),
 				kaleoDefinition.getKaleoDefinitionId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				kaleoDefinition.getContent(), _serviceContext));
+				kaleoDefinition.getContent(), false, _serviceContext));
 	}
 
 	private void _testUpdateKaleoDefinitionWithGroupId() throws Exception {
@@ -405,7 +405,7 @@ public class KaleoDefinitionServiceImplTest {
 				kaleoDefinition.getExternalReferenceCode(),
 				kaleoDefinition.getKaleoDefinitionId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				kaleoDefinition.getContent(),
+				kaleoDefinition.getContent(), false,
 				ServiceContextTestUtil.getServiceContext(
 					accountEntry.getAccountEntryGroupId(), user.getUserId())));
 
@@ -417,7 +417,7 @@ public class KaleoDefinitionServiceImplTest {
 				kaleoDefinition.getExternalReferenceCode(),
 				kaleoDefinition.getKaleoDefinitionId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				kaleoDefinition.getContent(),
+				kaleoDefinition.getContent(), false,
 				ServiceContextTestUtil.getServiceContext(
 					accountEntry.getAccountEntryGroupId(), user.getUserId())));
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionServiceImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionServiceImplTest.java
@@ -70,7 +70,7 @@ public class KaleoDefinitionVersionServiceImplTest {
 			_kaleoDefinitionLocalService.addKaleoDefinition(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				_read(), StringPool.BLANK, 1, serviceContext);
+				_read(), StringPool.BLANK, false, 1, serviceContext);
 
 		_kaleoDefinitionLocalService.activateKaleoDefinition(
 			kaleoDefinition.getKaleoDefinitionId(), serviceContext);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceServiceTest.java
@@ -108,7 +108,7 @@ public class KaleoInstanceServiceTest {
 				TestPropsValues.getCompanyId(), null,
 				accountEntry.getAccountEntryGroupId(),
 				RandomTestUtil.randomString(),
-				WorkflowDefinitionConstants.SCOPE_AI,
+				WorkflowDefinitionConstants.SCOPE_AI, false,
 				RandomTestUtil.randomString(), user.getUserId());
 
 		ConfigurationTestUtil.saveConfiguration(

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/service/test/WorkflowDefinitionLinkServiceImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/service/test/WorkflowDefinitionLinkServiceImplTest.java
@@ -237,7 +237,7 @@ public class WorkflowDefinitionLinkServiceImplTest {
 	private KaleoDefinition _addKaleoDefinition() throws Exception {
 		return _kaleoDefinitionLocalService.addKaleoDefinition(
 			null, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), null, StringPool.BLANK, 1,
+			RandomTestUtil.randomString(), null, StringPool.BLANK, false, 1,
 			_serviceContext);
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeJakartaTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeJakartaTest.java
@@ -938,7 +938,7 @@ public class UpgradeJakartaTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			_read("javax-workflow-definition.xml"),
-			WorkflowDefinitionConstants.SCOPE_ALL, 1, _serviceContext);
+			WorkflowDefinitionConstants.SCOPE_ALL, false, 1, _serviceContext);
 	}
 
 	private KaleoInstance _addKaleoInstance() throws Exception {

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/workflow-definitions/test-workflow-definition-1/workflow-definition.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/workflow-definitions/test-workflow-definition-1/workflow-definition.json
@@ -3,6 +3,7 @@
 	"description": "This is the description for Test Workflow Definition 1.",
 	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:TESTACCOUNT1$]",
 	"name": "Test Workflow Definition 1",
+	"system": true,
 	"title": "Test Workflow Definition 1",
 	"title_i18n": {
 		"en_US": "Test Workflow Definition 1"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/v1_0_1/test/KaleoDefinitionVersionUpgradeProcessTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/v1_0_1/test/KaleoDefinitionVersionUpgradeProcessTest.java
@@ -101,7 +101,7 @@ public class KaleoDefinitionVersionUpgradeProcessTest {
 	private void _addKaleoDefinition() throws Exception {
 		_kaleoDefinition = _kaleoDefinitionLocalService.addKaleoDefinition(
 			null, _NAME, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), null, StringPool.BLANK, 1,
+			RandomTestUtil.randomString(), null, StringPool.BLANK, false, 1,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/BundleSiteInitializerTest.java
+++ b/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/BundleSiteInitializerTest.java
@@ -4567,6 +4567,7 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(
 			"This is the description for Test Workflow Definition 1.",
 			workflowDefinitionTest1.getDescription());
+		Assert.assertTrue(workflowDefinitionTest1.getSystem());
 
 		WorkflowDefinitionLink workflowDefinitionLink1 =
 			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
@@ -4590,6 +4591,7 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(
 			"This is the description for Test Workflow Definition 2.",
 			workflowDefinitionTest2.getDescription());
+		Assert.assertFalse(workflowDefinitionTest2.getSystem());
 
 		WorkflowDefinitionLink workflowDefinitionLink2 =
 			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101039

## What Is Being Fixed

LPD-99497 replaced the name-based derivation of `WorkflowDefinition.isSystem()` with a real `system_` column on the `KaleoDefinition` entity, but removed the mechanism that *set* the flag without adding a replacement. Nothing in the write path ever calls `KaleoDefinition.setSystem(...)`, so on a fresh install `system_` is always `false` and only the one-shot `v4_7_0` upgrade process can produce a `true`. The AI Hub site initializer provisions its workflow definitions by posting the headless DTO, so it has no way to persist a system workflow definition.

## How It Is Being Fixed

`system` becomes a writable `boolean` on the headless `WorkflowDefinition` schema, matching how `ObjectDefinition`, `ObjectField` and `ListTypeDefinition` already expose theirs. The resource impl returns it on reads and forwards it on both write endpoints, which covers `postWorkflowDefinition`, `putWorkflowDefinition` and the batch upsert since they all funnel through those two.

Below the resource, `WorkflowDefinitionManager.deployWorkflowDefinition` and `saveWorkflowDefinition` take a nullable `Boolean system`, and `WorkflowDefinitionManagerImpl` carries it down as a `ServiceContext` attribute that `KaleoDefinitionLocalServiceImpl` reads. That is the same route `groupId` and `checkPermission` already travel on this path, and it avoids widening `WorkflowEngine`, `WorkflowDeployer` and the Service Builder services for a single flag. The nullability is what makes the update branch safe: absent means leave the flag alone, so a Kaleo Designer republish or any client that omits the property cannot silently clear `system` on the definitions the upgrade process backfilled, while an explicit `false` still demotes.

Changing the flag is restricted to allow-listed bundles through `ObjectDefinitionUtil.isInvokerBundleAllowed()`, mirroring `ListTypeDefinitionUtil.validateInvokerBundle` and `NotificationTemplateUtil`. `com.liferay.ai.hub.site.initializer` is already on that list, so the initializer passes while an ordinary REST caller gets a `WorkflowDefinitionSystemException`.

The consuming change lives in `liferay-portal-ee` — `"system": true` on the 19 AI Hub `workflow-definition.json` files — and is blocked until this reaches the LTS line that workspace pins.

## PR Check

**pr-check: PASS** — tested on `b25b37b8e1a26f28f0d8800c0bca49a4cb1a507f`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b25b37b8e1a26f28f0d8800c0bca49a4cb1a507f"} -->
